### PR TITLE
Fix Transifex: install the client with python3 and pipenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
     - libstdc++6
       # This is required to run new chrome on old trusty
     - libnss3
+      # Add python3 dependencies to run transifex-client
+    - python3
+    - python3-pip
 
 before_script:
     - TEST=true npm run build

--- a/.tx/push.sh
+++ b/.tx/push.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
-
 set -e
 
 npm run build
 npm run i18n
-pip install virtualenv
-virtualenv ~/env
-. ~/env/bin/activate
-pip install transifex-client
+pip3 install --user pipenv
+pipenv install transifex-client
 sudo echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"$TRANSIFEX_API_USER"$'\npassword = '"$TRANSIFEX_API_KEY"$'\n' > ~/.transifexrc
-tx push -st
+pipenv run tx push -st


### PR DESCRIPTION
The last "deploy" on master failed because of some python2 dependencies problem. 
https://travis-ci.org/QwantResearch/erdapfel/builds/442590372

Let's use Python 3 !