### PR TITLE
Panel manager clean-up

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
     "globals": {
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly",
-        "PanelManager": "readonly",
         "listen": "readonly",
         "fire": "readonly"
     },

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -16,6 +16,7 @@ import DirectionPoi from './poi/specials/direction_poi';
 import Error from '../adapters/error';
 import { createIcon } from '../adapters/icon_manager';
 import SceneEasterEgg from './scene_easter_egg';
+import PanelManager from 'src/proxies/panel_manager';
 
 const performanceEnabled = nconf.get().performance.enabled;
 const baseUrl = nconf.get().system.baseUrl;

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -3,6 +3,7 @@ import { map } from '../../config/constants.yml';
 import Device from '../libs/device';
 import layouts from '../panel/layouts.js';
 import LatLonPoi from '../adapters/poi/latlon_poi';
+import PanelManager from 'src/proxies/panel_manager';
 
 const ALTERNATE_ROUTE_COLOR = '#c8cbd3';
 const MAIN_ROUTE_COLOR = '#4ba2ea';

--- a/src/main.js
+++ b/src/main.js
@@ -8,14 +8,12 @@ import './proxies/panel_manager';
 import Store from './adapters/store';
 import UrlState from './proxies/url_state';
 
-/* global PanelManager */
 (async function main() {
   new I18n();
   await window.setLang();
 
   new Store();
 
-  PanelManager.init();
   UrlState.init();
   window.app = new App('panels');
 

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -38,6 +38,16 @@ export default class AppPanel {
     this.categoryPanel = this.categoryEnabled ? new CategoryPanel() : null;
     this.directionPanel = this.directionEnabled ? new DirectionPanel(this.sharePanel) : null;
 
+    PanelManager.register(this.servicePanel);
+    PanelManager.register(this.favoritePanel);
+    PanelManager.register(this.poiPanel);
+    if (this.categoryEnabled) {
+      PanelManager.register(this.categoryPanel);
+    }
+    if (this.directionPanel) {
+      PanelManager.register(this.directionPanel);
+    }
+
     this.panel = new Panel(this, PanelsView, parent);
     this.geolocationModal = new GeolocationModal();
     this.geolocationDeniedModal = new GeolocationDeniedModal();

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -18,6 +18,7 @@ import DirectionPanel from './direction/direction_panel';
 import Menu from './menu';
 import Telemetry from '../libs/telemetry';
 import CategoryPanel from './category_panel';
+import PanelManager from 'src/proxies/panel_manager';
 
 const performanceEnabled = nconf.get().performance.enabled;
 const directionEnabled = nconf.get().direction.enabled;

--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -10,6 +10,7 @@ import debounce from '../libs/debounce';
 import poiSubClass from '../mapbox/poi_subclass';
 import {sources} from '../../config/constants.yml';
 import nconf from '@qwant/nconf-getter';
+import PanelManager from 'src/proxies/panel_manager';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);

--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -29,7 +29,6 @@ export default class CategoryPanel {
     this.dataSource = '';
 
     UrlState.registerResource(this, 'places');
-    PanelManager.register(this);
 
     listen('map_moveend', debounce( function() {
       if (this.active) {

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -11,6 +11,7 @@ import Device from '../../libs/device';
 import Telemetry from '../../libs/telemetry';
 import NavigatorGeolocalisationPoi from '../../adapters/poi/specials/navigator_geolocalisation_poi';
 import {vehiculeMatching} from '../../adapters/direction_api';
+import PanelManager from 'src/proxies/panel_manager';
 
 export default class DirectionPanel {
   constructor(roadPanel) {

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -26,7 +26,6 @@ export default class DirectionPanel {
       () => this.handleClose(),
       roadPanel,
     );
-    PanelManager.register(this);
     UrlState.registerResource(this, 'routes');
     this.activePanel = this;
   }

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -31,7 +31,6 @@ function Favorite(sharePanel) {
   });
 
   this.panel = new Panel(this, FavoritePanelView);
-  PanelManager.register(this);
 
   this.store = new Store();
 

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -8,7 +8,7 @@ import layouts from './layouts.js';
 import {version} from '../../config/constants.yml';
 import nconf from '@qwant/nconf-getter';
 import MasqOnboardingModal from '../modals/masq_onboarding_modal';
-
+import PanelManager from 'src/proxies/panel_manager';
 import poiSubClass from '../mapbox/poi_subclass';
 
 const masqEnabled = nconf.get().masq.enabled;

--- a/src/panel/menu.js
+++ b/src/panel/menu.js
@@ -5,6 +5,7 @@ import LoginMasqPanel from './login_masq';
 import SearchInput from '../ui_components/search_input';
 import nconf from '../../local_modules/nconf_getter';
 import Store from '../adapters/store';
+import PanelManager from 'src/proxies/panel_manager';
 
 export default class Menu {
   constructor() {

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -13,7 +13,7 @@ import layouts from './layouts.js';
 import nconf from '../../local_modules/nconf_getter';
 import MasqFavoriteModal from '../modals/masq_favorite_modal';
 import Device from '../libs/device';
-
+import PanelManager from 'src/proxies/panel_manager';
 import poiSubClass from '../mapbox/poi_subclass';
 
 const store = new Store();

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -35,7 +35,6 @@ function PoiPanel(sharePanel) {
   this.minimalHourPanel = new MinimalHourPanel();
   this.sceneState = SceneState.getSceneState();
   this.isDirectionActive = nconf.get().direction.enabled;
-  PanelManager.register(this);
   UrlState.registerResource(this, 'place');
   this.isMasqEnabled = nconf.get().masq.enabled;
 

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -2,6 +2,7 @@ import ServicePanelView from '../views/service_panel.dot';
 import Panel from '../libs/panel';
 import nconf from '../../local_modules/nconf_getter';
 import CategoryService from '../adapters/category_service';
+import PanelManager from 'src/proxies/panel_manager';
 
 export default class ServicePanel {
   constructor() {

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -11,8 +11,6 @@ export default class ServicePanel {
     this.isDeployed = false;
     this.isDirectionActive = nconf.get().direction.enabled;
     this.active = true;
-
-    PanelManager.register(this);
   }
 
   toggleCategories() {

--- a/src/proxies/panel_manager.js
+++ b/src/proxies/panel_manager.js
@@ -48,45 +48,35 @@ PanelManager.getDirectionPanel = function() {
   return window.__panel_manager.panels.find(panel => panel instanceof DirectionPanel);
 };
 
-PanelManager.openDirection = async function(options) {
+function openPanel(panelType, options) {
   /*
     "unminify" needs to be called before panel.open :
     DirectionPanel will minify the main search input (unused for Directions)
   */
   window.app.unminify();
-  window.__panel_manager.panels.find(panel => {
-    if (panel instanceof DirectionPanel) {
-      if (!panel.active) {
-        panel.open(options);
-      }
-    } else if (panel.active) {
-      panel.close();
-    }
-  });
-};
-
-PanelManager.openFavorite = async function() {
   window.__panel_manager.panels.forEach(panel => {
-    if (panel instanceof FavoritePanel) {
-      if (!panel.active) {
-        panel.open();
-      }
-    } else if (panel.active) {
-      panel.close();
-    }
-  });
-  window.app.unminify();
-};
-
-PanelManager.openCategory = async function(options) {
-  window.__panel_manager.panels.forEach(panel => {
-    if (panel instanceof CategoryPanel) {
+    if (panel instanceof panelType) {
       panel.open(options);
-    } else if (panel.active) {
+    } else {
       panel.close();
     }
   });
-  window.app.unminify();
+}
+
+PanelManager.openDirection = function(options) {
+  openPanel(DirectionPanel, options);
+};
+
+PanelManager.openFavorite = function() {
+  openPanel(FavoritePanel);
+};
+
+PanelManager.openCategory = function(options) {
+  openPanel(CategoryPanel, options);
+};
+
+PanelManager.resetLayout = function() {
+  openPanel(ServicePanel);
 };
 
 PanelManager.keepOnlyPoi = async function() {
@@ -95,17 +85,6 @@ PanelManager.keepOnlyPoi = async function() {
       panel.close();
     }
   });
-};
-
-PanelManager.resetLayout = function() {
-  window.__panel_manager.panels.forEach(panel => {
-    if (panel instanceof ServicePanel) {
-      panel.open();
-    } else {
-      panel.close();
-    }
-  });
-  window.app.unminify();
 };
 
 PanelManager.register = function(panel) {

--- a/src/proxies/panel_manager.js
+++ b/src/proxies/panel_manager.js
@@ -5,93 +5,93 @@ import FavoritePanel from '../panel/favorites_panel';
 import CategoryPanel from '../panel/category_panel';
 import PoiPanel from '../panel/poi_panel';
 
-function PanelManager() {}
-
-PanelManager.init = function() {
-  window.__panel_manager = {panels: []};
-};
-
-PanelManager.setPoi = async function(poi, options = {}) {
-  window.__panel_manager.panels.forEach(panel => {
-    if (panel.isPoiComplient) {
-      panel.setPoi(poi, options);
-    } else if (!options.isFromList && !options.isFromFavorite) {
-      panel.close();
-    }
-  });
-  window.app.unminify();
-};
-
-PanelManager.loadPoiById = async function(id, options) {
-  if (id) {
-    const poi = await ApiPoi.poiApiLoad(id);
-    if (poi) {
-      PanelManager.setPoi(poi, options);
-    } else {
-      PanelManager.resetLayout();
-    }
-    return poi;
-  } else {
-    PanelManager.resetLayout();
+class PanelManager {
+  constructor() {
+    this.panels = [];
   }
-};
 
-PanelManager.emptyClickOnMap = function() {
-  window.__panel_manager.panels.forEach(p => {
-    if (p.emptyClickOnMap) {
-      p.emptyClickOnMap();
-    }
-  });
-};
+  async setPoi(poi, options = {}) {
+    this.panels.forEach(panel => {
+      if (panel.isPoiComplient) {
+        panel.setPoi(poi, options);
+      } else if (!options.isFromList && !options.isFromFavorite) {
+        panel.close();
+      }
+    });
+    window.app.unminify();
+  }
 
-PanelManager.getDirectionPanel = function() {
-  return window.__panel_manager.panels.find(panel => panel instanceof DirectionPanel);
-};
-
-function openPanel(panelType, options) {
-  /*
-    "unminify" needs to be called before panel.open :
-    DirectionPanel will minify the main search input (unused for Directions)
-  */
-  window.app.unminify();
-  window.__panel_manager.panels.forEach(panel => {
-    if (panel instanceof panelType) {
-      panel.open(options);
+  async loadPoiById(id, options) {
+    if (id) {
+      const poi = await ApiPoi.poiApiLoad(id);
+      if (poi) {
+        this.setPoi(poi, options);
+      } else {
+        this.resetLayout();
+      }
+      return poi;
     } else {
-      panel.close();
+      this.resetLayout();
     }
-  });
+  }
+
+  emptyClickOnMap() {
+    this.panels.forEach(p => {
+      if (p.emptyClickOnMap) {
+        p.emptyClickOnMap();
+      }
+    });
+  }
+
+  getDirectionPanel() {
+    return this.panels.find(panel => panel instanceof DirectionPanel);
+  }
+
+  _openPanel(panelType, options) {
+    /*
+      "unminify" needs to be called before panel.open :
+      DirectionPanel will minify the main search input (unused for Directions)
+    */
+    window.app.unminify();
+    this.panels.forEach(panel => {
+      if (panel instanceof panelType) {
+        panel.open(options);
+      } else {
+        panel.close();
+      }
+    });
+  }
+
+  openDirection(options) {
+    this._openPanel(DirectionPanel, options);
+  }
+
+  openFavorite() {
+    this._openPanel(FavoritePanel);
+  }
+
+  openCategory(options) {
+    this._openPanel(CategoryPanel, options);
+  }
+
+  resetLayout() {
+    this._openPanel(ServicePanel);
+  }
+
+  async keepOnlyPoi() {
+    this.panels.forEach(panel => {
+      if (!(panel instanceof PoiPanel) && panel.active) {
+        panel.close();
+      }
+    });
+  }
+
+  register(panel) {
+    const existingPanel = this.panels.find(panelIterator => {
+      return panelIterator.panel.cid === panel.panel.cid;
+    });
+    !existingPanel && this.panels.push(panel);
+  }
 }
 
-PanelManager.openDirection = function(options) {
-  openPanel(DirectionPanel, options);
-};
-
-PanelManager.openFavorite = function() {
-  openPanel(FavoritePanel);
-};
-
-PanelManager.openCategory = function(options) {
-  openPanel(CategoryPanel, options);
-};
-
-PanelManager.resetLayout = function() {
-  openPanel(ServicePanel);
-};
-
-PanelManager.keepOnlyPoi = async function() {
-  window.__panel_manager.panels.forEach(panel => {
-    if (!(panel instanceof PoiPanel) && panel.active) {
-      panel.close();
-    }
-  });
-};
-
-PanelManager.register = function(panel) {
-  const existingPanel = window.__panel_manager.panels.find(panelIterator => {
-    return panelIterator.panel.cid === panel.panel.cid;
-  });
-  !existingPanel && window.__panel_manager.panels.push(panel);
-};
-
-window.PanelManager = PanelManager;
+export default new PanelManager();

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -3,6 +3,7 @@ import layouts from '../panel/layouts.js';
 import UrlState from '../proxies/url_state';
 import Poi from '../adapters/poi/poi';
 import Category from '../adapters/category';
+import PanelManager from 'src/proxies/panel_manager';
 
 const MAPBOX_RESERVED_KEYS = [
   'ArrowLeft', // ←


### PR DESCRIPTION
## Description
**First step** of refacto on panel manager, which is a center piece of the app state management. Currently there is a lot of bidirectional coupling everywhere, a lot of global variables involved, and a separation of concerns which is unclear. The result is it's really confusing to follow the state change logic and it leads to many bugs (ex: multiple panels at the same time, history navigation not restoring view, etc.).
Let's try to simplify and clean that.

## Why
 - Reducing `window` namespace pollution with globals
 - Reducing hard coupling of components and the number of places where state management happens