### PR TITLE
Add a setting to override idunn url used by server

### DIFF
--- a/bin/middlewares/og_meta.js
+++ b/bin/middlewares/og_meta.js
@@ -5,7 +5,12 @@ const ogMetas = [
   {name : 'image', content : './statics/images/qwant-logo.svg'}
 ]
 
+const idunnTimeout = 2000 // ms
+
 module.exports = function(config) {
+  // Use url from server config if defined
+  const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url
+
   async function getPoi(poiId, locale) {
     let id = poiId
     let atPos = poiId.indexOf('@')
@@ -14,8 +19,12 @@ module.exports = function(config) {
     }
 
     return new Promise((resolve, reject) => {
-      let idunnUrl =`${config.services.idunn.url}/v1/pois/${id}?lang=${locale.code}`
-      request(idunnUrl, {json : true}, (error, response, body) => {
+      let idunnUrl =`${idunnBaseUrl}/v1/pois/${id}?lang=${locale.code}`
+      request({
+        url: idunnUrl,
+        timeout: idunnTimeout,
+        json : true,
+      }, (error, response, body) => {
         if(error) {
           reject(error)
         } else if(response.statusCode === 404) {

--- a/bin/middlewares/og_meta.js
+++ b/bin/middlewares/og_meta.js
@@ -5,11 +5,13 @@ const ogMetas = [
   {name : 'image', content : './statics/images/qwant-logo.svg'}
 ]
 
-const idunnTimeout = 2000 // ms
-
 module.exports = function(config) {
   // Use url from server config if defined
   const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url
+  const idunnTimeout = Number(config.server.services.idunn.timeout)
+  if(isNaN(idunnTimeout)) {
+    throw new Error(`Invalid config: idunn timeout is set to "${config.server.services.idunn.timeout}"`)
+  }
 
   async function getPoi(poiId, locale) {
     let id = poiId

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -6,6 +6,9 @@ server:
   acceptPostedLogs: true
   acceptPostedEvents: true
   enablePrometheus: true
+  services:
+    idunn:
+      url: # client url will be used by default
 
 
 # Services

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -9,6 +9,7 @@ server:
   services:
     idunn:
       url: # client url will be used by default
+      timeout: 2000 # ms
 
 
 # Services

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -1,8 +1,5 @@
 const App = require( './../../bin/app')
-
 const configBuilder = require('@qwant/nconf-builder')
-const config = configBuilder.get()
-global.appServer = new App(config)
 const nock = require('nock')
 
 nock(/idunn_test\.test/)
@@ -15,13 +12,16 @@ nock(/idunn_test\.test/)
   .get(/osm:way:2403/)
   .reply(404)
 
+
 configBuilder.set('store:name', 'local_store')
 configBuilder.set('mapStyle:baseMapUrl', "[]")
 configBuilder.set('mapStyle:poiMapUrl', "[]")
 configBuilder.set('services:idunn:url', 'http://idunn_test.test')
-configBuilder.set('services:geocoder:url', `http://localhost:${config.PORT}/autocomplete`)
-configBuilder.set('services:poi:url', `http://localhost:${config.PORT}/poi`)
+configBuilder.set('services:geocoder:url', `http://geocoder.test/autocomplete`)
 configBuilder.set('system:evalFiles', false)
+
+const config = configBuilder.get()
+global.appServer = new App(config)
 
 module.exports = async function() {
   console.log(`Start test on PORT : ${config.PORT}`)


### PR DESCRIPTION
* Define **`server.services.idunn.url`** setting:
For example in a containerized environment we could want to set
`TILEVIEW_server_services_idunn_url=http://idunn`

* Define a timeout value on idunn request

* Fix tests race condition