### PR TITLE
React <Panel> component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3859,6 +3859,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@qwant/uri": "file:local_modules/uri",
     "@turf/bbox": "^6.0.1",
     "bunyan": "^1.8.12",
+    "classnames": "^2.2.6",
     "compression": "^1.7.3",
     "ejs": "^2.6.1",
     "express": "^4.16.3",

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -29,17 +29,21 @@ export default class Panel extends React.Component {
   }
 
   componentDidMount() {
-    this.updateMobileMapUI();
+    this.updateMobileMapUI(this.panelDOMElement.offsetHeight);
   }
 
   componentDidUpdate() {
-    this.updateMobileMapUI();
+    this.updateMobileMapUI(this.panelDOMElement.offsetHeight);
   }
 
-  updateMobileMapUI = () => {
+  componentWillUnmount() {
+    this.updateMobileMapUI(0);
+  }
+
+  updateMobileMapUI = height => {
     if (this.props.resizable) {
       window.execOnMapLoaded(() => {
-        fire('move_mobile_bottom_ui', this.panelDOMElement.offsetHeight);
+        fire('move_mobile_bottom_ui', height);
       });
     }
   }

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+function getClosestIndex(arr, goal) {
+  return arr.reduce((closestIndex, curr, index) =>
+    Math.abs(curr - goal) < Math.abs(arr[closestIndex] - goal) ? index : closestIndex
+  );
+}
+
+export default class Panel extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    title: PropTypes.node,
+    minimizedTitle: PropTypes.node,
+    resizable: PropTypes.bool,
+    close: PropTypes.func,
+    className: PropTypes.string,
+  }
+
+  constructor(props) {
+    super(props);
+    this.moveCallback = e => this.move(e);
+    this.state = {
+      isTransitioning: false,
+      size: null,
+      currentHeight: null,
+    };
+  }
+
+  componentDidMount() {
+    this.updateMobileMapUI();
+  }
+
+  componentDidUpdate() {
+    this.updateMobileMapUI();
+  }
+
+  updateMobileMapUI = () => {
+    if (this.props.resizable) {
+      window.execOnMapLoaded(() => {
+        fire('move_mobile_bottom_ui', this.panelDOMElement.offsetHeight);
+      });
+    }
+  }
+
+  holdResizer = event => {
+    event.preventDefault();
+
+    if (this.state.isTransitioning) {
+      return;
+    }
+
+    this.setState({ size: null });
+    this.move(event.nativeEvent, true);
+
+    this.timer = setTimeout(() => {
+      if (this.timer) {
+        this.holding = true;
+        document.addEventListener('touchmove', this.moveCallback);
+        document.addEventListener('mousemove', this.moveCallback);
+      }
+    }, 250);
+  }
+
+  /**
+  * Triggered on mouse move inside the body element while holding the panel resizer
+  * @param {MouseEvent|TouchEvent} e event
+  * @param {boolean} force Apply the height outside a panel resize
+  */
+  move(e, force = false) {
+    if ((this.holding || force) && !this.state.isTransitioning) {
+      const clientY = e.changedTouches ? e.touches[0].clientY : e.clientY;
+      this.setState({
+        currentHeight: Math.abs(
+          window.innerHeight - clientY + this.handleElement.offsetHeight - 10
+        ),
+      });
+    }
+  }
+
+  /**
+   * Triggered on mouse up of the panel resizer
+   * @param {MouseEvent|TouchEvent} event
+   */
+  stopResize = event => {
+    event.preventDefault();
+    clearTimeout(this.timer);
+
+    const nativeEvent = event.nativeEvent;
+    const clientY = nativeEvent.changedTouches
+      ? nativeEvent.changedTouches[0].clientY
+      : nativeEvent.clientY;
+    const sizes = [0, window.innerHeight / 2, window.innerHeight];
+    const positionIndex = getClosestIndex(sizes, clientY);
+
+    let size = null;
+    if (positionIndex === 2 && this.holding) {
+      size = 'minimized';
+    } else if (positionIndex === 1 && !this.holding) {
+      size = 'minimized';
+    } else if (positionIndex === 0) {
+      size = 'maximized';
+    }
+
+    this.holding = false;
+    this.setState({
+      isTransitioning: true,
+      size,
+      currentHeight: null,
+    });
+
+    setTimeout(() => {
+      this.setState({ isTransitioning: false });
+      document.removeEventListener('touchmove', this.moveCallback);
+      document.removeEventListener('mousemove', this.moveCallback);
+    }, 250); // css transition delay
+  }
+
+  render() {
+    const { children, title, minimizedTitle, resizable, close, className } = this.props;
+    const { size, isTransitioning, currentHeight } = this.state;
+
+    const resizeHandlers = resizable ? {
+      onMouseDown: this.holdResizer,
+      onTouchStart: this.holdResizer,
+      onMouseUp: this.stopResize,
+      onTouchEnd: this.stopResize,
+    } : {};
+
+    return <div
+      className={classnames('panel', size, className, { 'smooth-resize': isTransitioning })}
+      style={{ height: currentHeight && `${currentHeight}px` }}
+      ref={panel => this.panelDOMElement = panel}
+    >
+      {close && <div className="panel-close" onClick={() => close()}><i className="icon-x" /></div>}
+      <div
+        className={classnames('panel-header', { 'panel-resizeHandle': resizable })}
+        {...resizeHandlers}
+        ref={element => this.handleElement = element}
+      >
+        {resizable && size === 'minimized' && minimizedTitle ? minimizedTitle : title}
+      </div>
+      <div className="panel-content">
+        {children}
+      </div>
+    </div>;
+  }
+}

