### PR TITLE
QMAPS-870 - update search input query according to the url shard

### DIFF
--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -145,7 +145,6 @@ export default class CategoryPanel {
     SearchInput.unMinify();
     document.querySelector('.top_bar').classList.remove('top_bar--category-open');
     this.active = false;
-    this.query = '';
     this.panel.update();
     UrlState.pushUrl();
     if (toggleMarkers) {

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -84,7 +84,7 @@ export default class SearchInput {
 
   async restore(fragment) {
     let shards = UrlShards.parseUrl();
-    if (shards.length === 1) {
+    if (shards.length > 0) {
       return await this.suggest.preselect(fragment);
     }
   }

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -84,7 +84,7 @@ export default class SearchInput {
 
   async restore(fragment) {
     let shards = UrlShards.parseUrl();
-    if (shards.length > 0) {
+    if (shards.length === 1) {
       return await this.suggest.preselect(fragment);
     }
   }


### PR DESCRIPTION
Fixing search input query not updating when accessing map through shared url (e.g `/maps/places/?q=Decathlon#map=12.40/43.7098068/7.2545280`)