### PR TITLE
Bug fix: do not update direction panel on close when direction not displayed

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -21,12 +21,14 @@ import Telemetry from "../libs/telemetry";
 function AppPanel(parent) {
   new TopBar()
   SearchInput.initSearchInput('#search')
-  this.directionEnabled = directionEnabled
   this.sharePanel = new Share()
   this.servicePanel = new ServicePanel()
   this.favoritePanel = new FavoritePanel(this.sharePanel)
   this.poiPanel = new PoiPanel(this.sharePanel)
-  this.directionPanel = new DirectionPanel()
+  this.directionEnabled = directionEnabled
+  if (this.directionEnabled) {
+    this.directionPanel = new DirectionPanel()
+  }
   this.masqPanel = new RegisterMasqPanel()
   this.panel = new Panel(this, PanelsView, parent)
   this.geolocationModal = new GeolocationModal()


### PR DESCRIPTION
When direction is not enabled, directionPanel is still instantiated and registered to panel manager. At each call to setPoi, panels which are not poi complient are closed including the direction panel.
In the close method of directionPanel panel.update is called which tries to set the innerHtml of the element which is not found because the direction panel is not rendered.

We could also solve this by not setting the innerHtml in the panel.update function when the element is not found with querySelector.