### PR TITLE
[Clean up] Route summary

### DIFF
--- a/src/panel/direction/road_map_panel.js
+++ b/src/panel/direction/road_map_panel.js
@@ -126,11 +126,6 @@ export default class RoadMapPanel {
     return ret;
   }
 
-  close_leg() {
-    this.routes = [];
-    this.panel.update();
-  }
-
   highlightStepMarker(i) {
     fire('highlight_step', i);
   }

--- a/src/panel/direction/road_map_panel.js
+++ b/src/panel/direction/road_map_panel.js
@@ -16,7 +16,6 @@ export default class RoadMapPanel {
     this.placeholder = false;
     this.error = false;
     this.origin = null;
-    this.openMoreMenuPosition = -1;
     this.sharePanel = sharePanel;
 
     listen('select_road_map', i => {
@@ -154,27 +153,6 @@ export default class RoadMapPanel {
       return 'icon-bike';
     default:
       return '';
-    }
-  }
-
-  toggleMore(position) {
-    if (this.openMoreMenuPosition !== position) {
-      this.closeMoreMenu();
-    }
-    this.openMoreMenu(position);
-  }
-
-  openMoreMenu(position) {
-    this.openMoreMenuPosition = position;
-    const menu = document.querySelector(`#itinerary_more_${position}`);
-    menu.classList.add('itinerary_panel__item__more--active');
-  }
-
-  closeMoreMenu() {
-    const menu = document.querySelector(`#itinerary_more_${this.openMoreMenuPosition}`);
-    if (menu) {
-      menu.classList.remove('itinerary_panel__item__more--active');
-      this.openMoreMenuPosition = -1;
     }
   }
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -223,20 +223,16 @@
   cursor: pointer;
   border-left: 4px solid $background;
   background: $background;
-}
 
-.itinerary_leg--active {
-  border-left: 4px solid #ff3b4a;
-}
-
-.itinerary_leg:hover {
-  border-left: 4px solid #ff3b4a;
+  &--active, &:hover {
+    border-left: 4px solid #ff3b4a;
+  }
 }
 
 .itinerary_leg_inner {
-  min-height: 95px;
-  margin: 0 33px;
-  padding: 20px 0 0;
+  display: flex;
+  padding: 20px;
+  align-items: center;
 }
 
 .itinerary__roadmap__separator {
@@ -244,26 +240,19 @@
   margin: 0 33px;
 }
 
-
-.itinerary_leg:last-of-type .itinerary_leg_inner {
-  border-bottom: none;
-}
-
 .itinerary_leg_icon {
   width: 20px;
   height: 20px;
-  position: absolute;
-  left: 34px;
-  top: 35px;
+  margin: 0 24px 0 12px;
   font-size: 18px;
   color: $primary_text;
+  flex-shrink: 0;
 }
 
 .itinerary_leg_via {
-  width: calc(100% - 225px);
-  position: absolute;
-  left: 80px;
-  text-align: left;
+  align-self: flex-start;
+  flex-grow: 1;
+  margin-right: 24px;
 }
 
 .itinerary_leg_via_title {
@@ -299,22 +288,21 @@
 }
 
 .itinerary_leg_info {
-  width: 90px;
-  position: absolute;
-  right: 60px;
   text-align: right;
+  align-self: flex-start;
+  margin-right: 24px;
+  font-size: 16px;
 }
 
 .itinerary_leg_duration {
-  font-size: 16px;
   font-weight: bold;
   color: #ff3b4a;
+  margin-bottom: 6px;
+  white-space: nowrap;
 }
 
 .itinerary_leg_distance {
-  font-size: 16px;
   color: $primary_text;
-  margin: 5px 0 0;
 }
 
 .itinerary_leg_detail {
@@ -538,9 +526,6 @@
 }
 
 .itinerary_panel__item__share {
-  position: absolute;
-  right: 25px;
-  top: 35px;
   font-size: 16px;
   color: #5c6f84;
 }
@@ -663,41 +648,25 @@
     border: 4px solid $background;
   }
 
