### PR TITLE
fix: every requests in suggest are now correctly handled

### DIFF
--- a/src/adapters/category_service.js
+++ b/src/adapters/category_service.js
@@ -18,7 +18,7 @@ export default class CategoryService {
     return CategoryService.getCategories().find(categ => categ.name === name) || null
   }
 
-  static getMatchingCategories (term) {
+  static async getMatchingCategories (term) {
     const matchedCategories = []
     const loadedCategories = CategoryService.getCategories()
     const cleanedTerm = term.normalize('NFD').replace(/[\u0300-\u036f]/g, '') // replace accent by non accentued chars

--- a/src/adapters/category_service.js
+++ b/src/adapters/category_service.js
@@ -18,7 +18,7 @@ export default class CategoryService {
     return CategoryService.getCategories().find(categ => categ.name === name) || null
   }
 
-  static async getMatchingCategories (term) {
+  static getMatchingCategories (term) {
     const matchedCategories = []
     const loadedCategories = CategoryService.getCategories()
     const cleanedTerm = term.normalize('NFD').replace(/[\u0300-\u036f]/g, '') // replace accent by non accentued chars

--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -79,7 +79,7 @@ export default class Suggest {
         pois.forEach((poi) => {
           if (poi instanceof PoiStore) {
             favorites.push(poi)
-          } if (poi instanceof  Category) {
+          } else if (poi instanceof  Category) {
             categories.push(poi)
           } else {
             remotes.push(poi)

--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -38,20 +38,20 @@ export default class Suggest {
         }
         else {
           promise = new Promise(async (resolve, reject) => {
-            this.suggestList = []
-
             /* 'bbox' is currently not used by the geocoder, it' will be used for the telemetry. */
             this.historyPromise = PoiStore.get(term)
             this.bragiPromise = BragiPoi.get(term)
-            this.categoryPromise = withCategories ? CategoryService.getMatchingCategories(term) : null
+            this.categoriesMatched = withCategories ? CategoryService.getMatchingCategories(term) : null
 
             try {
-              const [bragiResponse, storeResponse, categoryResponse] = await Promise.all([
-                this.bragiPromise, this.historyPromise, this.categoryPromise
+              const [bragiResponse, storeResponse] = await Promise.all([
+                this.bragiPromise, this.historyPromise
               ])
 
-              if (categoryResponse)
-                this.suggestList = this.suggestList.concat(categoryResponse)
+              this.suggestList = []
+
+              if (this.categoriesMatched)
+                this.suggestList = this.suggestList.concat(this.categoriesMatched)
 
               if (bragiResponse) {
                 this.bragiPromise = null
@@ -60,7 +60,10 @@ export default class Suggest {
 
               this.suggestList = this.suggestList.concat(storeResponse)
 
-              resolve(this.suggestList)
+              if (this.suggestList.length > 0)
+                resolve(this.suggestList)
+              else
+                resolve(null)
             } catch (e) {
               reject(e)
             }

--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -41,29 +41,26 @@ export default class Suggest {
             /* 'bbox' is currently not used by the geocoder, it' will be used for the telemetry. */
             this.historyPromise = PoiStore.get(term)
             this.bragiPromise = BragiPoi.get(term)
-            this.categoriesMatched = withCategories ? CategoryService.getMatchingCategories(term) : null
+            this.categoryPromise = withCategories ? CategoryService.getMatchingCategories(term) : null
 
             try {
-              const [bragiResponse, storeResponse] = await Promise.all([
-                this.bragiPromise, this.historyPromise
+              const [bragiResponse, storeResponse, categoryResponse] = await Promise.all([
+                this.bragiPromise, this.historyPromise, this.categoryPromise
               ])
+
+              if (!bragiResponse)
+                return resolve(null)
 
               this.suggestList = []
 
-              if (this.categoriesMatched)
-                this.suggestList = this.suggestList.concat(this.categoriesMatched)
+              if (categoryResponse)
+                this.suggestList = this.suggestList.concat(categoryResponse)
 
-              if (bragiResponse) {
-                this.bragiPromise = null
-                this.suggestList = this.suggestList.concat(bragiResponse)
-              }
-
+              this.bragiPromise = null
+              this.suggestList = this.suggestList.concat(bragiResponse)
               this.suggestList = this.suggestList.concat(storeResponse)
 
-              if (this.suggestList.length > 0)
-                resolve(this.suggestList)
-              else
-                resolve(null)
+              resolve(this.suggestList)
             } catch (e) {
               reject(e)
             }

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -274,6 +274,8 @@ test('Search Query', async () => {
 test('Retrieve restaurant category when we search "restau"', async () => {
   const searchQuery = 'restau'
 
+  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=restau/)
+
   await page.goto(APP_URL)
   await page.keyboard.type(searchQuery)
   await page.waitForSelector('.autocomplete_suggestion')


### PR DESCRIPTION
The bug was when we type in search bar a category name quickly (like "restaurant", or "education" or "supermarket" something long enough), sometimes items are not loaded.

This fix seems to fix the bug (to be honest i don't know why, but it work).

Feel free to test on your device ! (think to clear the "cache" used in window object : `window = null` in developer console and reload)