### PR TITLE
Close Direction panel when unminifying main search bar

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -163,7 +163,11 @@ export default class AppPanel {
 
   toggleMinify() {
     if (SearchInput.isMinified()) {
-      this.unminify();
+      if (this.directionPanel.active) {
+        this.navigateTo('/');
+      } else {
+        this.unminify();
+      }
     } else {
       this.minify();
     }
@@ -234,10 +238,6 @@ export default class AppPanel {
   }
 
   _openPanel(panelToOpen, options) {
-    /*
-      "unminify" needs to be called before panel.open :
-      DirectionPanel will minify the main search input (unused for Directions)
-    */
     this.unminify();
     this.activePoiId = null;
     this.panels.forEach(panel => {
@@ -251,6 +251,7 @@ export default class AppPanel {
 
   openDirection(options) {
     this._openPanel(this.directionPanel, options);
+    SearchInput.minify();
   }
 
   openFavorite() {

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -4,7 +4,6 @@ import DirectionInput from '../../ui_components/direction_input';
 import RoadMapPanel from './road_map_panel';
 import DirectionApi from '../../adapters/direction_api';
 import { modes } from '../../adapters/direction_api';
-import SearchInput from '../../ui_components/search_input';
 import LatLonPoi from '../../adapters/poi/latlon_poi';
 import Error from '../../adapters/error';
 import Device from '../../libs/device';
@@ -214,7 +213,6 @@ export default class DirectionPanel {
     document.querySelector('#panels').classList.add('panels--direction-open');
     document.querySelector('.top_bar').classList.add('top_bar--direction-open');
     await this.restoreParams(options);
-    SearchInput.minify();
     this.active = true;
     await this.panel.update();
     this.initDirection();


### PR DESCRIPTION
## Description
Closes the direction panel if the user re-expand the main search bar.
Also move the auto minification of the bar outside of the direction panel itself to avoid manipulating global instances everywhere.

## Why
It was confusing for the user to be able to re-open the main search bar while still being in the direction panel.

## Screenshots
![Peek 07-10-2019 15-38](https://user-images.githubusercontent.com/243653/66317436-ca5c1f80-e919-11e9-9371-b2aa26751cd9.gif)
