### PR TITLE
Declare resolve aliases for 'config' and 'src' directories

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -87,6 +87,11 @@ const mainJsChunkConfig = buildMode => {
       chunkFilename: '[name].bundle.js',
       publicPath: './statics/build/javascript/',
     },
+    resolve: {
+      alias: {
+        config: path.resolve(__dirname, '../config/'),
+      },
+    },
     plugins: addJsOptimizePlugins(buildMode, [
       new webpack.NormalModuleReplacementPlugin(/mapbox-gl--ENV/, function(resource) {
         if (buildMode === 'test') {

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -90,6 +90,7 @@ const mainJsChunkConfig = buildMode => {
     resolve: {
       alias: {
         config: path.resolve(__dirname, '../config/'),
+        src: path.resolve(__dirname, '../src/'),
       },
     },
     plugins: addJsOptimizePlugins(buildMode, [

--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -2,7 +2,7 @@ import Poi from './poi';
 import Ajax from '../../libs/ajax';
 import nconf from '@qwant/nconf-getter';
 import Error from '../../adapters/error';
-import {sources} from '../../../config/constants.yml';
+import {sources} from 'config/constants.yml';
 import Telemetry from '../../libs/telemetry';
 
 const serviceConfig = nconf.get().services;

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -1,7 +1,7 @@
 /**
  * simple Poi helper
  */
-import {version} from '../../../config/constants.yml';
+import {version} from 'config/constants.yml';
 import ExtendedString from '../../libs/string';
 
 const ZOOM_BY_POI_TYPES = [

--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -1,7 +1,7 @@
 /* global _ */
 
 import Poi from '../poi';
-import GeolocationCheck from '../../../libs/geolocation';
+import GeolocationCheck from 'src/libs/geolocation';
 export const GEOLOCALISATION_NAME = 'geolocalisation';
 
 export const navigatorGeolocationStatus = {

--- a/src/panel/poi_bloc/hour_panel.js
+++ b/src/panel/poi_bloc/hour_panel.js
@@ -1,8 +1,8 @@
-import HourPanelView from '../../views/poi_bloc/hour.dot';
-import nextTransitionPartial from '../../views/poi_bloc/hour_next_transition_partial.dot';
-import Panel from '../../libs/panel';
-import OsmSchedule from '../../../src/adapters/osm_schedule';
-import Telemetry from '../../libs/telemetry';
+import HourPanelView from 'src/views/poi_bloc/hour.dot';
+import nextTransitionPartial from 'src/views/poi_bloc/hour_next_transition_partial.dot';
+import Panel from 'src/libs/panel';
+import OsmSchedule from 'src/adapters/osm_schedule';
+import Telemetry from 'src/libs/telemetry';
 
 function HourPanel(block, poi, options) {
   this.nextTransitionPartial = nextTransitionPartial;

--- a/src/panel/poi_bloc/opening_minimal.js
+++ b/src/panel/poi_bloc/opening_minimal.js
@@ -1,6 +1,6 @@
-import HourPanelView from '../../views/poi_bloc/hour_next_transition_partial.dot';
-import Panel from '../../libs/panel';
-import OsmSchedule from '../../../src/adapters/osm_schedule';
+import HourPanelView from 'src/views/poi_bloc/hour_next_transition_partial.dot';
+import Panel from 'src/libs/panel';
+import OsmSchedule from 'src/adapters/osm_schedule';
 import constants from 'config/constants.yml';
 
 export default class MinimalHourPanel {

--- a/src/panel/poi_bloc/opening_minimal.js
+++ b/src/panel/poi_bloc/opening_minimal.js
@@ -1,7 +1,7 @@
 import HourPanelView from '../../views/poi_bloc/hour_next_transition_partial.dot';
 import Panel from '../../libs/panel';
 import OsmSchedule from '../../../src/adapters/osm_schedule';
-import constants from '../../../config/constants.yml';
+import constants from 'config/constants.yml';
 
 export default class MinimalHourPanel {
   constructor() {

--- a/src/panel/poi_bloc/poi_bloc_container.js
+++ b/src/panel/poi_bloc/poi_bloc_container.js
@@ -1,6 +1,6 @@
 import Panel from '../../libs/panel';
 import PoiBlocContainerView from '../../views/poi_bloc/poi_bloc_container.dot';
-import constants from '../../../config/constants.yml';
+import constants from 'config/constants.yml';
 
 function PoiBlocContainer() {}
 

--- a/src/panel/poi_bloc/website_panel.js
+++ b/src/panel/poi_bloc/website_panel.js
@@ -1,7 +1,7 @@
-import WebsiteView from '../../views/poi_bloc/website.dot';
-import Panel from '../../libs/panel';
+import WebsiteView from 'src/views/poi_bloc/website.dot';
+import Panel from 'src/libs/panel';
 import URI from '../../../local_modules/uri/index';
-import Telemetry from '../../libs/telemetry';
+import Telemetry from 'src/libs/telemetry';
 
 function Website(block, poi) {
   this.URI = URI;


### PR DESCRIPTION
## Description
First example of how webpack resolve aliases can simplify imports.
If you like it, I'll do the same with `src` imports.

## Why
- Shorter and simpler to read imports
- No more hard coupling between files based on their relative place in the tree