### PR TITLE
geocoder: Enable query 'focus' by default

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -23,7 +23,7 @@ services:
     url: override_by_environment
     useLang: true
     maxItems: 7
-    useFocus: false
+    useFocus: true
     focusPrecision: '0.1' # lat/lon degrees
   idunn:
     url: override_by_environment


### PR DESCRIPTION
## Description
Enable `useFocus` by default.

With this setting, geocoder queries will use the current map position to focus on closest results. 
This option is effective on zoom levels greater or equal to 11.
