### PR TITLE
Use real JSON for tests fixture data

### DIFF
--- a/tests/__data__/autocomplete.json
+++ b/tests/__data__/autocomplete.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
   "type": "FeatureCollection",
   "geocoding": {"version": "0.1.0", "query": ""},
   "features": [{

--- a/tests/__data__/autocomplete_type.json
+++ b/tests/__data__/autocomplete_type.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
   "type": "FeatureCollection",
   "geocoding": {"version": "0.1.0", "query": ""},
   "features": [

--- a/tests/__data__/mapbox.json
+++ b/tests/__data__/mapbox.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
   "routes":
     [{
       "geometry": {"coordinates": [[2.290454, 48.823566], [2.290454, 48.823566]], "type": "LineString"},

--- a/tests/__data__/poi.json
+++ b/tests/__data__/poi.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
     "id": "osm:way:63178753",
     "meta": {
         "source": "osm"

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -2,7 +2,7 @@ const App = require( './../../bin/app')
 const configBuilder = require('@qwant/nconf-builder')
 const nock = require('nock')
 
-let {...poiNoName} = require('../__data__/poi')
+let {...poiNoName} = require('../__data__/poi.json')
   /* default test with matching name & local_name */
   poiNoName.id = 'osm:way:453204'
   nock(/idunn_test\.test/)
@@ -11,7 +11,7 @@ let {...poiNoName} = require('../__data__/poi')
     .reply(200, JSON.stringify(poiNoName))
 
 /* set mismatching local_name */
-let {...poiFullName} = require('../__data__/poi')
+let {...poiFullName} = require('../__data__/poi.json')
   poiFullName.local_name = 'Orsay museum'
   poiFullName.id = 'osm:way:453203'
   nock(/idunn_test\.test/)
@@ -22,7 +22,7 @@ let {...poiFullName} = require('../__data__/poi')
 nock(/idunn_test\.test/)
   .persist(true)
   .get(/osm:way:63178753.*/)
-  .reply(200, JSON.stringify(require('../__data__/poi')))
+  .reply(200, JSON.stringify(require('../__data__/poi.json')))
 
 nock(/idunn_test\.test/)
   .persist(true)

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -12,8 +12,8 @@ let browser
 let page
 let autocompleteHelper
 let responseHandler
-const mockAutocomplete = require('../../__data__/autocomplete')
-const mockAutocompleteAllTypes = require('../../__data__/autocomplete_type')
+const mockAutocomplete = require('../../__data__/autocomplete.json')
+const mockAutocompleteAllTypes = require('../../__data__/autocomplete_type.json')
 
 beforeAll(async () => {
   let browserPage = await initBrowser()

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -4,8 +4,8 @@ const configBuilder = require('@qwant/nconf-builder')
 const config = configBuilder.get()
 const APP_URL = `http://localhost:${config.PORT}`
 const ROUTES_PATH = `routes`
-const mockAutocomplete = require('../../__data__/autocomplete')
-const mockMapBox = require('../../__data__/mapbox')
+const mockAutocomplete = require('../../__data__/autocomplete.json')
+const mockMapBox = require('../../__data__/mapbox.json')
 
 let browser
 let page

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -1,4 +1,4 @@
-const poiMock = require('../../__data__/poi')
+const poiMock = require('../../__data__/poi.json')
 const configBuilder = require('@qwant/nconf-builder')
 const config = configBuilder.get()
 const APP_URL = `http://localhost:${config.PORT}`
@@ -25,7 +25,7 @@ beforeEach(async () => {
   responseHandler = new ResponseHandler(page)
   await responseHandler.prepareResponse()
 
-  const autocompleteMock = require('../../__data__/autocomplete')
+  const autocompleteMock = require('../../__data__/autocomplete.json')
   responseHandler.addPreparedResponse(autocompleteMock, /autocomplete/)
   responseHandler.addPreparedResponse(poiMock, /places\/osm:way:63178753/)
   responseHandler.addPreparedResponse(poiMock, /places\/1/)
@@ -208,7 +208,7 @@ test('Poi name i18n', async () => {
 test('Test 24/7', async () => {
   expect.assertions(1)
 
-  let {...poi} = require('../../__data__/poi')
+  let {...poi} = require('../../__data__/poi.json')
   poi.blocks.forEach((block => {
     if(block.type === 'opening_hours') {
       block.is_24_7 = true


### PR DESCRIPTION
## Description
Change test data files which are actually JSON-in-JS to real JSON.

## Why
- they **are** JSON/GeoJSON
- JS Linting won't run on them uselessly
- Easier to work with these files if they are not polluted my `module.exports`. For example running then through CLI tools or displaying them on [geojson.io](http://geojson.io).