### PR TITLE
Directions: Fix transport route destination marker position

### DIFF
--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -125,13 +125,14 @@ export default class SceneDirection {
         .addTo(this.map)
         .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
 
+      const lastStepCoords = this.steps[this.steps.length - 1].geometry.coordinates;
       const markerDestination = document.createElement('div');
       markerDestination.className = 'itinerary_marker_destination';
       this.markerDestination = new Marker({
         element: markerDestination,
         draggable: true,
       })
-        .setLngLat(this.steps[this.steps.length - 1].maneuver.location)
+        .setLngLat(lastStepCoords[lastStepCoords.length - 1])
         .addTo(this.map)
         .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
 


### PR DESCRIPTION
## Description
Fixes the position of the destination marker when displaying public transport routes.

## Why
For public transport route results (not for other vehicle types), the destination marker was positioned on the start of the last step.
The reason is road map instructions for other vehicle types include a "fake" last step with only the last point as a maneuver, which was what we used as the marker position. We now use the last coordinates of the last geometry, which is more robust for all cases.
 
## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2019-10-03 15-36-47](https://user-images.githubusercontent.com/243653/66131617-0cbcee00-e5f4-11e9-84c5-2f7e8a6f8ff4.png)|![Capture d’écran de 2019-10-03 15-38-00](https://user-images.githubusercontent.com/243653/66131626-1181a200-e5f4-11e9-8620-97bb052063f3.png)|