-  .itinerary_leg_close {
-    display: none;
-  }
-
-  .itinerary_leg .itinerary_leg_inner {
-    margin: 0 17px;
-    padding: 15px 0 0;
-  }
-  
-  .itinerary_leg .itinerary_leg_distance {
-    margin: 0;
-  }
-  
-  .itinerary_leg .itinerary_leg_duration {
-    float: left;
-    margin: 0 5px 0 0;
-  }
-  
-  .itinerary_leg .itinerary_leg_via {
-    width: calc(100% - 200px);
-    position: absolute;
-    left: 17px;
-    text-align: left;
-    clear: both;
-    margin: 10px 0 0;
-  }
-
   .itinerary_leg_inner {
-    border-bottom: none;
+    padding: 17px;
+  }
+  
+  .itinerary_leg_inner_wrapper {
+    flex-grow: 1;
   }
 
+  .itinerary_leg_info {
+    text-align: left;
+  }
+
+  .itinerary_leg_duration,
+  .itinerary_leg_distance {
+    display: inline-block;
+    margin-right: 6px;
+  }
+  
   .itinerary_leg_preview {
-    position: absolute;
-    right: 17px;
-    bottom: 26px;
     width: 110px;
     height: 35px;
     line-height: 35px;
@@ -714,17 +683,6 @@
     background-size: 100% auto;
     margin: 0 10px 0 10px;
     font-size: 16px;
-  }
-  
-  .itinerary_leg_close {
-    position: absolute;
-    top: 7px;
-    right: 5px;
-    width: 20px;
-    height: 20px;
-    text-align: center;
-    font-size: 16px;
-    color: $secondary_text;
   }
   
   .itinerary_mobile_step {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -537,17 +537,6 @@
   cursor: pointer;
 }
 
-.itinerary_panel__item__more_button {
-  float: right;
-  margin: 13px -10px 0 0;
-  height: 30px;
-  width: 30px;
-  border-radius: 50%;
-  text-align: center;
-  line-height: 30px;
-  color: $primary_clear;
-}
-
 .itinerary_panel__item__share {
   position: absolute;
   right: 25px;
@@ -555,44 +544,6 @@
   font-size: 16px;
   color: #5c6f84;
 }
-
-.itinerary_panel__item__more_button:hover {
-  background: $separator_color;
-  color: $primary_alternative_text;
-  cursor: pointer;
-}
-
-.itinerary_panel__item__more {
-  display: none;
-  position: absolute;
-  padding: 14px 16px 10px 16px;
-  background: $background;
-  color: $primary_text;
-  font-size: 13px;
-  border-radius: 3px;
-  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.2);
-  z-index: 2;
-  margin: 40px 0 0 270px;
-}
-
-.itinerary_panel__item__more--active {
-  display: block;
-}
-
-.itinerary_panel__item__more__line {
-  cursor: pointer;
-  height: 20px;
-  cursor: pointer;
-}
-
-.itinerary_panel__item__more__line:hover {
-  color : $secondary_text;
-}
-
-.itinerary_panel__item__more__icon {
-  padding-right: 9px;
-}
-
 
 /* Mobile */
 

--- a/src/views/direction/road_map.dot
+++ b/src/views/direction/road_map.dot
@@ -54,28 +54,9 @@
     {{??}}
       <div class='itinerary_leg {{= route.isActive ? ' itinerary_leg--active' : '' }}' id='itinerary_leg_{{= route.id }}' {{= click(this.toggleRoute, this, route.id) }}>
         <div class=itinerary_leg_inner>
-
-            <div class="itinerary_panel__item__share" {{= click(this.openShare, this, route) }}>
-              <i class="icon-share-2"></i>
-            </div>
-
-            <!--
-            <div class="itinerary_panel__item__more_button" {{= click(this.toggleMore, this, i) }}>
-              <i class="icon-more-horizontal"></i>
-            </div>
-
-            <div class="itinerary_panel__item__more" id="itinerary_more_{{= i }}">
-              <p class="itinerary_panel__item__more__line" {{= click(this.openShare, this, route) }}>
-                <i class="icon-share-2 itinerary_panel__item__more__icon"></i>
-                <span>{{= _('Share') }}</span>
-              </p>
-              <p class="itinerary_panel__item__more__line" {{= click(this.openPrint, this, route) }}>
-                <i class="icon-printer itinerary_panel__item__more__icon"></i>
-                <span>{{= _('print') }}</span>
-              </p>
-            </div>
-            -->
-
+          <div class="itinerary_panel__item__share" {{= click(this.openShare, this, route) }}>
+            <i class="icon-share-2"></i>
+          </div>
           <div class='itinerary_leg_icon {{= this.getVehicleIcon() }}'></div>
           <div class='itinerary_leg_via'>
             <div class='itinerary_leg_via_title'>{{= _('Via', 'direction') }} {{= this.routes[route.id].legs[0].summary.replace(/^(.*), (.*)$/, '$1') }}</div>

