### PR TITLE
Disable happy_hours block for now (existing implementation is obsolete)

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -55,21 +55,21 @@ pois:
       closed:
         msg: _('Closed')
         color: '#8c0212'
-- apiName: happy_hours
-  panelName: hour
-  options:
-    title: _('Happy hours')
-    messages:
-      open:
-        msg: _('happy hours!')
-        color: '#fcc035'
-      soon:
-        msg: _('Last pint')
-        time: 60
-        color: '#3f76e2'
-      closed:
-        msg: _('Closed')
-        color: '#8c0212'
+# - apiName: happy_hours
+#   panelName: hour
+#   options:
+#     title: _('Happy hours')
+#     messages:
+#       open:
+#         msg: _('happy hours!')
+#         color: '#fcc035'
+#       soon:
+#         msg: _('Last pint')
+#         time: 60
+#         color: '#3f76e2'
+#       closed:
+#         msg: _('Closed')
+#         color: '#8c0212'
 - apiName: website
   panelName: website
 - apiName: wikipedia


### PR DESCRIPTION
The "happy_hours" blocks has been implemented in Idunn in https://github.com/QwantResearch/idunn/pull/66

There was an existing (and very old) implementation in Erdapfel to display this block, using the same template as opening_hours.  
But it just does not work with the response from Idunn.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/4726554/63606887-68499400-c5d1-11e9-849e-70203e5c4678.png)|![image](https://user-images.githubusercontent.com/4726554/63606979-a8a91200-c5d1-11e9-8aff-029b090c5082.png)|

