### PR TITLE
ESLint: add rule to force space after async

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,11 @@
         ],
         "func-call-spacing": ["error", "never"],
         "space-infix-ops": "error",
-        "space-before-function-paren": ["error", "never"],
+        "space-before-function-paren": ["error", {
+          "anonymous": "never",
+          "named": "never",
+          "asyncArrow": "always"
+        }],
         "space-before-blocks": "error",
         "no-console": [
             "error",

--- a/src/adapters/poi/bragi_poi.js
+++ b/src/adapters/poi/bragi_poi.js
@@ -135,7 +135,7 @@ export default class BragiPoi extends Poi {
 
     /* ajax */
     let suggestsPromise;
-    const queryPromise = new Promise(async(resolve, reject) => {
+    const queryPromise = new Promise(async (resolve, reject) => {
       const query = {
         'q': term,
         'limit': geocoderConfig.max_items,

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -41,7 +41,7 @@ PoiPopup.prototype.addListener = function(layer) {
     }, WAIT_BEFORE_DISPLAY);
   });
 
-  this.map.on('mouseleave', layer, async() => {
+  this.map.on('mouseleave', layer, async () => {
     if (this.popupHandle) {
       this.popupHandle.remove();
     }

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -49,13 +49,13 @@ export default class Store {
       this.abstractStore = this.masqStore;
     }
 
-    this.masqStore.masq.eventTarget.addEventListener('logged_in', async() => {
+    this.masqStore.masq.eventTarget.addEventListener('logged_in', async () => {
       // login was successful, use masqStore as abstractStore until signout
       this.abstractStore = this.masqStore;
       this.masqEventTarget.dispatchEvent(new Event('store_logged_in'));
     });
 
-    this.masqStore.masq.eventTarget.addEventListener('signed_out', async() => {
+    this.masqStore.masq.eventTarget.addEventListener('signed_out', async () => {
       // signout was successful, use localStore as abstractStore until login
       this.abstractStore = this.localStore;
       this.masqEventTarget.dispatchEvent(new Event('store_logged_out'));

--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -40,7 +40,7 @@ export default class Suggest {
           // Prerender Favorites on focus in empty field
           promise = PoiStore.getAll();
         } else {
-          promise = new Promise(async(resolve, reject) => {
+          promise = new Promise(async (resolve, reject) => {
             this.historyPromise = PoiStore.get(term);
             this.bragiPromise = BragiPoi.get(term);
             this.categoryPromise = withCategories ?

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -13,7 +13,7 @@ Ajax.post = (url, data, options) => {
   return query(url, data, 'POST', options);
 };
 
-Ajax.getLang = async(url, data = {}, options) => {
+Ajax.getLang = async (url, data = {}, options) => {
   data.lang = window.getLang().code;
   return Ajax.get(url, data, options);
 };

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -37,7 +37,7 @@ function Favorite(sharePanel) {
 
   this.store = new Store();
 
-  this.store.onToggleStore(async() => {
+  this.store.onToggleStore(async () => {
     await this.updateList();
   });
 

--- a/src/panel/login_masq.js
+++ b/src/panel/login_masq.js
@@ -18,7 +18,7 @@ export default class LoginMasqPanel {
     this.username = null;
     this.profileImage = null;
 
-    this.store.onToggleStore(async() => {
+    this.store.onToggleStore(async () => {
       this.isLoggedIn = await this.store.isLoggedIn();
       await this.getUserInfo();
       this.panel.update();

--- a/src/panel/menu.js
+++ b/src/panel/menu.js
@@ -25,7 +25,7 @@ export default class Menu {
       this.username = null;
       this.profileImage = null;
 
-      this.store.onToggleStore(async() => {
+      this.store.onToggleStore(async () => {
         this.isLoggedIn = await this.store.isLoggedIn();
         await this.getUserInfo();
         await this.updateAndKeepState();
@@ -38,7 +38,7 @@ export default class Menu {
         await this.getUserInfo();
       });
 
-      Promise.all([this.initPromise, this.masqPanel.init()]).then(async() => {
+      Promise.all([this.initPromise, this.masqPanel.init()]).then(async () => {
         this.menuInitialized = true;
         await this.updateAndKeepState();
       });

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -35,14 +35,14 @@ function PoiPanel(sharePanel) {
   UrlState.registerResource(this, 'place');
   this.isMasqEnabled = nconf.get().masq.enabled;
 
-  store.onToggleStore(async() => {
+  store.onToggleStore(async () => {
     if (this.poi) {
       this.poi.stored = await isPoiFavorite(this.poi);
       this.panel.update();
     }
   });
 
-  store.eventTarget.addEventListener('poi_added', async() => {
+  store.eventTarget.addEventListener('poi_added', async () => {
     if (this.poi && !this.poi.stored) {
       this.poi.stored = await isPoiFavorite(this.poi);
       this.panel.update();

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -66,7 +66,7 @@ export default class SearchInput {
     this.isEnabled = true;
 
     UrlState.registerGet(this, 'q');
-    listen('submit_autocomplete', async() => {
+    listen('submit_autocomplete', async () => {
       this.suggest.onSubmit();
     });
   }

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -15,7 +15,7 @@ let responseHandler;
 const mockAutocomplete = require('../../__data__/autocomplete.json');
 const mockAutocompleteAllTypes = require('../../__data__/autocomplete_type.json');
 
-beforeAll(async() => {
+beforeAll(async () => {
   const browserPage = await initBrowser();
   page = browserPage.page;
   browser = browserPage.browser;
@@ -23,7 +23,7 @@ beforeAll(async() => {
   autocompleteHelper = new AutocompleteHelper(page);
 });
 
-test('search and clear', async() => {
+test('search and clear', async () => {
   expect.assertions(4);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Helloa/);
@@ -44,7 +44,7 @@ test('search and clear', async() => {
   expect(searchValueAfterClear).toEqual('');
 });
 
-test('search has lang in query', async() => {
+test('search has lang in query', async () => {
   const langPage = await browser.newPage();
   await langPage.setDefaultTimeout(2000); // to raise Puppeteer timeout early on fail
   await langPage.setExtraHTTPHeaders({
@@ -62,7 +62,7 @@ test('search has lang in query', async() => {
   expect(autocompleteItems).toHaveLength(SUGGEST_MAX_ITEMS);
 });
 
-test('keyboard navigation', async() => {
+test('keyboard navigation', async () => {
   const TypedSearch = 'Hello';
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
@@ -116,7 +116,7 @@ test('keyboard navigation', async() => {
   expect(selectElemPosition).toEqual(-1);
 });
 
-test('mouse navigation', async() => {
+test('mouse navigation', async () => {
   const TypedSearch = 'Hello';
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await page.goto(APP_URL);
@@ -137,7 +137,7 @@ test('mouse navigation', async() => {
   expect(selectedSearchValue).toEqual(expectedLabelName);
 });
 
-test('move to on click', async() => {
+test('move to on click', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
@@ -155,7 +155,7 @@ test('move to on click', async() => {
   expect(map_position_after).toEqual({lat: expectedLat, lng: expectedLng});
 });
 
-test('bbox & center', async() => {
+test('bbox & center', async () => {
   expect.assertions(3);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
@@ -179,7 +179,7 @@ test('bbox & center', async() => {
   expect(newCenter).toEqual({ lat: 4, lng: 3 });
 });
 
-test('favorite search', async() => {
+test('favorite search', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
@@ -195,7 +195,7 @@ test('favorite search', async() => {
 
 
 // http://idunn_test.test/v1/pois/osm:node:4872758213?lang=fr
-test('submit key', async() => {
+test('submit key', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await page.goto(APP_URL);
   /* submit with data already loaded */
@@ -227,7 +227,7 @@ test('submit key', async() => {
   expect(center).toEqual({lat: firstFeatureCenter[1], lng: firstFeatureCenter[0]});
 });
 
-test('check template', async() => {
+test('check template', async () => {
   expect.assertions(8);
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=type/);
   await page.goto(APP_URL);
@@ -271,7 +271,7 @@ test('check template', async() => {
 });
 
 
-test('Search Query', async() => {
+test('Search Query', async () => {
   expect.assertions(1);
   const searchQuery = 'test';
   await page.goto(`${APP_URL}/?q=${searchQuery}`);
@@ -283,7 +283,7 @@ test('Search Query', async() => {
   expect(searchValue).toEqual(searchQuery);
 });
 
-test('Retrieve restaurant category when we search "restau"', async() => {
+test('Retrieve restaurant category when we search "restau"', async () => {
   const searchQuery = 'restau';
 
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=restau/);
@@ -305,7 +305,7 @@ test('Retrieve restaurant category when we search "restau"', async() => {
   expect(suggestionId).toEqual('category:restaurant');
 });
 
-test('Retrieve no category when we search "barcelona", not even "bar"', async() => {
+test('Retrieve no category when we search "barcelona", not even "bar"', async () => {
   const searchQuery = 'barcelona';
 
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=barcelona/);
@@ -323,11 +323,11 @@ test('Retrieve no category when we search "barcelona", not even "bar"', async() 
   expect(firstLine).toEqual('test result 1');
 });
 
-afterEach(async() => {
+afterEach(async () => {
   await clearStore(page);
   responseHandler.reset();
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -12,17 +12,17 @@ let browser;
 let page;
 let responseHandler;
 
-beforeAll(async() => {
+beforeAll(async () => {
   browser = (await initBrowser()).browser;
 });
 
-beforeEach(async() => {
+beforeEach(async () => {
   page = await browser.newPage();
   responseHandler = new ResponseHandler(page);
   await responseHandler.prepareResponse();
 });
 
-test('check "My position" label', async() => {
+test('check "My position" label', async () => {
   expect.assertions(1);
   await showDirection(page);
 
@@ -35,7 +35,7 @@ test('check "My position" label', async() => {
   expect(yourPositionItem).not.toBeNull();
 });
 
-test('switch start end', async() => {
+test('switch start end', async () => {
   expect.assertions(1);
   await showDirection(page);
 
@@ -49,7 +49,7 @@ test('switch start end', async() => {
   expect(inputValues).toEqual({startInput: 'end', endInput: 'start'});
 });
 
-test('simple search', async() => {
+test('simple search', async () => {
   expect.assertions(1);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=direction/);
   responseHandler.addPreparedResponse(mockMapBox, /\/30\.0000000,5\.0000000;30\.0000000,5\.0000000/);
@@ -65,7 +65,7 @@ test('simple search', async() => {
   expect(leg0).not.toBeNull();
 });
 
-test('route flag', async() => {
+test('route flag', async () => {
   expect.assertions(3);
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
 
@@ -84,7 +84,7 @@ test('route flag', async() => {
 });
 
 
-test('destination', async() => {
+test('destination', async () => {
   expect.assertions(3);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?destination=latlon:47.4:7.5@Monoprix Nice`);
 
@@ -102,7 +102,7 @@ test('destination', async() => {
   expect(directionEndInput).toEqual('Monoprix Nice');
 });
 
-test('origin & destination', async() => {
+test('origin & destination', async () => {
   expect.assertions(3);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5@Monoprix Nice&destination=latlon:47.4:7.5@Franprix Cannes`);
   await page.waitForSelector('#itinerary_input_origin');
@@ -120,7 +120,7 @@ test('origin & destination', async() => {
   expect(directionEndInput).toEqual('Franprix Cannes');
 });
 
-test('origin & destination & mode', async() => {
+test('origin & destination & mode', async () => {
   expect.assertions(4);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5@Monoprix Nice&destination=latlon:47.4:7.5974115&mode=walking`);
 
@@ -149,7 +149,7 @@ const showDirection = async page => {
   await page.click('.service_panel__item__direction');
 };
 
-test('select itinerary leg', async() => {
+test('select itinerary leg', async () => {
   expect.assertions(1);
   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.0000000,6\.6000000/);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/routes/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.0`);
@@ -167,7 +167,7 @@ test('select itinerary leg', async() => {
   expect(featureState).toEqual({source: 'source_0', id: 1});
 });
 
-test('select itinerary step', async() => {
+test('select itinerary step', async () => {
   expect.assertions(1);
   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/routes/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
@@ -185,7 +185,7 @@ test('select itinerary step', async() => {
 });
 
 
-test('api error handling', async() => {
+test('api error handling', async () => {
   expect.assertions(1);
   /* prepare "error" response */
   responseHandler.addPreparedResponse({}, /\/7\.5000000,47\.4000000;6\.6000000,6\.6000000/, {status: 422});
@@ -194,7 +194,7 @@ test('api error handling', async() => {
   expect(errorMessageHandler).not.toBeNull();
 });
 
-test('api wait effect', async() => {
+test('api wait effect', async () => {
   expect.assertions(2);
   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.7000000,6\.6000000/);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/routes/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.7`);
@@ -204,6 +204,6 @@ test('api wait effect', async() => {
   expect(firstLeg).not.toBeNull(); // test result
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });

--- a/tests/integration/tests/favorite.js
+++ b/tests/integration/tests/favorite.js
@@ -8,13 +8,13 @@ import {toggleFavoritePanel} from '../favorites_tools';
 let browser;
 let page;
 
-beforeAll(async() => {
+beforeAll(async () => {
   const browserPage = await initBrowser();
   page = browserPage.page;
   browser = browserPage.browser;
 });
 
-test('toggle favorite panel', async() => {
+test('toggle favorite panel', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   await page.waitForSelector('.side_panel__container', {visible: true});
@@ -26,7 +26,7 @@ test('toggle favorite panel', async() => {
   expect(favPanel).toBeTruthy();
 });
 
-test('favorite added is present in favorite panel', async() => {
+test('favorite added is present in favorite panel', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   page.evaluate(() => {
@@ -37,7 +37,7 @@ test('favorite added is present in favorite panel', async() => {
   expect(items).not.toBeNull();
 });
 
-test('restore favorite from localStorage', async() => {
+test('restore favorite from localStorage', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   const testTitle = 'demo_fav';
@@ -53,7 +53,7 @@ test('restore favorite from localStorage', async() => {
   expect(title.trim()).toEqual(testTitle);
 });
 
-test('remove favorite using favorite panel', async() => {
+test('remove favorite using favorite panel', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   await page.evaluate(() => {
@@ -74,7 +74,7 @@ test('remove favorite using favorite panel', async() => {
   expect(items).not.toBeNull();
 });
 
-test('center map after a favorite poi click', async() => {
+test('center map after a favorite poi click', async () => {
   await page.goto(APP_URL);
   await page.evaluate(() => {
     window.MAP_MOCK.flyTo({center: {lat: 10, lng: 0}, zoom: 10});
@@ -97,10 +97,10 @@ test('center map after a favorite poi click', async() => {
   expect(center).toEqual({lng: favoriteMockCoordinates.lng, lat: favoriteMockCoordinates.lat});
 });
 
-afterEach(async() => {
+afterEach(async () => {
   await clearStore(page);
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -5,33 +5,33 @@ const APP_URL = `http://localhost:${config.PORT}`;
 let browser;
 let page;
 
-beforeAll(async() => {
+beforeAll(async () => {
   const browserPage = await initBrowser();
   page = browserPage.page;
   browser = browserPage.browser;
 });
 
-test('is dom loaded', async() => {
+test('is dom loaded', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   const sceneContent = await page.waitForSelector('#scene_container');
   expect(sceneContent).not.toBeFalsy();
 });
 
-test('is panels loaded', async() => {
+test('is panels loaded', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   const sceneContent = await page.waitForSelector('.service_panel');
   expect(sceneContent).not.toBeFalsy();
 });
 
-test('is map loaded', async() => {
+test('is map loaded', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   const sceneContent = await page.waitForSelector('.mapboxgl-canvas');
   expect(sceneContent).not.toBeFalsy();
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });

--- a/tests/integration/tests/map.js
+++ b/tests/integration/tests/map.js
@@ -5,13 +5,13 @@ const APP_URL = `http://localhost:${config.PORT}`;
 let browser;
 let page;
 
-beforeAll(async() => {
+beforeAll(async () => {
   const browserPage = await initBrowser();
   page = browserPage.page;
   browser = browserPage.browser;
 });
 
-test('priority order with url & local-storage', async() => {
+test('priority order with url & local-storage', async () => {
   const center = {lng: 11.1, lat: 43.3};
 
   expect.assertions(1);
@@ -26,7 +26,7 @@ test('priority order with url & local-storage', async() => {
   expect(pageCenter).toEqual(center);
 });
 
-test('test local storage map center', async() => {
+test('test local storage map center', async () => {
   const center = {lng: 11.1, lat: 43.3};
 
   expect.assertions(1);
@@ -41,10 +41,10 @@ test('test local storage map center', async() => {
   expect(pageCenter).toEqual(center);
 });
 
-afterEach(async() => {
+afterEach(async () => {
   await clearStore(page);
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -8,7 +8,7 @@ let browser;
 let page;
 let responseHandler;
 
-beforeAll(async() => {
+beforeAll(async () => {
   const browserPage = await initBrowser();
   page = browserPage.page;
   browser = browserPage.browser;
@@ -17,7 +17,7 @@ beforeAll(async() => {
 });
 
 
-test('test menu template', async() => {
+test('test menu template', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   page.waitForSelector('.menu__button');
@@ -40,7 +40,7 @@ test('test menu template', async() => {
   expect(panelPosition).toEqual(460);
 });
 
-test('menu open favorite', async() => {
+test('menu open favorite', async () => {
   await page.goto(APP_URL);
   expect.assertions(2);
   await page.goto(APP_URL);
@@ -61,7 +61,7 @@ test('menu open favorite', async() => {
   expect(favorites).not.toBeNull();
 });
 
-test('one panel open at a time', async() => {
+test('one panel open at a time', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   const servicePanelOpen = await page.waitForSelector('.service_panel--active');
@@ -72,17 +72,17 @@ test('one panel open at a time', async() => {
   expect(servicePanelClose).not.toBeFalsy();
 });
 
-test('service panel open on load', async() => {
+test('service panel open on load', async () => {
   expect.assertions(1);
   await page.goto(`${APP_URL}/routes`);
   const servicePanelOpen = await page.waitForSelector('.service_panel');
   expect(servicePanelOpen).not.toBeFalsy();
 });
 
-afterEach(async() => {
+afterEach(async () => {
   await clearStore(page);
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -13,11 +13,11 @@ let browser;
 let page;
 let responseHandler;
 
-beforeAll(async() => {
+beforeAll(async () => {
   browser = (await initBrowser()).browser;
 });
 
-beforeEach(async() => {
+beforeEach(async () => {
   page = await browser.newPage();
   await page.setExtraHTTPHeaders({
     'accept-language': 'fr_FR,fr,en;q=0.8', /* force fr header */
@@ -31,7 +31,7 @@ beforeEach(async() => {
   responseHandler.addPreparedResponse(poiMock, /places\/1/);
 });
 
-test('click on a poi', async() => {
+test('click on a poi', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   await selectPoiLevel(page, 1);
@@ -41,7 +41,7 @@ test('click on a poi', async() => {
   expect(translatedSubClass).toEqual('musée');
 });
 
-test('load a poi from url', async() => {
+test('load a poi from url', async () => {
   expect.assertions(2);
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poi_panel__title');
@@ -55,7 +55,7 @@ test('load a poi from url', async() => {
   expect(address).toMatch(/1 Rue de la Légion d'Honneur \(Paris\)/);
 });
 
-test('load a poi from url on mobile', async() => {
+test('load a poi from url on mobile', async () => {
   await page.setViewport({
     width: 400,
     height: 800,
@@ -75,7 +75,7 @@ test('load a poi from url on mobile', async() => {
   expect(hours).toMatch(/Fermé/);
 });
 
-test('load a poi already in my favorite from url', async() => {
+test('load a poi already in my favorite from url', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   await page.evaluate(() => {
@@ -89,7 +89,7 @@ test('load a poi already in my favorite from url', async() => {
   expect(plainStar).not.toBeFalsy();
 });
 
-test('update url after a poi click', async() => {
+test('update url after a poi click', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   await selectPoiLevel(page, 1);
@@ -99,7 +99,7 @@ test('update url after a poi click', async() => {
   expect(location).toMatch(/@Mus%C3%A9e_dOrsay/);
 });
 
-test('update url after a favorite poi click', async() => {
+test('update url after a favorite poi click', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   page.evaluate(() => {
@@ -118,7 +118,7 @@ test('update url after a favorite poi click', async() => {
   expect(location).toMatch(/@Mus%C3%A9e_dOrsay/);
 });
 
-test('open poi from autocomplete selection', async() => {
+test('open poi from autocomplete selection', async () => {
   responseHandler.addPreparedResponse(poiMock, /places\/osm:node:4811858213/);
 
   expect.assertions(2);
@@ -138,7 +138,7 @@ test('open poi from autocomplete selection', async() => {
   expect(await page.$('.poi_panel.poi_panel--hidden')).toBeFalsy();
 });
 
-test('display a popup on hovering a poi', async() => {
+test('display a popup on hovering a poi', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   await selectPoiLevel(page, 1);
@@ -148,7 +148,7 @@ test('display a popup on hovering a poi', async() => {
   expect(popups).toHaveLength(1);
 });
 
-test('center the map to the poi on a poi click', async() => {
+test('center the map to the poi on a poi click', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poi_panel__title');
   expect.assertions(1);
@@ -166,7 +166,7 @@ test('center the map to the poi on a poi click', async() => {
   });
 });
 
-test('display details about the poi on a poi click', async() => {
+test('display details about the poi on a poi click', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/48.8605833/2.3261037`);
   await page.waitForSelector('.poi_panel__title');
   expect.assertions(8);
@@ -203,7 +203,7 @@ test('display details about the poi on a poi click', async() => {
   expect(wiki_block).not.toBeFalsy();
 });
 
-test('Poi name i18n', async() => {
+test('Poi name i18n', async () => {
   expect.assertions(2);
 
   await page.goto(`${APP_URL}/place/osm:way:453203@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
@@ -215,7 +215,7 @@ test('Poi name i18n', async() => {
 });
 
 
-test('Test 24/7', async() => {
+test('Test 24/7', async () => {
   expect.assertions(1);
 
   const {...poi} = require('../../__data__/poi.json');
@@ -241,7 +241,7 @@ test('Test 24/7', async() => {
   expect(hours).toEqual('Ouvert 24h/24 et 7j/7');
 });
 
-test('check pre-loaded Poi error handling', async() => {
+test('check pre-loaded Poi error handling', async () => {
 
   expect.assertions(1);
 
@@ -269,7 +269,7 @@ async function selectPoiLevel(page, level) {
   await wait(300);
 }
 
-test('add a poi as favorite and find it back in the favorite menu', async() => {
+test('add a poi as favorite and find it back in the favorite menu', async () => {
   await page.goto(APP_URL);
 
   // we select a poi and 'star' it
@@ -303,7 +303,7 @@ test('add a poi as favorite and find it back in the favorite menu', async() => {
 });
 
 
-test('Poi hour i18n', async() => {
+test('Poi hour i18n', async () => {
   await Promise.all(languages.supportedLanguages.map(async language => {
     return new Promise(async resolve => {
       const langPage = await browser.newPage();
@@ -327,7 +327,7 @@ test('Poi hour i18n', async() => {
   }));
 });
 
-afterEach(async() => {
+afterEach(async () => {
   try {
     await clearStore(page); /* if only the above test is run page is not used */
   } catch (e) {
@@ -335,7 +335,7 @@ afterEach(async() => {
   }
 });
 
-afterAll(async() => {
+afterAll(async () => {
   await browser.close();
 });
 

--- a/tests/integration/tests/server.js
+++ b/tests/integration/tests/server.js
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 let server;
 
-beforeAll(async() => {
+beforeAll(async () => {
   server = request('http://localhost:3000');
 });
 


### PR DESCRIPTION
## Description
Tune the [https://eslint.org/docs/rules/space-before-function-paren](space-before-function-paren) rule to force a space between `async` and an arrow function.

## Why
`async()` is syntaxically correct but really weird.

Maybe we could switch to https://prettier.io/ to solve all that once and for all :slightly_smiling_face: 