### PR TITLE
Fix direction panel destruction when roadmap preview is enabled on mobile

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -224,13 +224,13 @@ Scene.prototype.isBBoxInExtendedViewport = function(bbox) {
   // Check bounds:
 
   // Lng between -180 and 180 (wraps: 180 + 1 = -179)
-  if (viewport._ne.lng < 180) {
+  if (viewport._ne.lng < -180) {
     viewport._ne.lng += 360;
   } else if (viewport._ne.lng > 180) {
     viewport._ne.lng -= 360;
   }
 
-  if (viewport._sw.lng < 180) {
+  if (viewport._sw.lng < -180) {
     viewport._sw.lng += 360;
   } else if (viewport._sw.lng > 180) {
     viewport._sw.lng -= 360;

--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -342,7 +342,7 @@ export default function autoComplete(options) {
       } else {
         that.removeAttribute('autocomplete');
       }
-      that.offsetParent.removeChild(that.sc);
+      that.sc.parentNode.removeChild(that.sc);
       that = null;
     }
   };

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -185,6 +185,30 @@ test('select itinerary step', async () => {
 });
 
 
+test('show itinerary roadmap on mobile', async () => {
+  await page.setViewport({
+    width: 400,
+    height: 800,
+  });
+  responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
+  await page.goto(`${APP_URL}/${ROUTES_PATH}/routes/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
+
+  await page.waitForSelector('#itinerary_leg_0');
+  await page.click('#itinerary_leg_0 .itinerary_leg_preview');
+  await page.waitForSelector('.itinerary_mobile_step');
+
+  /*
+    Force resetLayout.
+    This simulates a user action that will close
+    all panels related to the current itinerary,
+    such as a click on a POI on the map.
+  */
+  await page.evaluate('window.app.resetLayout()');
+  // Itinerary container should be disabled.
+  await page.waitForSelector('#itinerary_container', { hidden: true, timeout: 1000});
+});
+
+
 test('api error handling', async () => {
   expect.assertions(1);
   /* prepare "error" response */


### PR DESCRIPTION
When the roadmap preview is enabled on mobile, a click on a POI would fail to close all panels related to the current itinerary.  

This is due to how the autocomplete inputs are destroyed in `vendors/autocomplete.js`.  
An error is thrown when using `offsetParent` property, that is undefined on invisible elements.