--- a/src/views/direction/road_map.dot
+++ b/src/views/direction/road_map.dot
@@ -39,11 +39,14 @@
     {{? this.isMobile() }}
       <div class='itinerary_leg{{= route.isActive ? ' itinerary_leg--active' : '' }}' id='itinerary_leg_{{= route.id }}''>
         <div class=itinerary_leg_inner>
-          <div class='itinerary_leg_close icon-x' {{= click(this.close_leg, this) }}></div>
-          <div class='itinerary_leg_duration'>{{= this.duration(this.routes[route.id].legs[0].duration) }}</div>
-          <div class='itinerary_leg_distance'>{{= this.distance(this.routes[route.id].legs[0].distance) }}</div>
-          <div class='itinerary_leg_via'>
-            <div class='itinerary_leg_via_title'>{{= _('Via', 'direction') }} {{= this.routes[route.id].legs[0].summary.replace(/^(.*), (.*)$/, '$1') }}</div>
+          <div class="itinerary_leg_inner_wrapper">
+            <div class="itinerary_leg_info">
+              <div class='itinerary_leg_duration'>{{= this.duration(this.routes[route.id].legs[0].duration) }}</div>
+              <div class='itinerary_leg_distance'>{{= this.distance(this.routes[route.id].legs[0].distance) }}</div>
+            </div>
+            <div class='itinerary_leg_via'>
+              <div class='itinerary_leg_via_title'>{{= _('Via', 'direction') }} {{= this.routes[route.id].legs[0].summary.replace(/^(.*), (.*)$/, '$1') }}</div>
+            </div>
           </div>
           <div class='itinerary_leg_preview' {{= click(this.preview, this) }}>
             <span class='itinerary_leg_preview_icon icon-navigation'></span>
@@ -54,9 +57,6 @@
     {{??}}
       <div class='itinerary_leg {{= route.isActive ? ' itinerary_leg--active' : '' }}' id='itinerary_leg_{{= route.id }}' {{= click(this.toggleRoute, this, route.id) }}>
         <div class=itinerary_leg_inner>
-          <div class="itinerary_panel__item__share" {{= click(this.openShare, this, route) }}>
-            <i class="icon-share-2"></i>
-          </div>
           <div class='itinerary_leg_icon {{= this.getVehicleIcon() }}'></div>
           <div class='itinerary_leg_via'>
             <div class='itinerary_leg_via_title'>{{= _('Via', 'direction') }} {{= this.routes[route.id].legs[0].summary.replace(/^(.*), (.*)$/, '$1') }}</div>
@@ -73,6 +73,9 @@
             <div class='itinerary_leg_distance'>
               {{= this.distance(this.routes[route.id].legs[0].distance) }}
             </div>
+          </div>
+          <div class="itinerary_panel__item__share" {{= click(this.openShare, this, route) }}>
+            <i class="icon-share-2"></i>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
Remove some dead code in the route result rendering and make CSS more simpler and robust with flex instead of float/absolute positioning.

## Why
Let's simplify things a bit before integrating public transports.
And it's great to get rid of all these floats, absolute and magic numbers.

## Screens

No big changes, and things are better positioned and spaced (and it works great on IE11).

|Before|After|
|---|---|
|![www qwant com_maps_routes__origin=latlon_48 86921_2 28543 destination=latlon_48 86135_2 27942 mode=driving(Pixel 2)](https://user-images.githubusercontent.com/243653/63516844-1714a400-c4ee-11e9-822d-9d0d756dc09c.png)|![localhost_3000_routes__origin=latlon_48 86921_2 28543 destination=latlon_48 86135_2 27942 mode=driving(Pixel 2)](https://user-images.githubusercontent.com/243653/63516857-1c71ee80-c4ee-11e9-84ad-0cdfd430ba89.png)|
|![Screenshot_2019-08-22 Qwant Maps(1)](https://user-images.githubusercontent.com/243653/63516864-2398fc80-c4ee-11e9-89f2-17e7ba4ae9c3.png)|![Screenshot_2019-08-22 Qwant Maps](https://user-images.githubusercontent.com/243653/63516870-272c8380-c4ee-11e9-8c4d-4dcafc67509d.png)|





