### PR TITLE
Fix geolocalisation wording on restaure panel

### DIFF
--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -6,7 +6,7 @@ export const navigatorGeolcationStatus = {PENDING : 'pending', FOUND : 'found', 
 
 export default class NavigatorGeolocalisationPoi extends Poi {
   constructor() {
-    super(GEOLOCALISATION_NAME, GEOLOCALISATION_NAME)
+    super(GEOLOCALISATION_NAME, _('Your position', 'direction'))
     this.status = navigatorGeolcationStatus.UNKNOWN
   }
 


### PR DESCRIPTION
Fix direction autcolplete label containing "geolocalisation" instead of "your localisation" on togle direction_panel twice