### PR TITLE
[Urls] Shards system refacto: don't expose low-level impl

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -13,7 +13,6 @@ import SceneState from './scene_state';
 import SceneDirection from './scene_direction';
 import SceneCategory from './scene_category';
 import DirectionPoi from './poi/specials/direction_poi';
-import UrlShards from '../proxies/url_shards';
 import Error from '../adapters/error';
 import { createIcon } from '../adapters/icon_manager';
 import SceneEasterEgg from './scene_easter_egg';
@@ -195,8 +194,7 @@ Scene.prototype.initMapBox = function() {
 };
 
 Scene.prototype.saveLocation = function() {
-  const locationShard = UrlShards.parseUrl().find(shard => shard.prefix === 'map');
-  this.savedLocation = locationShard.value;
+  this.savedLocation = UrlState.getShardValue('map');
 };
 
 Scene.prototype.restoreLocation = function() {
@@ -370,15 +368,14 @@ Scene.prototype.isWindowedPoi = function(poi) {
   return compareBoundsArray(windowBounds.toArray(), originalWindowBounds);
 };
 
+// TODO: put that with global browser history management
 Scene.prototype.onHashChange = function() {
   window.onhashchange = () => {
-    const shards = UrlShards.parseUrl();
-    shards.forEach(shard => {
-      if (shard.prefix === 'map') {
-        this.restore(shard.value);
-        this.mb.jumpTo({center: this.urlCenter, zoom: this.urlZoom});
-      }
-    });
+    const mapShardValue = UrlState.getShardValue('map');
+    if (mapShardValue) {
+      this.restore(mapShardValue);
+      this.mb.jumpTo({center: this.urlCenter, zoom: this.urlZoom});
+    }
   };
 };
 

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -9,7 +9,6 @@ import Telemetry from '../libs/telemetry';
 import headerPartial from '../views/poi_partial/header.dot';
 import MinimalHourPanel from './poi_bloc/opening_minimal';
 import SceneState from '../adapters/scene_state';
-import {paramTypes} from '../proxies/url_shard';
 import layouts from './layouts.js';
 import nconf from '../../local_modules/nconf_getter';
 import MasqFavoriteModal from '../modals/masq_favorite_modal';
@@ -37,7 +36,7 @@ function PoiPanel(sharePanel) {
   this.sceneState = SceneState.getSceneState();
   this.isDirectionActive = nconf.get().direction.enabled;
   PanelManager.register(this);
-  UrlState.registerUrlShard(this, 'place', paramTypes.RESOURCE);
+  UrlState.registerResource(this, 'place');
   this.isMasqEnabled = nconf.get().masq.enabled;
 
   store.onToggleStore(async() => {

--- a/src/proxies/url_state.js
+++ b/src/proxies/url_state.js
@@ -21,7 +21,7 @@ UrlState.registerResource = function(component, prefix) {
 
 UrlState.registerUrlShard = function(component, prefix, paramType) {
   if (!component.store || !component.restore) {
-    throw 'this componentn doesn\'t implement required methods';
+    throw 'this component doesn\'t implement required methods';
   }
   UrlShards.add(new UrlShard(component, prefix, paramType));
 };

--- a/src/proxies/url_state.js
+++ b/src/proxies/url_state.js
@@ -62,4 +62,8 @@ UrlState.getShardValue = function(shardPrefix) {
   return shard && shard.value;
 };
 
+UrlState.getShardCount = function() {
+  return UrlShards.parseUrl().length;
+};
+
 export default UrlState;

--- a/src/proxies/url_state.js
+++ b/src/proxies/url_state.js
@@ -57,4 +57,9 @@ UrlState.load = function() {
   });
 };
 
+UrlState.getShardValue = function(shardPrefix) {
+  const shard = UrlShards.parseUrl().find(shard => shard.prefix === shardPrefix);
+  return shard && shard.value;
+};
+
 export default UrlState;

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -1,7 +1,6 @@
 import Suggest from '../adapters/suggest';
 import layouts from '../panel/layouts.js';
 import UrlState from '../proxies/url_state';
-import UrlShards from '../proxies/url_shards';
 import Poi from '../adapters/poi/poi';
 import Category from '../adapters/category';
 
@@ -90,8 +89,7 @@ export default class SearchInput {
   store() {}
 
   async restore(fragment) {
-    const shards = UrlShards.parseUrl();
-    if (shards.length === 1) {
+    if (UrlState.getShardCount() === 1) {
       return await this.suggest.preselect(fragment);
     }
   }


### PR DESCRIPTION
## Description
First PR to clean and simplify the url "shards" system.
Here we remove low-level calls to the shard implementation by components. Now the only needed import is `UrlState`, and everything passes through it only.

## Why
Debug the browser history management.