### PR TITLE
Use commit sha1 as image label on docker automated build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN chown node $PROJECT_DIR
 USER node
 WORKDIR $PROJECT_DIR
 
+# Use SOURCE_COMMIT set docker-hub automated build as label
+# Build args are defined in hooks/build
+ARG SOURCE_COMMIT
+LABEL source-commit=$SOURCE_COMMIT
+
 ###########################################################
 
 FROM base as builder

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "------ HOOK START - BUILD -------"
+
+# ENV VARs are set by the cloud.docker.com build process, and are available during automated builds, automated tests,
+# and while executing hooks like here.
+# SOURCE_COMMIT: the SHA1 hash of the commit being built.
+# https://docs.docker.com/docker-hub/builds/advanced/
+docker build -t $IMAGE_NAME --build-arg SOURCE_COMMIT=$SOURCE_COMMIT .
+
+echo "------ HOOK END   - BUILD -------"


### PR DESCRIPTION
## Description
Define a **label** with the commit sha1 in the docker image, using a custom build hook for Docker Hub. 
See https://docs.docker.com/docker-hub/builds/advanced/#build-hook-examples for more details


## Why
This will help to track which version is built and released, both on Docker Hub and in CI pipelines.

