### PR TITLE
server: Add headers whitelist in 'req' serializer

### DIFF
--- a/bin/serializers/request.js
+++ b/bin/serializers/request.js
@@ -1,15 +1,45 @@
 /* globals require, module, Buffer */
 
 const bunyan = require('bunyan');
+const allowedHeaders = [
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'content-type',
+  'content-length',
+  'host',
+  'referer',
+  'user-agent',
+  'x-client-hash',
+  'x-origin',
+  'x-uniq-id',
+];
 
-module.exports = function(req) {
-  const reqObject = bunyan.stdSerializers.req(req);
-  const headers = reqObject.headers;
-  for (const k in headers) {
-    // geoip headers are utf8 encoded
-    if (k.startsWith('x-geoip-')) {
-      headers[k] = Buffer.from(headers[k], 'binary').toString('utf8');
+const allowedHeadersRules = [
+  /^x-forwarded-(.*)/,
+  /^x-geoip-(.*)/,
+  /^x-qwantmaps-(.*)/,
+];
+
+module.exports = function(config) {
+  return req => {
+    const reqObject = bunyan.stdSerializers.req(req);
+    const headers = reqObject.headers;
+    for (const k in headers) {
+      // geoip headers are utf8 encoded
+      if (k.startsWith('x-geoip-')) {
+        headers[k] = Buffer.from(headers[k], 'binary').toString('utf8');
+      }
+
+      if (config.server.logger.headersWhitelistEnabled) {
+        if (
+          !allowedHeaders.includes(k) &&
+          !allowedHeadersRules.some(rule => rule.test(k))
+        ) {
+          delete headers[k];
+        }
+      }
     }
-  }
-  return reqObject;
+    return reqObject;
+  };
 };

--- a/bin/serializers/request.js
+++ b/bin/serializers/request.js
@@ -16,9 +16,9 @@ const allowedHeaders = [
 ];
 
 const allowedHeadersRules = [
-  /^x-forwarded-(.*)/,
-  /^x-geoip-(.*)/,
-  /^x-qwantmaps-(.*)/,
+  /^x-forwarded-([^.]*)$/,
+  /^x-geoip-([^.]*)$/,
+  /^x-qwantmaps-([^.]*)$/,
 ];
 
 module.exports = function(config) {

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -10,6 +10,8 @@ server:
     idunn:
       url: # client url will be used by default
       timeout: 2000 # ms
+  logger:
+    headersWhitelistEnabled: true
 
 app:
   versionFlag: Beta

--- a/tests/units/serializers.js
+++ b/tests/units/serializers.js
@@ -1,0 +1,37 @@
+import getReqSerializer from '../../bin/serializers/request';
+import defaultConfig from '../../config/default_config.yml';
+
+const reqSerializer = getReqSerializer(defaultConfig);
+
+describe('request serializer', () => {
+  describe('rejected headers', () => {
+    const cases = [
+      // exclude header with dot
+      { 'x-geoip-region.abc': 'value' },
+      // exclude arbitrary headers
+      { 'some-header': 'xyz' },
+    ];
+
+    cases.map(headers =>
+      test(`Exclude header ${Object.keys(headers)}`, () => {
+        expect(reqSerializer({ headers })).toEqual({ headers: {} });
+      })
+    );
+  });
+
+  describe('allowed headers', () => {
+    const cases = [
+      { 'accept-encoding': 'value' },
+      { 'host': 'value' },
+      { 'user-agent': 'value' },
+      { 'x-geoip-region': 'value' },
+      { 'x-qwantmaps-query': 'value' },
+    ];
+
+    cases.map(headers =>
+      test(`Keep header ${Object.keys(headers)}`, () => {
+        expect(reqSerializer({ headers })).not.toEqual({ headers: {} });
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Description
Implements headers filtering in `req` serializer to prevent arbitrary data from being logged.

