### PR TITLE
Simplify POI panel CSS

### DIFF
--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -5,6 +5,7 @@ import PoiBlocContainer from './poi_bloc/poi_bloc_container';
 import SearchInput from '../ui_components/search_input';
 import Telemetry from '../libs/telemetry';
 import headerPartial from '../views/poi_partial/header.dot';
+import titleImagePartial from '../views/poi_partial/title_image.dot';
 import MinimalHourPanel from './poi_bloc/opening_minimal';
 import layouts from './layouts.js';
 import nconf from '@qwant/nconf-getter';
@@ -27,6 +28,7 @@ function PoiPanel(sharePanel) {
   this.lang = window.getBaseLang().code;
   this.card = true;
   this.headerPartial = headerPartial;
+  this.titleImagePartial = titleImagePartial;
   this.minimalHourPanel = new MinimalHourPanel();
   this.isDirectionActive = nconf.get().direction.enabled;
   this.categories = CategoryService.getCategories();

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -2,7 +2,6 @@
 
 $BLOCK_INDENT: 28px;
 $CARD_ACTION_WIDTH: 112px;
-$CARD_ACTION_RIGHT_MARGIN: 8px;
 $CARD_PADDING: 8px;
 $BLOCK_PADDING: 24px;
 $BLOCK_ICON_FONT_SIZE: 16px;
@@ -30,10 +29,8 @@ $HEADER_SIZE: 40px;
   background-size: cover;
   background-position: center center;
   background-color: white;
-  position: absolute;
-  top: 0px;
-  right: 0;
 }
+
 .poi_panel--hidden {
   display: none;
 }
@@ -48,16 +45,6 @@ $HEADER_SIZE: 40px;
   position: relative;
 }
 
-.poi_panel__content__card__content {
-  float: left;
-  width: calc(100vw - (2 * #{$CARD_PADDING} + #{$CARD_ACTION_WIDTH} + #{$CARD_ACTION_RIGHT_MARGIN}));
-}
-
-.poi_panel__content__card__action__container {
-  margin-top: 42px;
-  float: right;
-}
-
 .poi_panel__content__card__action {
   display: block;
   width: $CARD_ACTION_WIDTH;
@@ -68,16 +55,12 @@ $HEADER_SIZE: 40px;
   font-weight: 600;
   color: $primary_text;
   border-radius: 18px;
-  margin: 0 $CARD_ACTION_RIGHT_MARGIN 8px 0;
+  margin: 8px 0;
   cursor: pointer;
   text-align: center;
   /* secure  long translation */
   white-space: nowrap;
   overflow: hidden;
-}
-
-.poi_panel__content__card__action__direction {
-  margin: 0 $CARD_ACTION_RIGHT_MARGIN 8px 0;
 }
 
 .poi_panel__close {
@@ -134,17 +117,10 @@ $HEADER_SIZE: 40px;
 }
 
 .poi_panel__description_container {
-  position: relative;
-  padding: 0 120px 0 0;
   margin-bottom: 25px;
   cursor: pointer;
-  min-height: 50px;
-}
-
-.poi_panel__description_container:after {
-  display: block;
-  clear: both;
-  content: '';
+  display: flex;
+  justify-content: space-between;
 }
 
 /* wrap it into an element and then put padding on this new element instead */
@@ -468,12 +444,6 @@ $HEADER_SIZE: 40px;
 .poi_panel__title__symbol {
   font-size: 45px;
   color: #E93865;
-
-  .poi_panel & {
-    position: absolute;
-    right: 0px;
-    top: 5px;
-  }
 }
 
 /* symbols */
@@ -667,6 +637,22 @@ $HEADER_SIZE: 40px;
   }
 }
 
