### PR TITLE
Add a GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Description
+*What this PR does. If needed, explain choices you made, complex parts, architectural changes, etc.*
+
+## Why
+*Why this PR is needed. Feature, step to something bigger, bug, etc.*
+
+## Screenshots
+*For PRs with visual impacts. It's sometimes useful to provide before/after images.*


### PR DESCRIPTION
## Description
Add a pull request template file to the repo, using the [dedicated GitHub feature](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository).

## Why
Encourage contributors to write meaningful PR messages.