### PR TITLE
Fix failing Idunn request when navigating back to POI

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -4,6 +4,7 @@ import nconf from '@qwant/nconf-getter';
 import Error from '../../adapters/error';
 import { sources } from 'config/constants.yml';
 import Telemetry from '../../libs/telemetry';
+import QueryContext from 'src/adapters/query_context';
 
 const serviceConfig = nconf.get().services;
 const LNG_INDEX = 0;
@@ -94,10 +95,7 @@ export default class IdunnPoi extends Poi {
       requestParams = { verbosity: 'short' };
     }
     try {
-      const headers = {};
-      if (obj.queryContext) {
-        obj.queryContext.fillHeaders(headers);
-      }
+      const headers = QueryContext.toHeaders(obj.queryContext);
       rawPoi = await Ajax.getLang(url, requestParams, {}, headers);
       return new IdunnPoi(rawPoi);
     } catch (err) {

--- a/src/adapters/query_context.js
+++ b/src/adapters/query_context.js
@@ -14,21 +14,24 @@ export default class QueryContext {
     this.position = position;
   }
 
-  fillHeaders(headers) {
-    if (!sendQueryContextHeaders) {
-      return;
+  static toHeaders(queryContext) {
+    if (!sendQueryContextHeaders || !queryContext) {
+      return {};
     }
-    if (this.position.lon !== undefined &&
-        this.position.lat !== undefined &&
-        this.position.zoom !== undefined) {
-      const { lon, lat, zoom } = this.position;
+    const headers = {};
+    const { term, ranking, lang, position } = queryContext;
+    if (position.lon !== undefined &&
+        position.lat !== undefined &&
+        position.zoom !== undefined) {
+      const { lon, lat, zoom } = position;
       headers['X-QwantMaps-FocusPosition'] =
         `${Number(lon).toFixed(4)};${Number(lat).toFixed(4)};${Number(zoom).toFixed(1)}`;
     }
-    headers['X-QwantMaps-Query'] = encodeURIComponent(this.term);
-    headers['X-QwantMaps-SuggestionRank'] = this.ranking;
-    if (this.lang !== null) {
-      headers['X-QwantMaps-QueryLang'] = this.lang;
+    headers['X-QwantMaps-Query'] = encodeURIComponent(term);
+    headers['X-QwantMaps-SuggestionRank'] = ranking;
+    if (lang !== null) {
+      headers['X-QwantMaps-QueryLang'] = lang;
     }
+    return headers;
   }
 }


### PR DESCRIPTION
## Description
Fixes the POI panel failing to restore POI info when navigating back after a Bragi request.

Uses a functional approach instead of an instance method, to avoid unknown function error.

IMO there is zero added value to use real classes everywhere and for all data we should just use plain key/value objects instead of class instances, but let's keep that change for later. That's why I kept the `QueryContext` class and used a static method for now.

## Why
To reproduce the bug:
 - Look for a POI using the search input and click it (ex: Musée d'Orsay) => the POI panel is displayed with extended information
 - Close the POI panel => the service panel is displayed
 - Use the brower "back" button => the POI panel is restored (which is correct) but doesn't contain any info apart from the name and type. There is a console error telling `fillHeaders` function doesn't exist.

The `fillHeaders` method didn't exist on the POI `queryContext` object the second time, when using "back", because it went through serialization in the history state.
https://github.com/QwantResearch/erdapfel/pull/384/files#diff-e57b634ee537bafbc6f740beff4c341eL99