### PR TITLE
Don't rotate geoloc icon background when active

### DIFF
--- a/src/scss/includes/mapbox-gl-override.scss
+++ b/src/scss/includes/mapbox-gl-override.scss
@@ -2,3 +2,12 @@
 .mapboxgl-ctrl-top-right,
 .mapboxgl-ctrl-bottom-left,
 .mapboxgl-ctrl-bottom-right  { position:absolute; pointer-events:none; }
+
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate.mapboxgl-ctrl-geolocate-waiting {
+    animation: none;
+}
+
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate.mapboxgl-ctrl-geolocate-waiting::before {
+    animation: mapboxgl-spin 2s infinite linear;
+    display: flex;
+}


### PR DESCRIPTION
Fix proposal for the rotating black square background when hovering active geoloc icon.

Cause: the black bg is specific to Qwant, but the rotation effect comes from Mapbox GL CSS, which applies it to the whole element. We override it to apply it to the icon only.

| Before | After |
|---|---|
|![Capture d’écran du 2019-07-16 15-22-28](https://user-images.githubusercontent.com/243653/61298550-b606fb80-a7de-11e9-8077-a7749881e590.png)|![Capture d’écran du 2019-07-16 13-58-37](https://user-images.githubusercontent.com/243653/61298561-bb644600-a7de-11e9-8982-b866a70ba26b.png)|
