### PR TITLE
Standardize imports from local_modules

### DIFF
--- a/src/adapters/category_service.js
+++ b/src/adapters/category_service.js
@@ -1,5 +1,5 @@
 import Category from './category';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 import categories from '../../config/categories.yml';
 import ExtendedString from '../libs/string';
 

--- a/src/adapters/direction_api.js
+++ b/src/adapters/direction_api.js
@@ -1,5 +1,5 @@
 import Ajax from '../libs/ajax';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 
 const directionConfig = nconf.get().direction.service;
 const timeout = nconf.get().direction.timeout;

--- a/src/adapters/error.js
+++ b/src/adapters/error.js
@@ -1,5 +1,5 @@
 import Ajax from '../libs/ajax';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 
 const errorEventUrl = 'logs';
 const system = nconf.get().system;

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -4,7 +4,7 @@ import MobileCompassControl from '../mapbox/mobile_compass_control';
 import ExtendedControl from '../mapbox/extended_nav_control';
 import UrlState from '../proxies/url_state';
 import {map, layout} from '../../config/constants.yml';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 import MapPoi from './poi/map_poi';
 import HotLoadPoi from './poi/hotload_poi';
 import LocalStore from '../libs/local_store';

--- a/src/panel/login_masq.js
+++ b/src/panel/login_masq.js
@@ -1,7 +1,7 @@
 import LoginMasqPanelView from '../views/login_masq.dot';
 import Panel from '../libs/panel';
 import Store from '../adapters/store';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 import MasqOnboardingModal from '../modals/masq_onboarding_modal';
 import Telemetry from '../libs/telemetry';
 

--- a/src/panel/menu.js
+++ b/src/panel/menu.js
@@ -3,7 +3,7 @@ import menuView from '../views/menu.dot';
 import constants from '../../config/constants.yml';
 import LoginMasqPanel from './login_masq';
 import SearchInput from '../ui_components/search_input';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 import Store from '../adapters/store';
 import PanelManager from 'src/proxies/panel_manager';
 

--- a/src/panel/poi_bloc/website_panel.js
+++ b/src/panel/poi_bloc/website_panel.js
@@ -1,6 +1,6 @@
 import WebsiteView from 'src/views/poi_bloc/website.dot';
 import Panel from 'src/libs/panel';
-import URI from '../../../local_modules/uri/index';
+import URI from '@qwant/uri';
 import Telemetry from 'src/libs/telemetry';
 
 function Website(block, poi) {

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -10,7 +10,7 @@ import headerPartial from '../views/poi_partial/header.dot';
 import MinimalHourPanel from './poi_bloc/opening_minimal';
 import SceneState from '../adapters/scene_state';
 import layouts from './layouts.js';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 import MasqFavoriteModal from '../modals/masq_favorite_modal';
 import Device from '../libs/device';
 import PanelManager from 'src/proxies/panel_manager';

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -1,6 +1,6 @@
 import ServicePanelView from '../views/service_panel.dot';
 import Panel from '../libs/panel';
-import nconf from '../../local_modules/nconf_getter';
+import nconf from '@qwant/nconf-getter';
 import CategoryService from '../adapters/category_service';
 import PanelManager from 'src/proxies/panel_manager';
 


### PR DESCRIPTION
There are `@qwant/…` npm aliases defined in package.json, so use them everywhere.