### PR TITLE
QMAPS-1005: fallback to tile POI when unknown by Idunn

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -197,10 +197,13 @@ export default class AppPanel {
     this.activePoiId = poiId;
 
     options.layout = options.layout || layouts.POI;
-    if (options.poi) {
-      // If a POI object is provided before fetching full data,
-      // update the map immediately for UX responsiveness
-      this._updateMapPoi(Poi.deserialize(options.poi), options);
+
+    // If a POI object is provided before fetching full data,
+    // we can update the map immediately for UX responsiveness
+    const shallowPoi = options.poi && Poi.deserialize(options.poi);
+    const updateMapEarly = !!shallowPoi;
+    if (updateMapEarly) {
+      this._updateMapPoi(shallowPoi, options);
     }
 
     let poi;
@@ -212,11 +215,15 @@ export default class AppPanel {
       poi = await ApiPoi.poiApiLoad(options.poi || { id: poiId });
     }
 
+    // fallback on the simple POI object from the map
+    // if Idunn doesn't know this POI
+    poi = poi || shallowPoi;
+
     if (!poi) {
       this.navigateTo('/');
     } else {
       this.openPoiPanel(poi, options);
-      if (!options.poi) {
+      if (!updateMapEarly) {
         this._updateMapPoi(poi, options);
       }
     }

--- a/src/panel/poi_bloc/opening_minimal.js
+++ b/src/panel/poi_bloc/opening_minimal.js
@@ -13,7 +13,7 @@ export default class MinimalHourPanel {
   }
 
   set(poi) {
-    const openingBlock = poi.blocksByType.opening_hours;
+    const openingBlock = poi.blocksByType && poi.blocksByType.opening_hours;
     this.opening = null;
     if (openingBlock) {
       this.opening = new OsmSchedule(openingBlock, this.messages);

--- a/src/views/poi_panel.dot
+++ b/src/views/poi_panel.dot
@@ -98,7 +98,7 @@
             <div>{{= _('DIRECTIONS', 'poi') }}</div>
           </button>
         {{?}}
-        {{? this.poi.blocksByType.phone}}
+        {{? this.poi.blocksByType && this.poi.blocksByType.phone}}
           {{? this.shouldPhoneBeHidden() }}
           <button class="poi_panel__action icon-icon_phone poi_phone_container_hidden" {{= click(this.showPhone, this) }}>
             <div>{{= _('SHOW NUMBER', 'poi') }}</div>


### PR DESCRIPTION
## Description
Use the basic POI info from the tile feature to fill the POI panel when Idunn returned a 404 to the POI details request.
Also tries to clarify the flow of the `setPoi` method with better naming.

## Why
Some POI types are part of the tiles and clickable but not loaded in Idunn. Clicking on one of them returns to the default panel which is confusing.