### PR TITLE
clean last_val after suggest value set

### DIFF
--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -274,6 +274,7 @@ var autoComplete = (function(){
     
     this.setValue = function (value) {
       that.value = value
+      that.last_val = ''
     }
   }
   return autoComplete;


### PR DESCRIPTION
There was a little bug after invert start & end on the suggest preventing type the same word before invert