### PR TITLE
fix: handle correctly the url shard for "type" param

### DIFF
--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -24,7 +24,7 @@ export default class CategoryPanel {
   }
 
   store () {
-    if(this.active && this.pois.length > 0) {
+    if(this.active && this.categoryName && this.categoryName !== '') {
       return `type=${this.categoryName}`
     }
     return ''


### PR DESCRIPTION
We remove the test on `this.poi.length` because the results (`IdunnPoi.poiCategoryLoad`) are resolved after the rebuild of the url (`UrlShards.toUrl`). That's why this is not working !