### PR TITLE
Ignore non-implemented blocks when rendering informations block

### DIFF
--- a/src/panel/poi_bloc/informations_panel.js
+++ b/src/panel/poi_bloc/informations_panel.js
@@ -2,11 +2,27 @@ import InformationsView from '../../views/poi_bloc/informations.dot';
 import Panel from '../../libs/panel';
 import PoiBlocContainer from './poi_bloc_container';
 
-function Informations(block) {
-  this.PoiBlocContainer = PoiBlocContainer;
-  this.blocks = block.blocks;
-  this.panel = new Panel(this, InformationsView);
-  this.extended = false;
-}
+export default class Informations {
+  constructor(block) {
+    this.PoiBlocContainer = PoiBlocContainer;
+    this.blocks = this.cleanBlocks(block.blocks);
+    this.panel = new Panel(this, InformationsView);
+    this.extended = false;
+  }
 
-export default Informations;
+  cleanBlocks(blocks) {
+    /*
+      Exclude not implemented blocks, and blocks
+      where all nested blocks are not implemented
+    */
+    return blocks
+      .filter(b => {
+        if (b.blocks) {
+          b.blocks = b.blocks.filter(b => PoiBlocContainer.getBlock(b.type));
+          return b.blocks.length > 0;
+        }
+        return true;
+      })
+      .filter(b => PoiBlocContainer.getBlock(b.type));
+  }
+}

--- a/src/views/poi_bloc/informations.dot
+++ b/src/views/poi_bloc/informations.dot
@@ -1,3 +1,4 @@
+{{? this.blocks.length > 0 }}
 <div class="poi_panel__info__section poi_panel__info__section--information">
   <p class="poi_panel__info__section__description">
     <div class="icon-icon_info poi_panel__block__symbol"></div>
@@ -6,3 +7,4 @@
     {{~}}
   </p>
 </div>
+{{?}}


### PR DESCRIPTION
A new block with type "cuisine" has been implemented in Idunn API.  
As a result the information block that is returned may look like: 
```
{
  "type": "information",
  "blocks": [
    {
      "type": "services_and_information",
      "blocks": [
        {
          "type": "cuisine",
          "cuisines": [
            {
              "name": "pizza"
            }
          ],
          "vegetarian": "unknown",
          "vegan": "unknown",
          "gluten_free": "unknown"
        }
      ]
    }
  ]
}
```

At this point, this block rendering is not implemented and the whole "information" block should be ignored. 