### PR TITLE
Fix idle state for direction input on Firefox

### DIFF
--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -28,11 +28,6 @@ export default class Suggest {
         this.pending = false
       },
       source: (term) => {
-        /*
-          https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude/8674#8674
-          this post is about correlation between gps coordinates decimal count & real precision unit
-          110m = 3 decimals
-         */
         let promise = new Promise(async (resolve, reject) => {
           /* 'bbox' is currently not used by the geocoder, it' will be used for the telemetry. */
           this.historyPromise = PoiStore.get(term)
@@ -107,7 +102,7 @@ export default class Suggest {
   }
 
   setIdle(idle) {
-    this.searchInputDomHandler.disabled = idle
+    this.searchInputDomHandler.readOnly = idle
   }
 
   async onSubmit() {

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -21,7 +21,7 @@ export default class DirectionPanel {
     this.destination = null
     this.vehicle = this.vehicles.DRIVING
     this.roadMapPanel = new RoadMapPanel(() => this.handleOpen(), () => this.handleClose())
-    this.routes = null
+    this.routes = []
     PanelManager.register(this)
     UrlState.registerResource(this, 'routes')
     this.activePanel = this

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -7,6 +7,10 @@
   background-size: 100% 5px;
   @include card_shadow();
   border-radius: 3px;
+
+  input[readonly] {
+    opacity: 0.5
+  }
 }
 
 .itinerary_container {


### PR DESCRIPTION
Using `readonly` attribute instead of `disabled` makes "blur" events work as expected.