### PR TITLE
Fix menu search not getting correctly triggered

### DIFF
--- a/src/panel/menu.js
+++ b/src/panel/menu.js
@@ -60,6 +60,7 @@ export default class Menu {
   }
 
   search() {
+    PanelManager.resetLayout();
     this.close();
     SearchInput.select();
   }

--- a/src/panel/menu.js
+++ b/src/panel/menu.js
@@ -59,9 +59,9 @@ export default class Menu {
     ]);
   }
 
-  search() {
+  async search() {
     PanelManager.resetLayout();
-    this.close();
+    await this.close();
     SearchInput.select();
   }
 }


### PR DESCRIPTION
When clicking on "Rechercher" in the hamburger menu, if there is a direction panel open (for example), nothing will happen. This fixes it.