### PR TITLE
Fix mobile geoloc button icon alignment

### DIFF
--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -33,10 +33,13 @@
   color: $primary_text;
   font-size: 20px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate::before {
   background-image: none !important;
+  height: auto;
 }
 
 .mapboxgl-ctrl-geolocate::-moz-focus-inner { /* ff rotating outline fix */


### PR DESCRIPTION
## Description

Fixes the alignment of the geoloc button icon on small screens.

| Before | After |
|--|--|
|![Capture d’écran de 2019-08-14 15-20-53](https://user-images.githubusercontent.com/243653/63024326-42bcdc00-bea7-11e9-94f4-8a03236cafed.png)|![Capture d’écran de 2019-08-14 15-21-12](https://user-images.githubusercontent.com/243653/63024332-45b7cc80-bea7-11e9-82f0-94617734e783.png)|
|![Capture d’écran de 2019-08-14 15-20-45](https://user-images.githubusercontent.com/243653/63024400-6ed85d00-bea7-11e9-9dcd-a00b917b666c.png)|![Capture d’écran de 2019-08-14 15-19-38](https://user-images.githubusercontent.com/243653/63024403-71d34d80-bea7-11e9-94d3-fbc552200bdd.png)|

No changes on large screens.

## Why
It's broken since the last Mapbox-GL update.
