### PR TITLE
Clean-up: Factorize POI reviews template

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -6,6 +6,7 @@ import ApiPoi from './poi/idunn_poi';
 import Device from '../libs/device';
 import poiSubClass from '../mapbox/poi_subclass';
 import popupTemplate from '../views/popup.dot';
+import reviewsPartial from 'src/views/poi_partial/reviews.dot';
 import poiConfigs from '../../config/constants.yml';
 
 const WAIT_BEFORE_DISPLAY = 350;
@@ -96,7 +97,10 @@ PoiPopup.prototype.showPopup = function(poi, event) {
 
   this.popupHandle = new Popup(popupOptions)
     .setLngLat(poi.getLngLat())
-    .setHTML(popupTemplate.call({ poi, color, opening, address, reviews, category, htmlEncode }))
+    .setHTML(popupTemplate.call({
+      poi, color, opening, address, category, htmlEncode,
+      reviews, reviewsPartial,
+    }))
     .addTo(this.map);
 };
 

--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -9,6 +9,7 @@ import layouts from './layouts.js';
 import debounce from '../libs/debounce';
 import poiSubClass from '../mapbox/poi_subclass';
 import { sources } from '../../config/constants.yml';
+import reviewsPartial from 'src/views/poi_partial/reviews.dot';
 import nconf from '@qwant/nconf-getter';
 
 const categoryConfig = nconf.get().category;
@@ -19,7 +20,7 @@ export default class CategoryPanel {
     this.minimalHourPanel = new MinimalHourPanel();
     this.panel = new Panel(this, CategoryPanelView);
     this.panelResizer = new PanelResizer(this.panel);
-
+    this.reviewsPartial = reviewsPartial;
     this.pois = [];
     this.categoryName = '';
     this.active = false;

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -6,6 +6,7 @@ import SearchInput from '../ui_components/search_input';
 import Telemetry from '../libs/telemetry';
 import headerPartial from '../views/poi_partial/header.dot';
 import titleImagePartial from '../views/poi_partial/title_image.dot';
+import reviewsPartial from 'src/views/poi_partial/reviews.dot';
 import MinimalHourPanel from './poi_bloc/opening_minimal';
 import layouts from './layouts.js';
 import nconf from '@qwant/nconf-getter';
@@ -29,6 +30,7 @@ function PoiPanel(sharePanel) {
   this.card = true;
   this.headerPartial = headerPartial;
   this.titleImagePartial = titleImagePartial;
+  this.reviewsPartial = reviewsPartial;
   this.minimalHourPanel = new MinimalHourPanel();
   this.isDirectionActive = nconf.get().direction.enabled;
   this.categories = CategoryService.getCategories();

--- a/src/views/category_panel.dot
+++ b/src/views/category_panel.dot
@@ -66,15 +66,7 @@
                   {{?}}
 
                   {{? grades }}
-                    <a class="panel__note" rel="noopener noreferrer" href="{{= grades.url }}" {{= click(poi.logGradesClick, poi, 'multiple') }}>
-                      {{~ [...Array(5)]:star:k }}      
-                        <span class="icon-icon_star{{= k+1 <= grades.global_grade ? '-filled' : ''}}"></span>
-                      {{~}}
-
-                      <span class="panel__note__review_count">
-                        {{= grades.total_grades_count }} {{= _n('review', 'reviews', grades.total_grades_count) }}
-                      </span>
-                    </a>
+                    {{= this.reviewsPartial({ reviews: grades, poi }) }}
                   {{?}}
 
                   {{= this.minimalHourPanel.set(poi).render() }}

--- a/src/views/poi_partial/header.dot
+++ b/src/views/poi_partial/header.dot
@@ -26,14 +26,6 @@
     </p>
   {{?}}
   {{? grades }}
-    <a class="panel__note" rel="noopener noreferrer" href="{{= grades.url }}" {{= click(this.poi.logGradesClick, this.poi, 'single') }}>
-      {{~ [...Array(5)]:star:k }}
-        <span class="icon-icon_star{{= k+1 <= grades.global_grade ? '-filled' : ''}}"></span>
-      {{~}}
-
-      <span class="panel__note__review_count">
-        {{= grades.total_grades_count }} {{= _n('review', 'reviews', grades.total_grades_count) }}
-      </span>
-    </a>
+    {{= this.reviewsPartial({ reviews: grades, poi: this.poi }) }}
   {{?}}
 </div>

--- a/src/views/poi_partial/reviews.dot
+++ b/src/views/poi_partial/reviews.dot
@@ -1,0 +1,10 @@
+{{ const { poi, reviews } = it; }}
+<a class="panel__note" rel="noopener noreferrer" href="{{= reviews.url }}" {{= click(poi.logGradesClick, poi, 'single') }}>
+  {{~ [...Array(5)]:star:k }}
+    <span class="icon-icon_star{{= k+1 <= reviews.global_grade ? '-filled' : ''}}"></span>
+  {{~}}
+
+  <span class="panel__note__review_count">
+    {{= reviews.total_grades_count }} {{= _n('review', 'reviews', reviews.total_grades_count) }}
+  </span>
+</a>

--- a/src/views/popup.dot
+++ b/src/views/popup.dot
@@ -4,14 +4,7 @@
   <div>
   {{? this.reviews }}
     <div class="poi_popup__review">
-
-      {{~ [...Array(5)]:star:k }}
-        <span class="icon-icon_star{{= k+1 <= this.reviews.global_grade ? '-filled' : ''}}"></span>
-      {{~}}
-
-      <span class="panel__note__review_count">
-        {{= this.reviews.total_grades_count }} {{= _n('review', 'reviews', this.reviews.total_grades_count) }}
-      </span>
+      {{= this.reviewsPartial({ reviews: this.reviews, poi: this.poi }) }}
     </div>
 
   {{?? this.opening && this.opening.days }}


### PR DESCRIPTION
## Description
Factorize the dotJs template code to render PJ POI reviews, instead of copy/pasting.
The 3 places where it's used now have the same rendering code:
![Capture d’écran de 2019-08-14 17-44-18](https://user-images.githubusercontent.com/243653/63035434-7144b200-bebb-11e9-80f6-8f4f48f9eba9.png)
![Capture d’écran de 2019-08-14 17-44-27](https://user-images.githubusercontent.com/243653/63035435-7144b200-bebb-11e9-828c-f7d9cad4e6e7.png)
![Capture d’écran de 2019-08-14 17-44-38](https://user-images.githubusercontent.com/243653/63035437-71dd4880-bebb-11e9-9de1-0ea7d36f769f.png)

## Why
Consistency + easier to maintain and migrate to another component system.
