### PR TITLE
Directions layout: apply visibility rules on mobile only

### DIFF
--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -20,19 +20,6 @@ BODY {
   width: 100%;
 }
 
-.panels--direction-open {
-  .menu__button,
-  .direction_shortcut {
-    visibility: hidden;
-  }
-}
-
-.top_bar--direction-open {
-  .search_form {
-    visibility: hidden;
-  }
-}
-
 #info {
   font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
   background-color: $background;
@@ -73,6 +60,19 @@ BODY {
 }
 
 @media (max-width: 640px) {
+  .panels--direction-open {
+    .menu__button,
+    .direction_shortcut {
+      visibility: hidden;
+    }
+  }
+
+  .top_bar--direction-open {
+    .search_form {
+      visibility: hidden;
+    }
+  }
+
   .side_panel__container {
     position: inherit;
     height: 0;


### PR DESCRIPTION
Fix on css, following #141 
On desktop, top bar logo and burger menu should stay visible on the directions layout.
