### PR TITLE
Fix the mobile map UI when opening directions

### DIFF
--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -25,7 +25,6 @@ export default class ExtendedControl {
       ev => {
         ev.target.style.display = 'none';
         window.app.navigateTo('/routes');
-        fire('move_mobile_bottom_ui', 0);
       }
     );
 

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -103,8 +103,9 @@ export default class AppPanel {
       this.openFavorite();
     });
 
-    this.router.addRoute('Routes', '/routes(?:/?)(.*)', routeParams => {
-      this.openDirection(parseQueryString(routeParams));
+    this.router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
+      fire('move_mobile_bottom_ui', 0);
+      this.openDirection({ ...parseQueryString(routeParams), ...options });
     });
 
     this.router.addRoute('Direct search query', '/([?].*)', queryString => {

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -161,7 +161,7 @@ PoiPanel.prototype.backToList = function() {
 };
 
 PoiPanel.prototype.openDirection = function() {
-  window.app.openDirection({
+  window.app.navigateTo('/routes/', {
     poi: this.poi,
     isFromCategory: this.fromCategory,
     isFromFavorite: this.fromFavorite,


### PR DESCRIPTION
## Description
Ensure the position of mobile map UI elements (buttons, scale and info) is always reset when opening the directions panel.

## Why
We forgot one navigation case in https://github.com/QwantResearch/erdapfel/pull/365.
When clicking on the "Directions" button from a POI card, the map UI elements kept their last position.

![Peek 25-09-2019 11-58](https://user-images.githubusercontent.com/243653/65603325-bd4c4180-dfa5-11e9-9a6d-2c4bb70dc58b.gif)
