### PR TITLE
Fix clicking on route displaying a POI anywhere

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -77,6 +77,12 @@ Scene.prototype.initMapBox = function() {
   this.mb.on('load', () => {
     this.onHashChange();
     new SceneDirection(this.mb);
+    listen('set_route', () => {
+      this.routeDisplayed = true;
+    });
+    listen('clean_route', () => {
+      this.routeDisplayed = false;
+    });
     new SceneCategory(this.mb);
     if (performanceEnabled) {
       window.times.mapLoaded = Date.now();
@@ -110,7 +116,7 @@ Scene.prototype.initMapBox = function() {
 
     this.mb.on('click', e => {
       // Disable POI anywhere feature on mobile until we opt for an adapted UX
-      if (Device.isMobile() || e._interactiveClick) {
+      if (Device.isMobile() || e._interactiveClick || this.routeDisplayed) {
         return;
       }
       const poi = new LatLonPoi(e.lngLat);


### PR DESCRIPTION
## Description
Listen to directions events to deactivate the creation of "POI anywhere" when clicking on a displayed route result.

Like discussed previously, we should probably have other cases when we deactivative that, but for now let's fix this one case because it's really broken.

## Why
Since the introduction of the "POI anywhere" feature, clicking on a route result linestring (for example to display one of the route alternatives) creates a POI anywhere, which turns the route result off.