+.poi_panel__content__card .poi_panel__description_container {
+  flex-grow: 1;
+  margin: 0;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+
+  .poi_panel__image {
+    display: none;
+  }
+
+  .poi_panel__title__symbol {
+    display: block;
+    margin: -9px 3px 0 0;
+  }
+}
+
 @media (max-width: 640px) {
   .poi_panel {
     width: 100vw;
@@ -727,23 +713,17 @@ $HEADER_SIZE: 40px;
     min-height: 125px;
   }
 
-  .poi_panel__content__card {
-    display: none;
-  }
-
   .poi_panel--card .poi_panel__content {
     display: none;
   }
 
   .poi_panel--card .poi_panel__content__card {
-    display: block;
+    display: flex;
+    justify-content: space-between;
+    padding: 20px $CARD_PADDING $CARD_PADDING;
   }
 
   .poi_panel--card {
-    .poi_panel__title {
-      width: auto;
-      padding-top: 20px;
-    }
     .poi_panel__address {
       font-size: 14px;
       padding: 8px 10px 0 0;
@@ -782,33 +762,12 @@ $HEADER_SIZE: 40px;
     margin-top: 17px;
   }
 
-  .poi_panel__content__card__content .poi_panel__title__symbol.icon {
-    margin: 6px 0 0 7px;
-    right: initial;
-    padding-left: 0;
-  }
-
   .poi_panel__info__section:not(:last-of-type):after {
     width: calc(100% - 40px);
   }
 
   .poi_panel__description__ellipsis {
     width: 100%;
-  }
-
-  .poi_panel__content__card__content > .poi_panel__address, .poi_panel__content__card__content > * {
-    padding-left: 55px;
-  }
-
-  .poi_panel__content__card__content .poi_panel__image {
-    display: none;
-  }
-  .poi_panel__image + .poi_panel__title__symbol {
-    display: block;
-  }
-
-  .poi_panel__content__card__action__container {
-    margin-top: 26px;
   }
 
   .poi_panel__content__card__action__direction {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -290,6 +290,7 @@ $HEADER_SIZE: 40px;
 
 .poi_panel__actions {
   display: flex;
+  margin-bottom: 12px;
 }
 
 .poi_panel__action {
@@ -514,7 +515,7 @@ $HEADER_SIZE: 40px;
 }
 
 .service_panel__categories--poi {
-  margin: 12px 0;
+  margin-bottom: 12px;
   border-top: 1px solid rgba(0,0,0,.16);
 
   .service_panel__categories_title {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -289,34 +289,29 @@ $HEADER_SIZE: 40px;
 }
 
 .poi_panel__actions {
-  width: 100%;
-  position: relative;
-  margin-bottom: 10px;
-  overflow: auto;
+  display: flex;
 }
 
 .button_container {
-  float: left;
+  flex-grow: 0;
   text-decoration: none;
   text-align: center;
-  min-width: 45px;
+  cursor: pointer;
 
   &:not(:last-child){
     margin-right: 15px;
-    max-width: calc(23% - 20px);
-  }
-
-  &.poi_panel__actions__phone_container {
-    max-width: 28%;
   }
 
   &:not(:first-child){
     min-width: 20%
   }
 
-
   &:hover {
     text-decoration: none;
+
+    button, div {
+      color: $primary_text;
+    }
   }
 
   button {
@@ -324,16 +319,6 @@ $HEADER_SIZE: 40px;
     display: block;
     cursor: pointer;
   }
-}
-
-.button_container:hover {
-  button, div {
-    color: $primary_text;
-  }
-}
-
-.button_container:hover {
-  cursor: pointer;
 }
 
 .poi_panel__actions__icon {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -292,11 +292,23 @@ $HEADER_SIZE: 40px;
   display: flex;
 }
 
-.button_container {
-  flex-grow: 0;
-  text-decoration: none;
-  text-align: center;
+.poi_panel__action {
+  font-size: 22px;
+  color: $secondary_text;
   cursor: pointer;
+  height: auto;
+  text-align: center;
+
+  div {
+    margin: 9px 0;
+    font-family: Asap;
+    font-size: 12px;
+  }
+
+  &:hover {
+    color: $primary_text;
+    text-decoration: none;
+  }
 
   &:not(:last-child){
     margin-right: 15px;
@@ -305,43 +317,7 @@ $HEADER_SIZE: 40px;
   &:not(:first-child){
     min-width: 20%
   }
-
-  &:hover {
-    text-decoration: none;
-
-    button, div {
-      color: $primary_text;
-    }
-  }
-
-  button {
-    width: 100%;
-    display: block;
-    cursor: pointer;
-  }
 }
-
-.poi_panel__actions__icon {
-  display: inline-block;
-  height: 25px;
-  font-size: 22px;
-  color: $secondary_text;
-  vertical-align: middle;
-}
-
-.poi_panel__actions__text {
-  display: flex;
-  justify-content: center;
-  height: 25px;
-  font-size: 12px;
-  color: $secondary_text;
-  margin: 7px 0 0;
-}
-
-.poi_panel__actions__text:hover {
-  color: $primary_text;
-}
-
 
 .poi_panel__store_status__toggle:after {
   content: '';

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -538,14 +538,14 @@ $HEADER_SIZE: 40px;
 }
 
 .service_panel__categories--poi {
-  margin: 15px 0;
+  margin: 12px 0;
   border-top: 1px solid rgba(0,0,0,.16);
 
   .service_panel__categories_title {
     font-weight: normal;
     font-size: 16px;
     color: #495063;
-    margin: 20px 0 15px 12px;
+    margin: 15px 0;
 
     .icon-icon_compass {
       color: #c8cbd3;

--- a/src/views/poi_panel.dot
+++ b/src/views/poi_panel.dot
@@ -84,38 +84,29 @@
          {{= this.panel.renderPartial(this.titleImagePartial) }}
       </div>
       <div class="poi_panel__actions">
-        <div class="button_container" {{= click(this.toggleStorePoi, this) }}>
-          {{? this.poi.stored}}
-            <button class="poi_panel__actions__icon__store poi_panel__actions__icon icon-icon_star-filled"></button>
-            <div class="poi_panel__actions__text">{{= _('SAVED', 'poi') }}</div>
-          {{??}}
-            <button class="poi_panel__actions__icon__store poi_panel__actions__icon icon-icon_star"></button>
-            <div class="poi_panel__actions__text">{{= _('FAVORITES', 'poi') }}</div>
-          {{?}}
-        </div>
-        <div class="poi_panel__actions__share_container button_container" {{= click(this.openShare, this) }}>
-          <button class="poi_panel__actions__icon icon-share-2">
-          </button>
-          <div class="poi_panel__actions__text">{{= _('SHARE', 'poi') }}</div>
-        </div>
+        <button class="poi_panel__action poi_panel__actions__icon__store
+          {{? this.poi.stored}} icon-icon_star-filled {{??}} icon-icon_star {{?}}"
+          {{= click(this.toggleStorePoi, this) }}
+        >
+          <div>{{? this.poi.stored}} {{= _('SAVED', 'poi') }} {{??}} {{= _('FAVORITES', 'poi') }} {{?}}</div>
+        </button>
+        <button class="poi_panel__action icon-share-2" {{= click(this.openShare, this) }}>
+          <div>{{= _('SHARE', 'poi') }}</div>
+        </button>
         {{? this.isDirectionActive }}
-          <div class="poi_panel__actions__direction_container button_container" {{= click(this.openDirection, this) }}>
-            <button class="poi_panel__actions__icon icon-corner-up-right">
-            </button>
-            <div class="poi_panel__actions__text">{{= _('DIRECTIONS', 'poi') }}</div>
-          </div>
+          <button class="poi_panel__action icon-corner-up-right" {{= click(this.openDirection, this) }}>
+            <div>{{= _('DIRECTIONS', 'poi') }}</div>
+          </button>
         {{?}}
         {{? this.poi.blocksByType.phone}}
           {{? this.shouldPhoneBeHidden() }}
-          <a class="poi_panel__actions__phone_container button_container poi_phone_container_hidden" {{= click(this.showPhone, this) }}>
-            <button class="poi_panel__actions__icon icon-icon_phone"></button>
-            <div class="poi_panel__actions__text">{{= _('SHOW NUMBER', 'poi') }}</div>
-          </a>
+          <button class="poi_panel__action icon-icon_phone poi_phone_container_hidden" {{= click(this.showPhone, this) }}>
+            <div>{{= _('SHOW NUMBER', 'poi') }}</div>
+          </button>
           {{?}}
           <a {{? this.shouldPhoneBeHidden() }} style="display:none" {{?}}
-            class="poi_panel__actions__phone_container button_container poi_phone_container_revealed" data-rel="external" rel="noopener noreferrer" href="{{= this.poi.blocksByType.phone.url }}">
-            <button class="poi_panel__actions__icon icon-icon_phone"></button>
-            <div class="poi_panel__actions__text">{{= this.htmlEncode(this.poi.blocksByType.phone.local_format) }}</div>
+            class="poi_panel__action icon-icon_phone poi_phone_container_revealed" data-rel="external" rel="noopener noreferrer" href="{{= this.poi.blocksByType.phone.url }}">
+            <div>{{= this.htmlEncode(this.poi.blocksByType.phone.local_format) }}</div>
           </a>
         {{?}}
       </div>

--- a/src/views/poi_panel.dot
+++ b/src/views/poi_panel.dot
@@ -122,24 +122,17 @@
 
       {{? isAnywherePoi && this.categories }}
           <div class="service_panel__categories--poi">
-            <hr>
             <h3 class="service_panel__categories_title">
               <span class="icon-icon_compass"></span>{{= _("Search around this place", "poi") }}
             </h3>
             {{~ this.categories:category:index }}
-              {{?
-                !this.mustDeployCategories ||
-                (this.mustDeployCategories && !this.isDeployed && index + 1 < 8) ||
-                (this.mustDeployCategories && this.isDeployed)
-              }}
-                <button class="service_panel__category" type="button" {{= click(this.openCategory, this, category) }}>
-                  <div class="service_panel__category__icon" style="background: {{= category.backgroundColor }}">
-                    <span class="icon icon-{{= category.iconName }}"></span>
-                  </div>
-                  <div class="service_panel__category__title">{{= category.label }}</div>
-                </button>
-            {{?}}
-          {{~}}
+              <button class="service_panel__category" type="button" {{= click(this.openCategory, this, category) }}>
+                <div class="service_panel__category__icon" style="background: {{= category.backgroundColor }}">
+                  <span class="icon icon-{{= category.iconName }}"></span>
+                </div>
+                <div class="service_panel__category__title">{{= category.label }}</div>
+              </button>
+            {{~}}
           </div>
         {{?}}
 

--- a/src/views/poi_panel.dot
+++ b/src/views/poi_panel.dot
@@ -55,9 +55,12 @@
         <i class="icon-x"></i>
       </div>
       {{?}}
-      <div class="poi_panel__content__card__content">
-       {{= this.panel.renderPartial(this.headerPartial) }}
-       {{= this.minimalHourPanel.render() }}
+      <div class="poi_panel__description_container">
+        <div>
+          {{= this.panel.renderPartial(this.headerPartial) }}
+          {{= this.minimalHourPanel.render() }}
+        </div>
+        {{= this.panel.renderPartial(this.titleImagePartial) }}
       </div>
       <div class="poi_panel__content__card__action__container">
         {{? this.isDirectionActive }}
@@ -78,6 +81,7 @@
     <div class="poi_panel__container">
       <div class="poi_panel__description_container" {{= click(this.center, this) }}>
          {{= this.panel.renderPartial(this.headerPartial) }}
+         {{= this.panel.renderPartial(this.titleImagePartial) }}
       </div>
       <div class="poi_panel__actions">
         <div class="button_container" {{= click(this.toggleStorePoi, this) }}>

--- a/src/views/poi_partial/header.dot
+++ b/src/views/poi_partial/header.dot
@@ -1,47 +1,39 @@
 {{
-  const ico = IconManager.get(this.poi);
   const grades = this.poi.blocksByType ? this.poi.blocksByType.grades : null;
 }}
 
-<h4 class="poi_panel__title">
-  {{? this.poi.localName && this.poi.name }}
-    <span class="poi_panel__title__main">{{= this.htmlEncode(this.poi.name) }}</span>
-    {{? this.poi.localName !== this.poi.name }}
-      <p class="poi_panel__title__alternative">{{= this.htmlEncode(this.poi.localName) }}</p>
+<div>
+  <h4 class="poi_panel__title">
+    {{? this.poi.localName && this.poi.name }}
+      <span class="poi_panel__title__main">{{= this.htmlEncode(this.poi.name) }}</span>
+      {{? this.poi.localName !== this.poi.name }}
+        <p class="poi_panel__title__alternative">{{= this.htmlEncode(this.poi.localName) }}</p>
+      {{?}}
+    {{?? this.poi.name }}
+      {{= this.htmlEncode(this.poi.name) }}
+    {{?? this.poi.localName }}
+      {{= this.htmlEncode(this.poi.localName) }}
+    {{??}}
+      {{= this.poiSubClass(this.poi.subClassName) }}
     {{?}}
-  {{?? this.poi.name }}
-    {{= this.htmlEncode(this.poi.name) }}
-  {{?? this.poi.localName }}
-    {{= this.htmlEncode(this.poi.localName) }}
-  {{??}}
-    {{= this.poiSubClass(this.poi.subClassName) }}
+  </h4>
+  {{? this.poi.subClassName }}
+    <p class="poi_panel__description">{{= this.poiSubClass(this.poi.subClassName) }}</p>
   {{?}}
-</h4>
-{{? this.poi.subClassName }}
-  <p class="poi_panel__description">{{= this.poiSubClass(this.poi.subClassName) }}</p>
-{{?}}
-{{? this.poi.address && this.poi.address.label }}
-  <p class="poi_panel__address">
-    {{= this.htmlEncode(this.poi.address.label) }}
-  </p>
-{{?}}
-{{? grades }}
-  <a class="panel__note" rel="noopener noreferrer" href="{{= grades.url }}" {{= click(this.poi.logGradesClick, this.poi, 'single') }}>
-    {{~ [...Array(5)]:star:k }}      
-      <span class="icon-icon_star{{= k+1 <= grades.global_grade ? '-filled' : ''}}"></span>
-    {{~}}
+  {{? this.poi.address && this.poi.address.label }}
+    <p class="poi_panel__address">
+      {{= this.htmlEncode(this.poi.address.label) }}
+    </p>
+  {{?}}
+  {{? grades }}
+    <a class="panel__note" rel="noopener noreferrer" href="{{= grades.url }}" {{= click(this.poi.logGradesClick, this.poi, 'single') }}>
+      {{~ [...Array(5)]:star:k }}
+        <span class="icon-icon_star{{= k+1 <= grades.global_grade ? '-filled' : ''}}"></span>
+      {{~}}
 
-    <span class="panel__note__review_count">
-      {{= grades.total_grades_count }} {{= _n('review', 'reviews', grades.total_grades_count) }}
-    </span>
-  </a>
-{{?}}
-{{? ico }}
-  <div class="poi_panel__title__symbol icon icon-{{= ico.iconClass }}" style="color:{{= ico.color ? ico.color : '#444648' }}"></div>
-{{??}}
-  <div class="poi_panel__title__symbol icon-location" style="color:#444648"></div>
-{{?}}
-{{? this.poi.topImageUrl }}
-  <div class="poi_panel__image" style="background-image: url(&quot;{{= this.poi.topImageUrl }}&quot;)"></div>
-{{?}}
-
+      <span class="panel__note__review_count">
+        {{= grades.total_grades_count }} {{= _n('review', 'reviews', grades.total_grades_count) }}
+      </span>
+    </a>
+  {{?}}
+</div>

--- a/src/views/poi_partial/title_image.dot
+++ b/src/views/poi_partial/title_image.dot
@@ -1,0 +1,15 @@
+{{
+  const ico = IconManager.get(this.poi);
+}}
+
+<div class="poi_panel__title_image">
+  {{? this.poi.topImageUrl }}
+    <div class="poi_panel__image" style="background-image: url(&quot;{{= this.poi.topImageUrl }}&quot;)"></div>
+  {{?}}
+  {{? ico }}
+    <div class="poi_panel__title__symbol icon icon-{{= ico.iconClass }}" style="color:{{= ico.color ? ico.color : '#444648' }}"></div>
+  {{??}}
+    <div class="poi_panel__title__symbol icon-location" style="color:#444648"></div>
+  {{?}}
+</div>
+

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -176,7 +176,7 @@ test('display details about the poi on a poi click', async () => {
       contact: document.querySelector('.poi_panel__info__contact').innerText,
       contactUrl: document.querySelector('.poi_panel__info__contact').href,
       hours: document.querySelector('.poi_panel__info__hours__status').innerText,
-      phone: document.querySelector('.poi_panel__actions__phone_container').innerText,
+      phone: document.querySelector('.poi_phone_container_revealed').innerText,
       website: document.querySelector('.poi_panel__info__link').innerText,
     };
   });

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -143,7 +143,7 @@ test('center the map to the poi on a poi click', async () => {
     window.MAP_MOCK.flyTo({ center: { lat: 0, lng: 0 }, zoom: 10 });
   });
   await wait(300);
-  await page.click('.poi_panel__description_container');
+  await page.click('.poi_panel__content .poi_panel__description_container');
   const center = await page.evaluate(() => {
     return window.MAP_MOCK.getCenter();
   });
@@ -158,7 +158,7 @@ test('display details about the poi on a poi click', async () => {
   await page.waitForSelector('.poi_panel__title');
   expect.assertions(8);
 
-  await page.click('.poi_panel__description_container');
+  await page.click('.poi_panel__content .poi_panel__description_container');
   let infoTitle = await page.evaluate(() => {
     return document.querySelector('.poi_panel__sub_block__title').innerText;
   });


### PR DESCRIPTION
## Description
Simplify some markup and CSS in the POI panel, especially start using `display: flexbox` instead of `float` to improve some layouts (tested successfully on IE11) and simplify the complicated action buttons.

## Why
Most layout DOM and CSS are far too complicated and use obsolete layout techniques. Ease future migration to another view framework.