### PR TITLE
mobile: Keep service panel resizer state on layout reset

### DIFF
--- a/src/libs/panel_resizer.js
+++ b/src/libs/panel_resizer.js
@@ -75,7 +75,7 @@ export default class PanelResizer {
         window.innerHeight - clientY + this.handleElement.offsetHeight - 10
       )}px`;
 
-      fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
+      this.updateMapUiPosition();
     }
   }
 
@@ -127,7 +127,7 @@ export default class PanelResizer {
     this.holding = false;
     await this.playTransition();
     if (this.resizableElement) {
-      fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
+      this.updateMapUiPosition();
     }
   }
 
@@ -153,5 +153,9 @@ export default class PanelResizer {
   reset() {
     this.reduced = false;
     this.maximized = false;
+  }
+
+  updateMapUiPosition() {
+    fire('move_mobile_bottom_ui', this.resizableElement.offsetHeight);
   }
 }

--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -88,10 +88,7 @@ export default class CategoryPanel {
     this.addCategoryMarkers();
     fire('save_location');
     window.execOnMapLoaded(() => {
-      fire(
-        'move_mobile_bottom_ui',
-        document.querySelector('.category__panel').offsetHeight
-      );
+      this.panelResizer.updateMapUiPosition();
     });
 
     document.querySelector('.service_panel').classList.remove('service_panel--active');

--- a/src/panel/favorites_panel.js
+++ b/src/panel/favorites_panel.js
@@ -94,10 +94,7 @@ Favorite.prototype.open = async function() {
   this.panel.update();
 
   window.execOnMapLoaded(() => {
-    fire(
-      'move_mobile_bottom_ui',
-      document.querySelector('.favorite_panel__container').offsetHeight
-    );
+    this.panelResizer.updateMapUiPosition();
   });
 };
 

--- a/src/panel/service_panel.js
+++ b/src/panel/service_panel.js
@@ -36,14 +36,12 @@ export default class ServicePanel {
 
   open() {
     this.active = true;
-    if (Device.isMobile()) {
-      this.panelResizer.reset();
-    }
     this.panel.update();
-
-    window.execOnMapLoaded(() => {
-      fire('move_mobile_bottom_ui', 210);
-    });
+    if (this.panelResizer) {
+      window.execOnMapLoaded(() => {
+        this.panelResizer.updateMapUiPosition();
+      });
+    }
   }
 
   close() {


### PR DESCRIPTION
## Description
On mobile, service panel state should be conserved after multiple interactions on the map.

This PR also defines an helper method in `PanelResizer` to remove a magic constant that defines the service panel default position.


## Why 
Resetting the service panel default (middle) position on each `navigateTo('/')`makes exploring the map more cumbersome.

## Screenshots
![Peek 11-09-2019 17-20](https://user-images.githubusercontent.com/4726554/64710914-12258d80-d4b9-11e9-99d7-7df63365f97a.gif)

