### PR TITLE
Qmaps 916 move mobile bottom ui for each panel

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -394,24 +394,24 @@ Scene.prototype.onHashChange = function() {
   };
 };
 
+Scene.prototype.translateUIControl = function(selector, bottom) {
+  const item = document.querySelector(selector);
+  if (item) {
+    item.style.transform = `translateY(${-bottom}px)` ;
+  }
+};
+
 Scene.prototype.moveMobileBottomUI = function(bottom = 0) {
   if (Device.isMobile()) {
-    const attrib = document.querySelector('.mapboxgl-ctrl-attrib'); // default bottom: 2px
-    const scale = document.querySelector('.map_control__scale'); // default bottom: 8px
-    const geoloc = document.querySelector('.mapboxgl-ctrl-geolocate'); // default bottom: 10px
-    const direction = document.querySelector('.direction_shortcut'); // default bottom: 65px
-    if (attrib) {
-      attrib.style.bottom = bottom + 2 + 'px';
-    }
-    if (scale) {
-      scale.style.bottom = bottom + 8 + 'px';
-    }
-    if (geoloc) {
-      geoloc.style.bottom = bottom + 10 + 'px';
-    }
-    if (direction) {
-      direction.style.bottom = bottom + 65 + 'px';
-    }
+    const uiControls = [
+      '.mapboxgl-ctrl-attrib',
+      '.map_control__scale',
+      '.mapboxgl-ctrl-geolocate',
+      '.direction_shortcut',
+    ];
+    uiControls.forEach(uiControl => {
+      this.translateUIControl(uiControl, bottom);
+    });
   }
 };
 

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -412,13 +412,6 @@ Scene.prototype.moveMobileBottomUI = function(bottom = 0){
     if(direction){
       direction.style.bottom = bottom + 65 + "px";
     }
-
-    // Retry in 500ms if the map hasn't finished loading
-    if(!attrib || !scale || !geoloc){
-      setTimeout(()=> {
-        fire("move_mobile_bottom_ui", bottom);
-      },500);
-    }
   }
 };
 

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -399,6 +399,7 @@ Scene.prototype.moveMobileBottomUI = function(bottom = 0){
     let attrib = document.querySelector(".mapboxgl-ctrl-attrib"); // default bottom: 2px
     let scale = document.querySelector(".map_control__scale"); // default bottom: 8px
     let geoloc = document.querySelector(".mapboxgl-ctrl-geolocate"); // default bottom: 10px
+    let direction = document.querySelector(".direction_shortcut"); // default bottom: 65px
     if(attrib){
       attrib.style.bottom = bottom + 2 + "px";
     }
@@ -407,6 +408,9 @@ Scene.prototype.moveMobileBottomUI = function(bottom = 0){
     }
     if(geoloc){
       geoloc.style.bottom = bottom + 10 + "px";
+    }
+    if(direction){
+      direction.style.bottom = bottom + 65 + "px";
     }
 
     // Retry in 500ms if the map hasn't finished loading

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -12,6 +12,7 @@ import SceneCategory from './scene_category';
 import Error from '../adapters/error';
 import { createIcon } from '../adapters/icon_manager';
 import LatLonPoi from './poi/latlon_poi';
+import Device from '../libs/device';
 import SceneEasterEgg from './scene_easter_egg';
 import Device from '../libs/device';
 import { parseMapHash, getMapHash } from 'src/libs/url_utils';
@@ -185,6 +186,10 @@ Scene.prototype.initMapBox = function() {
 
   listen('restore_location', () => {
     this.restoreLocation();
+  });
+
+  listen('move_mobile_bottom_ui', bottom => {
+    this.moveMobileBottomUI(bottom);
   });
 };
 
@@ -388,6 +393,30 @@ Scene.prototype.onHashChange = function() {
   window.onhashchange = () => {
     this.restoreFromHash(window.location.hash, { animate: false });
   };
+};
+
+Scene.prototype.moveMobileBottomUI = function(bottom = 0){
+  if(Device.isMobile()){
+    let attrib = document.querySelector(".mapboxgl-ctrl-attrib"); // default bottom: 2px
+    let scale = document.querySelector(".map_control__scale"); // default bottom: 8px
+    let geoloc = document.querySelector(".mapboxgl-ctrl-geolocate"); // default bottom: 10px
+    if(attrib){
+      attrib.style.bottom = bottom + 2 + "px";
+    }
+    if(scale){
+      scale.style.bottom = bottom + 8 + "px";
+    }
+    if(geoloc){
+      geoloc.style.bottom = bottom + 10 + "px";
+    }
+
+    // Retry in 500ms if the map hasn't finished loading
+    if(!attrib || !scale || !geoloc){
+      setTimeout(()=> {
+        fire("move_mobile_bottom_ui", bottom);
+      },500);
+    }
+  }
 };
 
 /* private */

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -395,7 +395,7 @@ Scene.prototype.onHashChange = function() {
 };
 
 Scene.prototype.moveMobileBottomUI = function(bottom = 0){
-  if(Device.isMobile()){
+  if (Device.isMobile()) {
     let attrib = document.querySelector(".mapboxgl-ctrl-attrib"); // default bottom: 2px
     let scale = document.querySelector(".map_control__scale"); // default bottom: 8px
     let geoloc = document.querySelector(".mapboxgl-ctrl-geolocate"); // default bottom: 10px

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -394,23 +394,23 @@ Scene.prototype.onHashChange = function() {
   };
 };
 
-Scene.prototype.moveMobileBottomUI = function(bottom = 0){
+Scene.prototype.moveMobileBottomUI = function(bottom = 0) {
   if (Device.isMobile()) {
-    let attrib = document.querySelector(".mapboxgl-ctrl-attrib"); // default bottom: 2px
-    let scale = document.querySelector(".map_control__scale"); // default bottom: 8px
-    let geoloc = document.querySelector(".mapboxgl-ctrl-geolocate"); // default bottom: 10px
-    let direction = document.querySelector(".direction_shortcut"); // default bottom: 65px
-    if(attrib){
-      attrib.style.bottom = bottom + 2 + "px";
+    const attrib = document.querySelector('.mapboxgl-ctrl-attrib'); // default bottom: 2px
+    const scale = document.querySelector('.map_control__scale'); // default bottom: 8px
+    const geoloc = document.querySelector('.mapboxgl-ctrl-geolocate'); // default bottom: 10px
+    const direction = document.querySelector('.direction_shortcut'); // default bottom: 65px
+    if (attrib) {
+      attrib.style.bottom = bottom + 2 + 'px';
     }
-    if(scale){
-      scale.style.bottom = bottom + 8 + "px";
+    if (scale) {
+      scale.style.bottom = bottom + 8 + 'px';
     }
-    if(geoloc){
-      geoloc.style.bottom = bottom + 10 + "px";
+    if (geoloc) {
+      geoloc.style.bottom = bottom + 10 + 'px';
     }
-    if(direction){
-      direction.style.bottom = bottom + 65 + "px";
+    if (direction) {
+      direction.style.bottom = bottom + 65 + 'px';
     }
   }
 };

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -12,7 +12,6 @@ import SceneCategory from './scene_category';
 import Error from '../adapters/error';
 import { createIcon } from '../adapters/icon_manager';
 import LatLonPoi from './poi/latlon_poi';
-import Device from '../libs/device';
 import SceneEasterEgg from './scene_easter_egg';
 import Device from '../libs/device';
 import { parseMapHash, getMapHash } from 'src/libs/url_utils';

--- a/src/libs/panel_resizer.js
+++ b/src/libs/panel_resizer.js
@@ -126,7 +126,9 @@ export default class PanelResizer {
 
     this.holding = false;
     await this.playTransition();
-    fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
+    if (this.resizableElement) {
+      fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
+    }
   }
 
   renderResizerActions() {

--- a/src/libs/panel_resizer.js
+++ b/src/libs/panel_resizer.js
@@ -74,6 +74,8 @@ export default class PanelResizer {
       this.resizableElement.style.height = `${Math.abs(
         window.innerHeight - clientY + this.handleElement.offsetHeight - 10
       )}px`;
+
+      fire("move_mobile_bottom_ui", this.resizableElement.offsetHeight);
     }
   }
 
@@ -124,6 +126,7 @@ export default class PanelResizer {
 
     this.holding = false;
     await this.playTransition();
+    fire("move_mobile_bottom_ui", this.resizableElement.offsetHeight);
   }
 
   renderResizerActions() {

--- a/src/libs/panel_resizer.js
+++ b/src/libs/panel_resizer.js
@@ -75,7 +75,7 @@ export default class PanelResizer {
         window.innerHeight - clientY + this.handleElement.offsetHeight - 10
       )}px`;
 
-      fire("move_mobile_bottom_ui", this.resizableElement.offsetHeight);
+      fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
     }
   }
 
@@ -126,7 +126,7 @@ export default class PanelResizer {
 
     this.holding = false;
     await this.playTransition();
-    fire("move_mobile_bottom_ui", this.resizableElement.offsetHeight);
+    fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
   }
 
   renderResizerActions() {

--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -24,8 +24,8 @@ export default class ExtendedControl {
     this._direction = this._createButton('direction_shortcut icon-corner-up-right', 'direction',
       ev => {
         ev.target.style.display = 'none';
-        window.app.directionPanel.open();
-      }
+        window.app.navigateTo('/routes');
+        fire("move_mobile_bottom_ui", 0);}
     );
 
     this._compassIndicator = this._createIcon('map_control__compass__icon');

--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -25,7 +25,8 @@ export default class ExtendedControl {
       ev => {
         ev.target.style.display = 'none';
         window.app.navigateTo('/routes');
-        fire("move_mobile_bottom_ui", 0);}
+        fire('move_mobile_bottom_ui', 0);
+      }
     );
 
     this._compassIndicator = this._createIcon('map_control__compass__icon');

--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -87,6 +87,12 @@ export default class CategoryPanel {
 
     this.addCategoryMarkers();
     fire('save_location');
+    window.execOnMapLoaded(() => {
+      fire(
+        'move_mobile_bottom_ui',
+        document.querySelector('.category__panel').offsetHeight
+      );
+    });
 
     document.querySelector('.service_panel').classList.remove('service_panel--active');
   }

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -108,7 +108,6 @@ Favorite.prototype.close = function() {
   this.closeMoreMenu();
   this.active = false;
   this.panel.update();
-  //fire("move_mobile_bottom_ui", 0);
 };
 
 Favorite.prototype.go = async function(poi) {

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -92,6 +92,7 @@ Favorite.prototype.open = async function() {
   this.active = true;
   this.panelResizer.reset();
   this.panel.update();
+  fire("move_mobile_bottom_ui", 130);
 };
 
 Favorite.prototype.closeAction = function() {
@@ -103,6 +104,7 @@ Favorite.prototype.close = function() {
   this.closeMoreMenu();
   this.active = false;
   this.panel.update();
+  fire("move_mobile_bottom_ui", 0);
 };
 
 Favorite.prototype.go = async function(poi) {

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -92,10 +92,16 @@ Favorite.prototype.open = async function() {
   this.active = true;
   this.panelResizer.reset();
   this.panel.update();
-  fire("move_mobile_bottom_ui", document.querySelector('.favorite_panel__container').offsetHeight);
+  fire(
+    'move_mobile_bottom_ui',
+    document.querySelector('.favorite_panel__container').offsetHeight
+  );
 
   window.execOnMapLoaded(() => {
-    fire("move_mobile_bottom_ui", document.querySelector('.favorite_panel__container').offsetHeight);
+    fire(
+      'move_mobile_bottom_ui',
+      document.querySelector('.favorite_panel__container').offsetHeight
+    );
   });
 };
 

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -93,6 +93,10 @@ Favorite.prototype.open = async function() {
   this.panelResizer.reset();
   this.panel.update();
   fire("move_mobile_bottom_ui", 130);
+
+  window.execOnMapLoaded(() => {
+    fire("move_mobile_bottom_ui", 130);
+  });
 };
 
 Favorite.prototype.closeAction = function() {
@@ -104,7 +108,7 @@ Favorite.prototype.close = function() {
   this.closeMoreMenu();
   this.active = false;
   this.panel.update();
-  fire("move_mobile_bottom_ui", 0);
+  //fire("move_mobile_bottom_ui", 0);
 };
 
 Favorite.prototype.go = async function(poi) {

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -92,10 +92,10 @@ Favorite.prototype.open = async function() {
   this.active = true;
   this.panelResizer.reset();
   this.panel.update();
-  fire("move_mobile_bottom_ui", 130);
+  fire("move_mobile_bottom_ui", document.querySelector('.favorite_panel__container').offsetHeight);
 
   window.execOnMapLoaded(() => {
-    fire("move_mobile_bottom_ui", 130);
+    fire("move_mobile_bottom_ui", document.querySelector('.favorite_panel__container').offsetHeight);
   });
 };
 

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -92,10 +92,6 @@ Favorite.prototype.open = async function() {
   this.active = true;
   this.panelResizer.reset();
   this.panel.update();
-  fire(
-    'move_mobile_bottom_ui',
-    document.querySelector('.favorite_panel__container').offsetHeight
-  );
 
   window.execOnMapLoaded(() => {
     fire(

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -105,9 +105,15 @@ PoiPanel.prototype.setPoi = async function(poi, options = {}) {
   this.active = true;
   await this.minimalHourPanel.set(this.poi);
   await this.panel.update();
-  fire("move_mobile_bottom_ui", document.querySelector('.poi_panel__content__card').offsetHeight + 20);
+  fire(
+    'move_mobile_bottom_ui',
+    document.querySelector('.poi_panel__content__card').offsetHeight + 20
+  );
   window.execOnMapLoaded(() => {
-    fire("move_mobile_bottom_ui", document.querySelector('.poi_panel__content__card').offsetHeight + 20);
+    fire(
+      'move_mobile_bottom_ui',
+      document.querySelector('.poi_panel__content__card').offsetHeight + 20
+    );
   });
 };
 

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -86,13 +86,13 @@ PoiPanel.prototype.close = async function() {
 
   this.active = false;
   this.panel.update();
-  if (this.sceneState) {
-    this.sceneState.unsetPoiID();
-  }
-  if (UrlState) {
-    UrlState.pushUrl();
-  }
-  fire("move_mobile_bottom_ui", 0);
+  //if (this.sceneState) {
+  //  this.sceneState.unsetPoiID();
+  //}
+  //if (UrlState) {
+  //  UrlState.pushUrl();
+  //}
+  //fire("move_mobile_bottom_ui", 0);
 };
 
 PoiPanel.prototype.restorePoi = async function(id) {
@@ -111,10 +111,9 @@ PoiPanel.prototype.restorePoi = async function(id) {
     await this.minimalHourPanel.set(this.poi);
     await this.panel.update();
 
-    // Move mobile UI in 500ms because scene's listener is not loaded yet
-    setTimeout(() => {
+    window.execOnMapLoaded(() => {
       fire("move_mobile_bottom_ui", 130);
-    }, 500);
+    });
   }
 };
 
@@ -176,14 +175,14 @@ PoiPanel.prototype.backToSmall = function() {
 PoiPanel.prototype.backToFavorite = function() {
   Telemetry.add(Telemetry.POI_BACKTOFAVORITE);
   window.app.navigateTo('/favs');
-  fire("move_mobile_bottom_ui", 0);
+  //fire("move_mobile_bottom_ui", 0);
 };
 
 PoiPanel.prototype.backToList = function() {
   Telemetry.add(Telemetry.POI_BACKTOLIST);
   fire('restore_location');
   window.app.navigateTo(`/places/?type=${this.sourceCategory}`);
-  fire("move_mobile_bottom_ui", 0);
+  //fire("move_mobile_bottom_ui", 0);
 };
 
 PoiPanel.prototype.openDirection = function() {

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -149,14 +149,12 @@ PoiPanel.prototype.backToSmall = function() {
 PoiPanel.prototype.backToFavorite = function() {
   Telemetry.add(Telemetry.POI_BACKTOFAVORITE);
   window.app.navigateTo('/favs');
-  //fire("move_mobile_bottom_ui", 0);
 };
 
 PoiPanel.prototype.backToList = function() {
   Telemetry.add(Telemetry.POI_BACKTOLIST);
   fire('restore_location');
   window.app.navigateTo(`/places/?type=${this.sourceCategory}`);
-  //fire("move_mobile_bottom_ui", 0);
 };
 
 PoiPanel.prototype.openDirection = function() {

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -105,10 +105,7 @@ PoiPanel.prototype.setPoi = async function(poi, options = {}) {
   this.active = true;
   await this.minimalHourPanel.set(this.poi);
   await this.panel.update();
-  fire(
-    'move_mobile_bottom_ui',
-    document.querySelector('.poi_panel__content__card').offsetHeight + 20
-  );
+
   window.execOnMapLoaded(() => {
     fire(
       'move_mobile_bottom_ui',

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -86,35 +86,6 @@ PoiPanel.prototype.close = async function() {
 
   this.active = false;
   this.panel.update();
-  //if (this.sceneState) {
-  //  this.sceneState.unsetPoiID();
-  //}
-  //if (UrlState) {
-  //  UrlState.pushUrl();
-  //}
-  //fire("move_mobile_bottom_ui", 0);
-};
-
-PoiPanel.prototype.restorePoi = async function(id) {
-  Telemetry.add(Telemetry.POI_RESTORE);
-  let hotLoadedPoi = new HotLoadPoi();
-  if (hotLoadedPoi.id === id) {
-    this.poi = hotLoadedPoi;
-    window.execOnMapLoaded(() => {
-      fire('map_mark_poi', this.poi);
-      fire('fit_map', this.poi, layouts.POI);
-    });
-    this.poi.stored = await isPoiFavorite(this.poi);
-    this.active = true;
-    this.sceneState.setPoiId(this.poi.id);
-    PanelManager.keepOnlyPoi();
-    await this.minimalHourPanel.set(this.poi);
-    await this.panel.update();
-
-    window.execOnMapLoaded(() => {
-      fire("move_mobile_bottom_ui", 130);
-    });
-  }
 };
 
 PoiPanel.prototype.setPoi = async function(poi, options = {}) {
@@ -134,7 +105,10 @@ PoiPanel.prototype.setPoi = async function(poi, options = {}) {
   this.active = true;
   await this.minimalHourPanel.set(this.poi);
   await this.panel.update();
-  fire("move_mobile_bottom_ui", 130);
+  fire("move_mobile_bottom_ui", document.querySelector('.poi_panel__content__card').offsetHeight + 20);
+  window.execOnMapLoaded(() => {
+    fire("move_mobile_bottom_ui", document.querySelector('.poi_panel__content__card').offsetHeight + 20);
+  });
 };
 
 PoiPanel.prototype.center = function() {

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -86,8 +86,12 @@ PoiPanel.prototype.close = async function() {
 
   this.active = false;
   this.panel.update();
-  this.sceneState.unsetPoiID();
-  UrlState.pushUrl();
+  if (this.sceneState) {
+    this.sceneState.unsetPoiID();
+  }
+  if (UrlState) {
+    UrlState.pushUrl();
+  }
   fire("move_mobile_bottom_ui", 0);
 };
 

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -35,7 +35,6 @@ export default class ServicePanel {
   }
 
   open() {
-    console.log(1);
     this.active = true;
     if (Device.isMobile()) {
       this.panelResizer.reset();

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -42,7 +42,8 @@ export default class ServicePanel {
     }
     this.panel.update();
 
-    // Move mobile UI in 500ms because scene's listener is not loaded yet
+    fire("move_mobile_bottom_ui", 210);
+
     window.execOnMapLoaded(() => {
       fire("move_mobile_bottom_ui", 210);
     });
@@ -54,7 +55,7 @@ export default class ServicePanel {
     }
     this.active = false;
     this.panel.update();
-    fire("move_mobile_bottom_ui", 0);
+    //fire("move_mobile_bottom_ui", 0);
   }
 
   openCategory(category) {

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -54,7 +54,6 @@ export default class ServicePanel {
     }
     this.active = false;
     this.panel.update();
-    //fire("move_mobile_bottom_ui", 0);
   }
 
   openCategory(category) {

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -35,11 +35,17 @@ export default class ServicePanel {
   }
 
   open() {
+    console.log(1);
     this.active = true;
     if (Device.isMobile()) {
       this.panelResizer.reset();
     }
     this.panel.update();
+
+    // Move mobile UI in 500ms because scene's listener is not loaded yet
+    window.execOnMapLoaded(() => {
+      fire("move_mobile_bottom_ui", 210);
+    });
   }
 
   close() {
@@ -48,6 +54,7 @@ export default class ServicePanel {
     }
     this.active = false;
     this.panel.update();
+    fire("move_mobile_bottom_ui", 0);
   }
 
   openCategory(category) {

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -41,10 +41,10 @@ export default class ServicePanel {
     }
     this.panel.update();
 
-    fire("move_mobile_bottom_ui", 210);
+    fire('move_mobile_bottom_ui', 210);
 
     window.execOnMapLoaded(() => {
-      fire("move_mobile_bottom_ui", 210);
+      fire('move_mobile_bottom_ui', 210);
     });
   }
 

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -41,8 +41,6 @@ export default class ServicePanel {
     }
     this.panel.update();
 
-    fire('move_mobile_bottom_ui', 210);
-
     window.execOnMapLoaded(() => {
       fire('move_mobile_bottom_ui', 210);
     });

--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -103,8 +103,8 @@ noscript {
   .map_container .map_control__scale_attribute_container {
     .mapboxgl-ctrl.map_control__scale {
       position: fixed;
-      left: 10px;
-      bottom: 10px;
+      left: 32px;
+      bottom: 8px;
       margin: 0;
     }
   }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -716,7 +716,7 @@
     height: 48px;
     background: $background;
     position: fixed;
-    bottom: 30px;
+    bottom: 8px;
     right: 8px;
     border-radius: 3px;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -789,7 +789,7 @@
     border-radius: 50%;
     box-shadow: rgba(0,0,0,.2) 0 2px 12px 0;
     position: fixed;
-    bottom: 80px;
+    bottom: 66px;
     right: 9px;
     color: #5c6f84;
     font-size: 25px;

--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -174,6 +174,8 @@
 
   .mapboxgl-ctrl-icon.mapboxgl-ctrl-geolocate {
     font-size: 24px;
+    position: relative;
+    bottom: 10px;
   }
 
   .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl, .mapboxgl-ctrl.mapboxgl-ctrl-attrib {

--- a/src/scss/includes/mapbox-gl-override.scss
+++ b/src/scss/includes/mapbox-gl-override.scss
@@ -2,3 +2,11 @@
 .mapboxgl-ctrl-top-right,
 .mapboxgl-ctrl-bottom-left,
 .mapboxgl-ctrl-bottom-right  { position:absolute; pointer-events:none; }
+
+@media (max-width: 640px) {
+  .map_container .map_control__scale_attribute_container .mapboxgl-ctrl-attrib {
+    position: fixed;
+    bottom: 2px;
+    left: 2px;
+  }
+}


### PR DESCRIPTION
## Description
*Make the bottom UI mobile moveable using an event. Make it generic so any future UI item is also moveable. Use CSS3D (GPU) for moving the UI items.*

## Why
*On mobile, most of the panels (resizeable or not) are on the bottom of the screen, and hide the map's UI. This branch places the UI above each panel, and makes it follow the resize in real time *

## Screenshots
![mmm](https://user-images.githubusercontent.com/1225909/64544283-0c983e00-d327-11e9-8b8b-c1b723bca19b.gif)

