### PR TITLE
Directions: display line colors on public transport routes

### DIFF
--- a/src/adapters/route_styles.js
+++ b/src/adapters/route_styles.js
@@ -1,0 +1,42 @@
+const ALTERNATE_ROUTE_COLOR = '#c8cbd3';
+const MAIN_ROUTE_COLOR = '#4ba2ea';
+
+export function getRouteStyle(vehicle, isActive) {
+  if (vehicle === 'walking') {
+    return {
+      type: 'symbol',
+      layout: {
+        'icon-image': isActive ? 'walking_bullet_active' : 'walking_bullet_inactive',
+        'symbol-placement': 'line',
+        'symbol-spacing': 12,
+        'icon-ignore-placement': true,
+        'icon-allow-overlap': true,
+        'symbol-avoid-edges': true,
+      },
+    };
+  }
+
+  return {
+    type: 'line',
+    layout: {
+      'line-join': 'round',
+      'line-cap': 'round',
+      'visibility': 'visible',
+    },
+    paint: {
+      'line-color': isActive ? MAIN_ROUTE_COLOR : ALTERNATE_ROUTE_COLOR,
+      'line-color-transition': { 'duration': 0 },
+      'line-width': 7,
+    },
+  };
+}
+
+export function setActiveRouteStyle(map, layerId, vehicle, isActive) {
+  if (vehicle === 'walking') {
+    map.setLayoutProperty(layerId, 'icon-image',
+      isActive ? 'walking_bullet_active' : 'walking_bullet_inactive');
+  } else {
+    map.setPaintProperty(layerId, 'line-color',
+      isActive ? MAIN_ROUTE_COLOR : ALTERNATE_ROUTE_COLOR);
+  }
+}

--- a/src/adapters/route_styles.js
+++ b/src/adapters/route_styles.js
@@ -1,5 +1,9 @@
-const ALTERNATE_ROUTE_COLOR = '#c8cbd3';
-const MAIN_ROUTE_COLOR = '#4ba2ea';
+const INACTIVE_ROUTE_COLOR = '#c8cbd3';
+const ACTIVE_ROUTE_COLOR = '#4ba2ea';
+const DYNAMIC_COLOR_EXPRESSION = ['case', ['has', 'lineColor'],
+  ['concat', '#', ['get', 'lineColor']],
+  ACTIVE_ROUTE_COLOR,
+];
 
 export function getRouteStyle(vehicle, isActive) {
   if (vehicle === 'walking') {
@@ -24,7 +28,7 @@ export function getRouteStyle(vehicle, isActive) {
       'visibility': 'visible',
     },
     paint: {
-      'line-color': isActive ? MAIN_ROUTE_COLOR : ALTERNATE_ROUTE_COLOR,
+      'line-color': isActive ? DYNAMIC_COLOR_EXPRESSION : INACTIVE_ROUTE_COLOR,
       'line-color-transition': { 'duration': 0 },
       'line-width': 7,
     },
@@ -37,6 +41,6 @@ export function setActiveRouteStyle(map, layerId, vehicle, isActive) {
       isActive ? 'walking_bullet_active' : 'walking_bullet_inactive');
   } else {
     map.setPaintProperty(layerId, 'line-color',
-      isActive ? MAIN_ROUTE_COLOR : ALTERNATE_ROUTE_COLOR);
+      isActive ? DYNAMIC_COLOR_EXPRESSION : INACTIVE_ROUTE_COLOR);
   }
 }

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -5,9 +5,7 @@ import { map } from '../../config/constants.yml';
 import Device from '../libs/device';
 import layouts from '../panel/layouts.js';
 import LatLonPoi from '../adapters/poi/latlon_poi';
-
-const ALTERNATE_ROUTE_COLOR = '#c8cbd3';
-const MAIN_ROUTE_COLOR = '#4ba2ea';
+import { getRouteStyle, setActiveRouteStyle } from './route_styles';
 
 export default class SceneDirection {
   constructor(map) {
@@ -75,13 +73,7 @@ export default class SceneDirection {
         mainRoute = route;
       }
 
-      if (this.vehicle === 'walking') {
-        this.map.setLayoutProperty(`route_${route.id}`, 'icon-image',
-          isActive ? 'walking_bullet_active' : 'walking_bullet_inactive');
-      } else {
-        this.map.setPaintProperty(`route_${route.id}`, 'line-color',
-          isActive ? MAIN_ROUTE_COLOR : ALTERNATE_ROUTE_COLOR);
-      }
+      setActiveRouteStyle(this.map, `route_${route.id}`, this.vehicle, isActive);
     });
     this.updateMarkers(mainRoute);
     this.map.moveLayer(`route_${routeId}`, map.routes_layer);
@@ -176,33 +168,9 @@ export default class SceneDirection {
   }
 
   addRouteFeature(route, vehicle) {
-    const layerStyle = vehicle === 'walking' ? {
-      'id': `route_${route.id}`,
-      'type': 'symbol',
-      'source': `source_${route.id}`,
-      'layout': {
-        'icon-image': route.isActive ? 'walking_bullet_active' : 'walking_bullet_inactive',
-        'symbol-placement': 'line',
-        'symbol-spacing': 12,
-        'icon-ignore-placement': true,
-        'icon-allow-overlap': true,
-        'symbol-avoid-edges': true,
-      },
-    } : {
-      'id': `route_${route.id}`,
-      'type': 'line',
-      'source': `source_${route.id}`,
-      'layout': {
-        'line-join': 'round',
-        'line-cap': 'round',
-        'visibility': 'visible',
-      },
-      'paint': {
-        'line-color': route.isActive ? MAIN_ROUTE_COLOR : ALTERNATE_ROUTE_COLOR,
-        'line-color-transition': { duration: 0 },
-        'line-width': 7,
-      },
-    };
+    const layerStyle = getRouteStyle(vehicle, route.isActive);
+    layerStyle.id = `route_${route.id}`;
+    layerStyle.source = `source_${route.id}`;
 
     const sourceId = `source_${route.id}`;
     const sourceJSON = {


### PR DESCRIPTION
## Description
Refactor route style management a bit to gain modularity and use the line color information available on public transport steps to draw routes on the map.
:warning: for now we draw "walk" steps with the default line style because mixing `line` and `symbol` in the same Mapbox layer doesn't seem possible. It will require extra work to split everything, better done separately.

## Screenshots
A route taking Paris metro lines 7, 5 and 11, displayed with the right colors.
![Capture d’écran de 2019-10-03 15-02-20](https://user-images.githubusercontent.com/243653/66129331-fc0a7900-e5ef-11e9-848a-f916a04191dd.png)
