### PR TITLE
Add missing manifest.json to docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !build/
 !public/fonts
 !public/images
+!public/manifest.json
 !src/
 !bin/
 !local_modules/


### PR DESCRIPTION
## Description
manifest.json was ignored on `docker build`, causing 404 on request to /maps/statics/manifest.json

