### PR TITLE
server: Add 'origin' header in serializer whitelist

### DIFF
--- a/bin/serializers/request.js
+++ b/bin/serializers/request.js
@@ -8,6 +8,7 @@ const allowedHeaders = [
   'content-type',
   'content-length',
   'host',
+  'origin',
   'referer',
   'user-agent',
   'x-client-hash',


### PR DESCRIPTION
## Description
Following #377, `origin` header should be serialized too.
