### PR TITLE
Improve formatting of route distance/duration

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -1,0 +1,30 @@
+
+export function formatDuration(sec) {
+  sec = Math.max(60, sec); // For duration < 60s, return '1 min'
+  let min = Math.round(sec / 60);
+
+  if (min < 60) {
+    return `${min}&nbsp;min`;
+  }
+
+  const hour = Math.floor(min / 60);
+  min = min - 60 * hour;
+  let ret = `${hour}&nbsp;h`;
+  if (min > 0 && hour < 10) {
+    ret += `&nbsp;${min < 10 ? '0' : ''}${min}&nbsp;min`;
+  }
+  return ret;
+}
+
+export function formatDistance(m) {
+  if (m > 99000) {
+    return `${Math.round(m / 1000)}&nbsp;km`;
+  }
+  if (m > 1000) {
+    return `${(m / 1000).toFixed(1).replace('.', ',')}&nbsp;km`;
+  }
+  if (m > 5) {
+    return `${m.toFixed(0)}&nbsp;m`;
+  }
+  return '';
+}

--- a/src/panel/direction/road_map_panel.js
+++ b/src/panel/direction/road_map_panel.js
@@ -4,6 +4,7 @@ import Device from '../../libs/device';
 import RoadMapPreviewPanel from './road_map_preview';
 import Telemetry from '../../libs/telemetry';
 import { openShareModal } from 'src/modals/ShareModal';
+import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
 export default class RoadMapPanel {
   constructor(onOpen, onClose) {
@@ -96,34 +97,11 @@ export default class RoadMapPanel {
   }
 
   duration(sec) {
-    sec = Math.max(60, sec); // For duration < 60s, return '1min'
-    let min = Math.round(sec / 60);
-    const hour = Math.floor(min / 60);
-    let ret = '';
-    if (hour) {
-      ret += hour + 'h ';
-      min = min - 60 * hour;
-    }
-    if ((hour > 0 || min > 0) && hour < 10) {
-      ret += min + 'min ';
-    }
-    return ret;
+    return formatDuration(sec);
   }
 
   distance(m) {
-    let ret = '';
-    if (m > 5) {
-      if (m > 1000) {
-        if (m > 99000) {
-          ret = `${Math.round(m / 1000)}km`;
-        } else {
-          ret = `${(m / 1000).toFixed(1).replace('.', ',')}km`;
-        }
-      } else {
-        ret = `${m.toFixed(0)}m`;
-      }
-    }
-    return ret;
+    return formatDistance(m);
   }
 
   highlightStepMarker(i) {

--- a/tests/units/route_utils.js
+++ b/tests/units/route_utils.js
@@ -1,0 +1,37 @@
+import { formatDuration, formatDistance } from '../../src/libs/route_utils';
+
+describe('route_utils', () => {
+  describe('formatDuration', () => {
+    const cases = [
+      { seconds: 0, result: '1&nbsp;min' },
+      { seconds: 37, result: '1&nbsp;min' },
+      { seconds: 125, result: '2&nbsp;min' },
+      { seconds: 3600, result: '1&nbsp;h' },
+      { seconds: 5100, result: '1&nbsp;h&nbsp;25&nbsp;min' },
+      { seconds: 36000, result: '10&nbsp;h' },
+    ];
+
+    cases.map(({ seconds, result }) =>
+      test(`Formats ${seconds} seconds as '${result}'`, () => {
+        expect(formatDuration(seconds)).toEqual(result);
+      })
+    );
+  });
+
+  describe('formatDistance', () => {
+    const cases = [
+      { meters: 0, result: '' },
+      { meters: 15, result: '15&nbsp;m' },
+      { meters: 500, result: '500&nbsp;m' },
+      { meters: 1234, result: '1,2&nbsp;km' },
+      { meters: 9999, result: '10,0&nbsp;km' },
+      { meters: 123456, result: '123&nbsp;km' },
+    ];
+
+    cases.map(({ meters, result }) =>
+      test(`Formats ${meters} meters as '${result}'`, () => {
+        expect(formatDistance(meters)).toEqual(result);
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Description
- Extract itinerary distance and duration format utilities to a shared file
- Add unit tests to cover these functions
- Add some non-breaking spaces before units and pad minutes

## Why
Improve legibility with respect to common typographic rules.
We should actually do that depending on the locale, but let's improve it later, this fixes most cases.

|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 89360_2 45293 destination=latlon_48 83291_2 31665 mode=cycling (1)](https://user-images.githubusercontent.com/243653/63845881-04391e00-c98b-11e9-8bbf-866c67b9f3b1.png)|![localhost_3000_routes__origin=latlon_48 89360_2 45293 destination=latlon_48 83291_2 31665 mode=cycling](https://user-images.githubusercontent.com/243653/63845893-08653b80-c98b-11e9-8fb2-8f76716a7d42.png)|

## Test suite
```
 PASS  tests/units/route_utils.js
  route_utils
    formatDuration
      ✓ Formats 0 seconds as '1&nbsp;min' (4ms)
      ✓ Formats 37 seconds as '1&nbsp;min'
      ✓ Formats 125 seconds as '2&nbsp;min'
      ✓ Formats 3600 seconds as '1&nbsp;h' (1ms)
      ✓ Formats 5100 seconds as '1&nbsp;h&nbsp;25&nbsp;min'
      ✓ Formats 36000 seconds as '10&nbsp;h'
    formatDistance
      ✓ Formats 0 meters as '' (1ms)
      ✓ Formats 15 meters as '15&nbsp;m'
      ✓ Formats 500 meters as '500&nbsp;m'
      ✓ Formats 1234 meters as '1,2&nbsp;km' (1ms)
      ✓ Formats 9999 meters as '10,0&nbsp;km'
      ✓ Formats 123456 meters as '123&nbsp;km'
```