### PR TITLE
Use Webpack code-splitting to lazy load map bundle

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-src/libs/import_masq.js
 src/vendors/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
         "listen": "readonly",
         "fire": "readonly"
     },
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaVersion": 2018,
         "sourceType": "module"

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -84,10 +84,17 @@ const mainJsChunkConfig = buildMode => {
     output: {
       path: path.join(__dirname, '..', 'public', 'build', 'javascript'),
       filename: 'bundle.js',
-      chunkFilename: '[name].bundle.js',
       publicPath: './statics/build/javascript/',
     },
-    plugins: addJsOptimizePlugins(buildMode, []),
+    plugins: addJsOptimizePlugins(buildMode, [
+      new webpack.NormalModuleReplacementPlugin(/mapbox-gl--ENV/, function(resource) {
+        if (buildMode === 'test') {
+          resource.request = resource.request.replace('--ENV', '-js-mock');
+        } else {
+          resource.request = resource.request.replace('--ENV', '');
+        }
+      }),
+    ]),
     module: {
       rules: [{
         test: /\.dot/,
@@ -113,6 +120,20 @@ const mainJsChunkConfig = buildMode => {
           {loader: 'yaml-loader'},
         ],
       }, {
+        test: /style\.json$/,
+        use: [
+          {
+            loader: '@qwant/map-style-loader',
+            options: {
+              output: 'production', // 'debug' | 'production' | 'omt'
+              outPath: __dirname + '/../public/mapstyle',
+              i18n: true,
+              icons: true,
+              pixelRatios: [1, 2],
+            },
+          },
+        ],
+      }, {
         test: /\.js$/,
         use: [
           {
@@ -124,78 +145,6 @@ const mainJsChunkConfig = buildMode => {
           /\/node_modules/,
         ],
       }],
-    },
-    devtool: 'source-map',
-    node: {
-      fs: 'empty',
-    },
-  };
-};
-
-const mapJsChunkConfig = buildMode => {
-  return {
-    entry: [path.join(__dirname, '..', 'src', 'map.js')],
-    output: {
-      path: path.join(__dirname, '..', 'public', 'build', 'javascript'),
-      filename: 'map.js',
-    },
-    plugins: addJsOptimizePlugins(buildMode, [
-      new webpack.NormalModuleReplacementPlugin(/mapbox-gl--ENV/, function(resource) {
-        if (buildMode === 'test') {
-          resource.request = resource.request.replace('--ENV', '-js-mock');
-        } else {
-          resource.request = resource.request.replace('--ENV', '');
-        }
-      }),
-    ]),
-    module: {
-      rules: [
-        {
-          test: /\.dot/,
-          use: [
-            {
-              loader: 'babel-loader',
-              options: babelConf(buildMode),
-            },
-            {
-              loader: 'dot-loader',
-              options: {},
-            },
-          ],
-        }, {
-          test: /\.yml$/,
-          use: [
-            {loader: '@qwant/config-sanitizer-loader'},
-            {loader: 'json-loader'},
-            {loader: 'yaml-loader'},
-          ],
-        }, {
-          test: /style\.json$/,
-          use: [
-            {
-              loader: '@qwant/map-style-loader',
-              options: {
-                output: 'production', // 'debug' | 'production' | 'omt'
-                outPath: __dirname + '/../public/mapstyle',
-                i18n: true,
-                icons: true,
-                pixelRatios: [1, 2],
-              },
-            },
-          ],
-        }, {
-          test: /\.js$/,
-          use: [
-            {
-              loader: 'babel-loader',
-              options: babelConf(buildMode),
-            },
-
-          ],
-          exclude: [
-            /\/node_modules/,
-          ],
-        }],
     },
     devtool: 'source-map',
     node: {
@@ -231,7 +180,6 @@ const webpackChunks = buildMode => {
     copyPluginConfig(),
     sassChunkConfig(buildMode),
     mainJsChunkConfig(buildMode),
-    mapJsChunkConfig(buildMode),
   ];
   const constants = yaml.readSync('../config/constants.yml');
 

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -84,6 +84,7 @@ const mainJsChunkConfig = buildMode => {
     output: {
       path: path.join(__dirname, '..', 'public', 'build', 'javascript'),
       filename: 'bundle.js',
+      chunkFilename: '[name].bundle.js',
       publicPath: './statics/build/javascript/',
     },
     plugins: addJsOptimizePlugins(buildMode, [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,6 +1293,21 @@
         "eslint-config-airbnb-base": "^13.1.0",
         "eslint-plugin-import": "^2.14.0",
         "eslint-plugin-promise": "^4.0.0"
+      },
+      "dependencies": {
+        "babel-eslint": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+          "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "eslint-scope": "3.7.1",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        }
       }
     },
     "@octetstream/promisify": {
@@ -2169,9 +2184,10 @@
       "dev": true
     },
     "babel-eslint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
+      "integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "acorn": "^6.1.1",
     "autoprefixer": "^9.5.1",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^10.0.2",
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.4",
     "babel-preset-env": "1.7.0",

--- a/src/main.js
+++ b/src/main.js
@@ -20,4 +20,6 @@ import UrlState from './proxies/url_state';
   window.app = new App('panels');
 
   UrlState.load();
+
+  await import(/* webpackChunkName: "map" */ './map');
 })();

--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -65,27 +65,6 @@ BODY {
   right: 10px;
 }
 
-.loader_bar {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  opacity: 1;
-  transition: opacity 0.3s;
-}
-
-.loader_bar--loaded {
-  opacity: 0;
-}
-
-.loader_bar__progress {
-  width: 0;
-  height: 4px;
-  position: relative;
-  background: linear-gradient(to right, #a83485 0%,#e04c16 25%,#ff2b5c 35%,#f29d26 55%,#77005f 82%,#77005f 82%,#6d45a5 100%);
-  background-size: 100vh;
-}
-
 @media (max-width: 640px) {
   .panels--direction-open {
     .menu__button,

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -59,17 +59,5 @@
       <script src="./statics/javascript/file_loader-debug.js"></script>
     <% } %>
     <script src="./statics/build/javascript/bundle.js"></script>
-    <script>
-      /* Progress */
-      const progressBar = document.querySelector('#progress-bar')
-      const loaderBar = document.querySelector('#loader-bar')
-      let mapLoader = new FileLoader('./statics/build/javascript/map.js')
-      mapLoader.onLoad = function() {
-        loaderBar.classList.add('loader_bar--loaded')
-      }
-      mapLoader.onProgress = function(e) {
-        progressBar.style.width = e.loaded / e.total * 100 + '%'
-      }
-    </script>
   </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -46,9 +46,6 @@
         <span class="icon-chevron-left"></span>
       </div>
     </div>
-    <div class="loader_bar" id="loader-bar">
-      <div id="progress-bar" class="loader_bar__progress"></div>
-    </div>
     <% if(config.performance.enabled) { %>
       <script>window.times = {init : Date.now()}</script>
     <% } %>


### PR DESCRIPTION
Advantages:
- simpler webpack config, `map` is now part of the main bundle, but still loaded asynchronously on start-up via a dynamic import (see https://webpack.js.org/guides/code-splitting/#dynamic-imports)
- simpler code, no need for a custom file loader (but it's still used to load language file so I didn't remove if from `index.ejs`)
- the total size downloaded is smaller because Webpack can now reuse code already imported in the parent bundle when loading the map part

Number proof

## Before
```
                             Asset       Size            Chunks             Chunk Names
                         bundle.js    972 KiB              main  [emitted]  main
                     bundle.js.map    799 KiB              main  [emitted]  main
                masq-lib.bundle.js   1.04 KiB          masq-lib  [emitted]  masq-lib
            masq-lib.bundle.js.map  430 bytes          masq-lib  [emitted]  masq-lib
        vendors~masq-lib.bundle.js    766 KiB  vendors~masq-lib  [emitted]  vendors~masq-lib
    vendors~masq-lib.bundle.js.map    854 KiB  vendors~masq-lib  [emitted]  vendors~masq-lib

[...]

         Asset      Size  Chunks             Chunk Names
        map.js   1.4 MiB    main  [emitted]  main
    map.js.map  1.24 MiB    main  [emitted]  main
```

==> bundle + map = 972 + 1400 => **2372 KiB**

## After
```
                             Asset       Size            Chunks             Chunk Names
                         bundle.js    972 KiB              main  [emitted]  main
                     bundle.js.map    799 KiB              main  [emitted]  main
                     map.bundle.js    144 KiB               map  [emitted]  map
                 map.bundle.js.map   82.6 KiB               map  [emitted]  map
                masq-lib.bundle.js   1.04 KiB          masq-lib  [emitted]  masq-lib
            masq-lib.bundle.js.map  430 bytes          masq-lib  [emitted]  masq-lib
             vendors~map.bundle.js    816 KiB       vendors~map  [emitted]  vendors~map
         vendors~map.bundle.js.map    779 KiB       vendors~map  [emitted]  vendors~map
        vendors~masq-lib.bundle.js    766 KiB  vendors~masq-lib  [emitted]  vendors~masq-lib
    vendors~masq-lib.bundle.js.map    854 KiB  vendors~masq-lib  [emitted]  vendors~masq-lib

```

==> bundle + map + vendors~map = 972 + 144 + 816 => **1932 KiB**
