### PR TITLE
Directions: highlight route alternative on summary hover

### DIFF
--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -4,9 +4,12 @@ import RoadMap from './RoadMap';
 
 const Route = ({
   id, route, icon, showDetails, origin, isActive,
-  openDetails, openPreview, selectRoute,
+  openDetails, openPreview, selectRoute, hoverRoute,
 }) =>
-  <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}>
+  <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
+    onMouseEnter={() => hoverRoute(id, true)}
+    onMouseLeave={() => hoverRoute(id, false)}
+  >
     <RouteSummary id={id} route={route}
       icon={icon}
       openDetails={openDetails}

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -34,9 +34,19 @@ export default class RouteResult extends React.Component {
     });
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.routes.length !== prevProps.routes.length) {
+      this.setState({ activeRouteId: 0 });
+    }
+  }
+
   selectRoute = routeId => {
     fire('toggle_route', routeId);
     this.setState({ activeRouteId: routeId });
+  }
+
+  hoverRoute = (routeId, highlightMapRoute) => {
+    fire('toggle_route', highlightMapRoute ? routeId : this.state.activeRouteId);
   }
 
   openRouteDetails = routeId => {
@@ -103,6 +113,7 @@ export default class RouteResult extends React.Component {
       openDetails={this.openRouteDetails}
       openPreview={this.openPreview}
       selectRoute={this.selectRoute}
+      hoverRoute={this.hoverRoute}
     />);
   }
 }


### PR DESCRIPTION
## Description
Highlight the corresponding route alternative on the map when hovering its summary in the panel.

## Why
Improve the route feature UX. Route summary reacted on mouse over but the route drawing on the map didn't.

## Screenshots
![Peek 03-10-2019 13-35](https://user-images.githubusercontent.com/243653/66123790-1ee26080-e5e3-11e9-87de-2d5613679920.gif)
