### PR TITLE
Simplify UI mode toggling with CSS classes

### DIFF
--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -185,8 +185,6 @@ export default class DirectionPanel {
     }
     Telemetry.add(Telemetry.ITINERARY_CLOSE);
     document.body.classList.remove('directions-open');
-    document.querySelector('#panels').classList.remove('panels--direction-open');
-    document.querySelector('.top_bar').classList.remove('top_bar--direction-open');
     const bottomButtonGroup = document.querySelector('.map_bottom_button_group');
     if (bottomButtonGroup) {
       // buttons may be absent during map loading
@@ -211,8 +209,6 @@ export default class DirectionPanel {
         }
       ) : null
     );
-    document.querySelector('#panels').classList.add('panels--direction-open');
-    document.querySelector('.top_bar').classList.add('top_bar--direction-open');
     await this.restoreParams(options);
     SearchInput.minify();
     this.active = true;

--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -73,14 +73,14 @@ noscript {
 }
 
 @media (max-width: 640px) {
-  .panels--direction-open {
+  .directions-open {
     .menu__button,
-    .direction_shortcut {
+    .direction_shortcut,
+    .search_form {
       visibility: hidden;
     }
   }
 
-  .top_bar--direction-open,
   .top_bar--category-open {
     .search_form {
       visibility: hidden;


### PR DESCRIPTION
## Description
Removes two overly specific CSS class toggles, used to change the UI when the direction panel is active.

## Why
Simplify and avoid duplication.
We already use the same mecanism with the `.directions-open` class on the `body` element, which is more global and doesn't require knowledge of specific DOM elements outside of the panel.