### PR TITLE
Fix travis configuration to be compatible with xenial environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,17 @@ language: node_js
 sudo: required
 node_js:
   - "8"
+dist: xenial
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.5
     packages:
     - libstdc++6
-      # This is required to run new chrome on old trusty
-    - libnss3
       # Add python3 dependencies to run transifex-client
     - python3.5
     - python3-pip
+    - python3-setuptools
 
 before_script:
     - TEST=true npm run build -- --mode=production


### PR DESCRIPTION
Travis CI now uses xenial (Ubuntu 16.04) as default environment (https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment)  

This caused the last run on master to fail because of a missing dependency when installing "transifex-client": https://travis-ci.org/QwantResearch/erdapfel/builds/527388352#L1197

`python3-setuptools` dependency is now explicit.