--- a/src/panel/reactPanelWrapper.js
+++ b/src/panel/reactPanelWrapper.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default class ReactPanelWrapper {
+  constructor(reactComponent) {
+    this.reactComponent = reactComponent;
+  }
+
+  open() {
+    ReactDOM.render(<this.reactComponent />, document.querySelector('.react_panel__container'));
+  }
+
+  close() {
+    ReactDOM.unmountComponentAtNode(document.querySelector('.react_panel__container'));
+  }
+}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -1,0 +1,117 @@
+.panel {
+  @include card_shadow();
+  @include card_radius();
+  background-color: white;
+  width: 400px;
+
+  &-header {
+    padding: 0 15px;
+    height: 40px;
+    color: #5c6f84;
+    font-size: 13px;
+    border-bottom: 1px solid #f4f6fa;
+    display: flex;
+    align-items: center;
+  }
+
+  &-close {
+    position: absolute;
+    right: 6px;
+    top: 6px;
+    cursor: pointer;
+    transition: background-color .1s;
+    border-radius: 50%;
+    font-size: 20px;
+    height: 24px;
+    width: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $secondary_text;
+    z-index: 1;
+  
+    &:hover {
+      background: $background_hover;
+      color: $primary_text;
+    }
+  }
+
+  &-content {
+    max-height: calc(100vh - 160px);
+    overflow-y: auto;
+  }
+
+  &--resizable .panel-resizeHandle {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .panel {
+    width: 100vw;
+    height: 50%;
+    position: absolute;
+    background: #f4f6fa;
+    border-radius: 0;
+    bottom: 0;
+
+    &-header {
+      border-bottom: 0;
+      padding: 9px 15px;
+      display: block;
+    }
+
+    &-close {
+      top: 0;
+      right: 0;
+      padding: 21px;
+    }
+
+    &.smooth-resize {
+      transition: all .2s ease-in-out;
+    }
+
+    &.maximized {
+      height: calc(100% + 70px);
+      padding-top: 60px;
+
+      .panel-close {
+        top: 68px;
+      }
+    }
+
+    &.minimized {
+      height: 50px;
+
+      .panel-header {
+        text-align: center;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+    }
+
+    &-content {
+      max-height: none;
+      height: calc(100% - 50px);
+    }
+
+    .panel-resizeHandle {
+      display: block;
+      min-height: 50px;
+      width: 100%;
+      cursor: -webkit-grab;
+      cursor: grab;
+      position: relative;
+
+      &:before {
+        content: '';
+        display: block;
+        border-radius: 2.5px;
+        background-color: #e0e1e6;
+        width: 40px;
+        height: 5px;
+        margin: 0 auto 8px;
+      }
+    }
+  }
+}

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -1,0 +1,1 @@
+@import "./components/panel";

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -31,3 +31,5 @@
 
 // font
 @import "includes/font";
+
+@import "includes/ui_components";

--- a/src/views/app_panel.dot
+++ b/src/views/app_panel.dot
@@ -9,6 +9,7 @@
       {{= this.categoryPanel.render() }}
     {{?}}
     {{= this.servicePanel.render() }}
+    <div class="react_panel__container"></div>
   </div>
 </div>
 


### PR DESCRIPTION
*According to what was decided, this is the first two commits of https://github.com/QwantResearch/erdapfel/pull/375, extracted so it's easier to review and faster to merge*

## Description
Introduces a generic `<Panel>` component and provides a "bridge" util to facilitate mounting and unmouting of the React tree.

## Why
Standardization of the behavior of app panel, with consistent style, fully responsive resizable option, close button, etc.
Ready to be re-used by all top-panels (Service, Category, POI, Favorites, etc.).

## Screenshots
This PR does nothing by itself, but here are screenshots from https://github.com/QwantResearch/erdapfel/pull/375, where the `<Panel>` component is used for the favorites panel:
![Capture d’écran de 2019-09-13 17-26-29](https://user-images.githubusercontent.com/243653/65523048-f88a3a00-deeb-11e9-90f3-e8759c5e13b8.png)
![Capture d’écran de 2019-09-13 17-26-39](https://user-images.githubusercontent.com/243653/65523049-f922d080-deeb-11e9-9a8e-880110757007.png)
![Capture d’écran de 2019-09-13 17-28-36](https://user-images.githubusercontent.com/243653/65523050-f922d080-deeb-11e9-916b-04d616c98374.png)
