### PR TITLE
Capitalize first letter in favorites too

### DIFF
--- a/src/scss/includes/panels/favorite_panel.scss
+++ b/src/scss/includes/panels/favorite_panel.scss
@@ -124,6 +124,10 @@ $MASQ_BANNER_HEIGHT: 93px;
   color: $secondary_text;
 }
 
+.favorite_panel__item__desc:first-letter {
+  text-transform: uppercase;
+}
+
 .favorite_panel__item__more_container {
   background: $background;
   max-height: 100px;

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -288,7 +288,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   let fav = await getFavorites(page);
   expect(fav).toHaveLength(1);
   expect(fav[0].title).toEqual('Musée d\'Orsay');
-  expect(fav[0].desc).toEqual('musée');
+  expect(fav[0].desc).toEqual('Musée');
   expect(fav[0].icons).toContainEqual('icon-museum');
 
   // we then reopen the poi panel and 'unstar' the poi.


### PR DESCRIPTION
![Screenshot from 2019-08-05 17-09-24](https://user-images.githubusercontent.com/3050060/62475175-d35b3400-b7a4-11e9-9e8a-522593511a36.png)

The first letter was not capitalized before in the favorites menu. It is now.
