### PR TITLE
scss/includes/panels/masqStatus.scss: remove specific appearance

### DIFF
--- a/src/scss/includes/panels/masqStatus.scss
+++ b/src/scss/includes/panels/masqStatus.scss
@@ -29,6 +29,10 @@
   letter-spacing: normal;
   padding: 12px;
 
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
   &_logged {
     background-color: #e9eaeb;
     font-size: 18px;


### PR DESCRIPTION
## Description
Remove specific appearance of the 'Activate' button on Chrome/Safari

## Why
We want the button 'Activate' to look the same on different browsers

## Screenshots
The following screenshot shows the rendering of the 'Activate' button on Chrome
![image-2019-09-12-15-53-58-843](https://user-images.githubusercontent.com/7206073/66408867-05308700-e9f0-11e9-9b72-5a65e9acdd2d.png)
