### PR TITLE
Handle direction button differently

### DIFF
--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -21,6 +21,12 @@ export default class ExtendedControl {
     this._compass = this._createButton(compassClass, 'Reset North', () => {
       this._resetNorthAndTilt();
     });
+    this._direction = this._createButton('direction_shortcut icon-corner-up-right', 'direction',
+      ev => {
+        ev.target.style.display = 'none';
+        window.app.directionPanel.open();
+      }
+    );
 
     this._compassIndicator = this._createIcon('map_control__compass__icon');
     this._compass.appendChild(this._compassIndicator);
@@ -41,6 +47,7 @@ export default class ExtendedControl {
     }, this.bottomButtonGroup);
 
     this.topButtonGroup.appendChild(this._compass);
+    this.topButtonGroup.appendChild(this._direction);
 
     geolocControl.onReady(() => {
       this.bottomButtonGroup.appendChild(this._zoomInButton);

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -178,6 +178,9 @@ export default class DirectionPanel {
   }
 
   close() {
+    Array.prototype.slice.call(document.getElementsByClassName('direction_shortcut')).forEach(e => {
+      e.style.display = '';
+    });
     if (!this.active) {
       return;
     }

--- a/src/views/direction/direction.dot
+++ b/src/views/direction/direction.dot
@@ -38,5 +38,3 @@
   </div>
   {{= this.roadMapPanel.render() }}
 </div>
-
-<button class="direction_shortcut icon-corner-up-right" {{= click(this.open, this) }}></div>


### PR DESCRIPTION
Instead of creating the direction button on its own outside of the mapbox owned DOM, we wait for mapbox to be loaded and then create it alongside other buttons.