### PR TITLE
QMAPS-852: hover style

### DIFF
--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -122,6 +122,12 @@
   text-decoration: underline;
 }
 
+.service_panel__category:hover .service_panel__category__icon,
+.service_panel__event:hover .service_panel__event__icon,
+.service_panel__action:hover .service_panel__action__icon {
+  transform: scale3d(1.1, 1.1, 1.1);
+}
+
 .service_panel__category__icon,
 .service_panel__event__icon,
 .service_panel__action__icon {


### PR DESCRIPTION
Fix: restores the hover style of category icons that got disabled in this diff https://github.com/QwantResearch/erdapfel/pull/358/files#diff-1765d48a01be94f5af1b3475b372c0f2L65