### PR TITLE
CSS fixes for Safari

### DIFF
--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -131,7 +131,8 @@
   }
 
   .menu__panel__action__icon {
-    margin: -5px 20px 0 0;
+    margin: -4px 20px 0 0;
+    padding: 4px 0;
     font-size: 22px;
     vertical-align: middle;
   }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -28,7 +28,6 @@
 }
 
 .search_form__input {
-  -webkit-appearance: none;
   width: 100%;
   max-width: 690px;
   height: 68px;
@@ -56,6 +55,9 @@
 }
 
 input[type="search"] {
+  /* Disable default Safari style */
+  -webkit-appearance: none;
+
   /* Disable Chrome custom 'cancel' button */
   &::-webkit-search-cancel-button {
     -webkit-appearance: none;


### PR DESCRIPTION
* Disable default style on all input fields (including directions origin and destination)
* Fix icons position in burger menu