### PR TITLE
Fix category POI back/forward navigation

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -175,7 +175,10 @@ export default class AppPanel {
     this.panels.forEach(panel => {
       if (panel === this.poiPanel) {
         panel.setPoi(poi, options);
-      } else if (!options.isFromCategory) {
+      } else if (panel === this.categoryPanel) {
+        const keepCategoryMarkers = options.isFromCategory;
+        panel.close(keepCategoryMarkers);
+      } else {
         panel.close();
       }
     });

--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -123,11 +123,11 @@ export default class CategoryPanel {
     }
   }
 
-  close(toggleMarkers = true) {
+  close(keepCategoryMarkers = false) {
     document.querySelector('.top_bar').classList.remove('top_bar--category-open');
     this.active = false;
     this.panel.update();
-    if (toggleMarkers) {
+    if (!keepCategoryMarkers) {
       this.removeCategoryMarkers();
     }
   }
@@ -181,7 +181,6 @@ export default class CategoryPanel {
         })
       );
     }
-    this.close(false);
     window.app.navigateTo(`/place/${poi.toUrl()}`, {
       poi: poi.serialize(),
       isFromCategory: true,


### PR DESCRIPTION
## Description
Fixes a bug where the category panel **and** the POI panel appeared simultaneously after back/forward navigation. 

![Capture d’écran de 2019-09-25 16-03-56](https://user-images.githubusercontent.com/243653/65688107-cd7a2480-e06a-11e9-8d5a-6eb5f9988910.png)

The reason was that the category panel is responsible for toggling on/off the special category markers, which have to be kept active even when viewing a single POI.
There was a subtle hack to keep the category panel virtually opened but hidden to not trigger the marker hiding event. But this hack wasn't working with the new proper history management.

I fixed it with a more explicit action and changed some names to be clearer.

Later (for example when all panels are react-ified) it would be good to have the "category marker mode" managed as global state because it's clearly not limited to the category panel only.