### PR TITLE
Implement configuration to use internal directions API

### DIFF
--- a/build/babel.config.js
+++ b/build/babel.config.js
@@ -1,15 +1,14 @@
 module.exports = function (mode) {
-  mode = 'dev'
   const production = {
     presets :
       [["@babel/preset-env", {
         "targets": {
           "browsers": [
-            "last 2 Chrome versions",
-            "FireFox >= 44",
+            "Chrome >= 60",
+            "Firefox >= 44",
             "Safari >= 7",
             "Explorer 11",
-            "last 4 Edge versions"
+            "Edge >= 17"
           ]
         },
         "useBuiltIns": "entry"

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -57,4 +57,6 @@ telemetry:
 direction:
   enabled: false
   service:
-    token: override_by_environment
+    api: 'mapbox' # 'mapbox' or 'qwant'
+    apiBaseUrl: https://api.mapbox.com/directions/v5/mapbox/
+    token: '' # for 'mapbox' only

--- a/src/adapters/direction_api.js
+++ b/src/adapters/direction_api.js
@@ -1,8 +1,13 @@
 import Ajax from "../libs/ajax";
 import nconf from "../../local_modules/nconf_getter";
 
-const token = nconf.get().direction.service.token
-const OVERVIEW_SETING = 'full'
+const directionConfig = nconf.get().direction.service
+const OVERVIEW_SETTING = 'full'
+const ACCEPTED_LANGUAGES = [
+  "da","de","en","eo","es","fi","fr","he","id","it",
+  "ko","my","nl","no","pl","pt","ro","ru","sv","tr",
+  "uk","vi","zh"
+]
 
 const geometries = 'geojson'
 export const vehiculeMatching = {driving : 'driving-traffic', walking : 'walking', cycling : 'cycling'}
@@ -10,11 +15,41 @@ export const vehiculeMatching = {driving : 'driving-traffic', walking : 'walking
 export default class DirectionApi {
   static async search(start, end, vehicle, exclude = '') {
     const apiVehicle = vehiculeMatching[vehicle]
-    const directionsUrl = `https://api.mapbox.com/directions/v5/mapbox/${apiVehicle}/${poiToMapBoxCoordinates(start)}%3B${poiToMapBoxCoordinates(end)}.json`
-    return await Ajax.get(directionsUrl, {language : getLang().locale, exclude : exclude, geometries : geometries, steps : true, access_token : token, alternatives : true, overview : OVERVIEW_SETING})
+    let directionsUrl = directionConfig.apiBaseUrl
+    let userLang = getLang()
+    let language
+    if (ACCEPTED_LANGUAGES.indexOf(userLang.code) !== -1){
+      language = userLang.locale
+    }
+    else {
+      language = userLang.fallback[0]
+    }
+    const directionsParams = {
+      language : language,
+      exclude : exclude,
+      geometries : geometries,
+      steps : true,
+      alternatives : true,
+      overview : OVERVIEW_SETTING,
+    }
+
+    if(directionConfig.api === 'mapbox'){
+      directionsUrl = `${directionsUrl}${apiVehicle}/`
+      directionsParams.access_token = directionConfig.token
+    }
+    else if (directionConfig.api === 'qwant'){
+      directionsParams.type = apiVehicle
+    }
+    directionsUrl = `${directionsUrl}${poiToMapBoxCoordinates(start)};${poiToMapBoxCoordinates(end)}`
+
+    let response = await Ajax.get(directionsUrl, directionsParams)
+    if (directionConfig.api === 'qwant'){
+      response = response.data
+    }
+    return response
   }
 }
 
 const poiToMapBoxCoordinates = (poi) => {
-  return `${poi.latLon.lng},${poi.latLon.lat}`
+  return `${poi.latLon.lng.toFixed(7)},${poi.latLon.lat.toFixed(7)}`
 }

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -24,6 +24,7 @@ export default class DirectionPanel {
     this.destination = null
     this.vehicle = this.vehicles.DRIVING
     this.roadMapPanel = new RoadMapPanel()
+    this.routes = null
     PanelManager.register(this)
     UrlState.registerResource(this, 'routes')
   }
@@ -161,19 +162,21 @@ export default class DirectionPanel {
 
   async searchDirection(options) {
     if(this.origin && this.destination) {
-
       let directionResponse = await DirectionApi.search(this.origin, this.destination, this.vehicle)
-
-      let routes = directionResponse.routes
-      routes.forEach((route, i) => {
+      this.routes = directionResponse.routes || []
+      this.routes.forEach((route, i) => {
         route.isActive = i === 0
         route.id = i
       })
-      if(routes) {
-        this.roadMapPanel.setRoad(routes, this.vehicle, this.origin)
-        fire('set_route', {...options, routes : routes, vehicle : this.vehicle, origin : this.origin, destination : this.destination})
+      if(this.routes){
+        this.roadMapPanel.setRoad(this.routes, this.vehicle, this.origin)
+        this.setRoutesOnMap(options)
       }
     }
+  }
+
+  setRoutesOnMap(options){
+    fire('set_route', {...options, routes : this.routes, vehicle : this.vehicle, origin : this.origin, destination : this.destination})
   }
 
   clearOrigin() {
@@ -238,7 +241,7 @@ export default class DirectionPanel {
     }
 
     execOnMapLoaded(() => {
-      this.searchDirection({move : false})
+      this.setRoutesOnMap({move : false})
     })
   }
 


### PR DESCRIPTION
* Implement both "mapbox" and "qwant" APIs
* Fix multiple calls to directions API when restoring /routes URLs
* Fix babel.config.js (`production` was not used ^^)