### PR TITLE
Small fixes about layout and roadmap duration

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -85,7 +85,13 @@ PoiPopup.prototype.showPopup = function(poi, event){
     address = poi.address.label;
   }
 
-  let popupOptions = {className: 'poi_popup__container', closeButton: false, closeOnClick: true};
+  let popupOptions = {
+    className: 'poi_popup__container',
+    closeButton: false,
+    closeOnClick: true,
+    maxWidth: 'none',
+    offset: 18, //px
+  };
 
   this.setPopupPosition(event, popupOptions);
   let htmlEncode = ExtendedString.htmlEncode;
@@ -120,12 +126,6 @@ PoiPopup.prototype.setPopupPosition = function(event, popupOptions) {
   }
 
   popupOptions.anchor = positionFragments.join('-');
-  popupOptions.offset = {
-    'bottom-left': [18, -8],
-    'bottom-right': [-18, -8],
-    'top-left': [18, 8],
-    'top-right': [-18, 8],
-  };
 };
 
 PoiPopup.prototype.close = function() {

--- a/src/panel/direction/road_map_panel.js
+++ b/src/panel/direction/road_map_panel.js
@@ -90,23 +90,17 @@ export default class RoadMapPanel {
     this.toggleRoute(i);
   }
 
-  duration(sec, isDisplaySeconds) {
-    let min = Math.floor(sec / 60);
+  duration(sec) {
+    sec = Math.max(60, sec); // For duration < 60s, return '1min'
+    let min = Math.round(sec / 60);
     let hour = Math.floor(min / 60);
     let ret = '';
-    if (sec < 5){
-      ret = '-';
-    } else {
-      if (hour){
-        ret += hour + 'h ';
-        min = min - 60 * hour;
-      }
-      if ((hour > 0 || min > 0) && hour < 10) {
-        ret += min + 'min ';
-      }
-      if (!hour && isDisplaySeconds) {
-        ret += Math.floor(sec - hour * 3600 - min * 60) + 's';
-      }
+    if (hour){
+      ret += hour + 'h ';
+      min = min - 60 * hour;
+    }
+    if ((hour > 0 || min > 0) && hour < 10) {
+      ret += min + 'min ';
     }
     return ret;
   }

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -91,7 +91,7 @@ export default class SearchInput {
 
   async selectItem(selectedItem) {
     if (selectedItem instanceof Poi) {
-      fire('fit_map', selectedItem, selectedItem.type === 'poi' ? layouts.POI : layouts.FULL);
+      fire('fit_map', selectedItem, layouts.POI);
       fire('map_mark_poi', selectedItem);
       PanelManager.loadPoiById(selectedItem.id);
     } else if (selectedItem instanceof Category) {

--- a/src/views/direction/road_map.dot
+++ b/src/views/direction/road_map.dot
@@ -40,7 +40,7 @@
       <div class='itinerary_leg{{= route.isActive ? ' itinerary_leg--active' : '' }}' id='itinerary_leg_{{= route.id }}''>
         <div class=itinerary_leg_inner>
           <div class='itinerary_leg_close icon-x' {{= click(this.close_leg, this) }}></div>
-          <div class='itinerary_leg_duration'>{{= this.duration(this.routes[route.id].legs[0].duration, false) }}</div>
+          <div class='itinerary_leg_duration'>{{= this.duration(this.routes[route.id].legs[0].duration) }}</div>
           <div class='itinerary_leg_distance'>{{= this.distance(this.routes[route.id].legs[0].distance) }}</div>
           <div class='itinerary_leg_via'>
             <div class='itinerary_leg_via_title'>{{= _('Via', 'direction') }} {{= this.routes[route.id].legs[0].summary.replace(/^(.*), (.*)$/, '$1') }}</div>
@@ -87,7 +87,7 @@
           </div>
           <div class='itinerary_leg_info'>
             <div class='itinerary_leg_duration'>
-              {{= this.duration(this.routes[route.id].legs[0].duration, false) }}
+              {{= this.duration(this.routes[route.id].legs[0].duration) }}
             </div>
             <div class='itinerary_leg_distance'>
               {{= this.distance(this.routes[route.id].legs[0].distance) }}


### PR DESCRIPTION
* Use `layouts.POI` for all types of Poi, as all items now trigger a poi_panel (including address, zone, etc)
* Fix popup position: default maxWidth (set by mapbox-gl-js) should be ignored
* Always display the duration value on roadmap (with "1min" as a minimum). Fixes https://github.com/QwantResearch/qwantmaps/issues/59