### PR TITLE
Improve collapsing placeholder on mobile

### DIFF
--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -115,12 +115,6 @@ BODY {
   }
 }
 
-@media (max-width: 350px) {
-  .search_form__input::placeholder {
-    font-size: 12px;
-  }
-}
-
 .map_container .marker-container {
   cursor: pointer;
   display: flex;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -346,15 +346,22 @@ input[type="search"] {
   }
 }
 
-@media (max-width: 370px) {
+@media (max-width: 380px) {
   .search_form__input {
-    padding-left: 45px;
     letter-spacing: -.5px;
+  }
+
+  &::placeholder {
+    font-size: 14px;
   }
 }
 
-@media (max-width: 370px) {
+@media (max-width: 340px) {
   .search_form__input {
+    &::placeholder {
+      color: transparent;
+    }
+
     &::-webkit-input-placeholder {
       color:transparent;
     }


### PR DESCRIPTION
This makes the search input placeholder visible on mobiles such as Samsung Galaxy S7 (width ~360px)