### PR TITLE
Fix attribution hover/click on mobile

### DIFF
--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -188,19 +188,15 @@
     border-radius: 12px;
 
     &::after {
-      position: relative;
+      position: absolute;
       bottom: 0;
-      right: 0;
+      left: 0;
       display: inline-block;
       vertical-align: middle;
     }
 
     &:hover {
-      padding: 0 0 0 5px;
-
-      .mapboxgl-ctrl-attrib-inner {
-        display: inline-block;
-      }
+      padding: 2px 4px 2px 24px;
     }
   }
 


### PR DESCRIPTION
## Description
Fix attribution style on mobile, to be able to see map credits on touch.

## Why
Following #365 the map attribution was moved to the left, but the "i" button was still aligned on the right. As a result, a touch on the icon triggered an unexpected click on the first link ("Qwant Maps")

## Screenshots

| Before        | After           | 
| ------------- |-------------|
| ![image](https://user-images.githubusercontent.com/4726554/64679317-cc969f80-d47b-11e9-8293-68eb407dfa05.png)      | ![image](https://user-images.githubusercontent.com/4726554/64679383-edf78b80-d47b-11e9-83b5-7f6600b8ef5f.png)|
