### PR TITLE
ESLint: brace-style, allow single line

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
         "brace-style": [
             "error",
             "1tbs",
-            { "allowSingleLine": false }
+            { "allowSingleLine": true }
         ],
         "curly": "error",
         "no-trailing-spaces": "error",

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -137,7 +137,7 @@ export default class Panel extends React.Component {
       style={{ height: currentHeight && `${currentHeight}px` }}
       ref={panel => this.panelDOMElement = panel}
     >
-      {close && <div className="panel-close" onClick={() => close()}><i className="icon-x" /></div>}
+      {close && <div className="panel-close" onClick={() => { close(); }}><i className="icon-x" /></div>}
       <div
         className={classnames('panel-header', { 'panel-resizeHandle': resizable })}
         {...resizeHandlers}

--- a/src/modals/ShareModal.jsx
+++ b/src/modals/ShareModal.jsx
@@ -60,14 +60,14 @@ export default class ShareModal extends React.Component {
         <hr className="modal__hr" />
         <i className="share__icons icon-facebook" />
         <a rel="noopener noreferrer" target="_blank" className="share__link"
-          href={facebookUrl} onClick={() => this.openPopup(facebookUrl)}
+          href={facebookUrl} onClick={() => { this.openPopup(facebookUrl); }}
         >
           {_('SHARE ON FACEBOOK', 'share')}
         </a>
         <hr className="modal__hr" />
         <i className="share__icons icon-twitter"></i>
         <a rel="noopener noreferrer" target="_blank" className="share__link"
-          href={twitterUrl} onClick={() => this.openPopup(twitterUrl)}
+          href={twitterUrl} onClick={() => { this.openPopup(twitterUrl); }}
         >
           {_('SHARE ON TWITTER', 'share')}
         </a>

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -87,7 +87,7 @@ export default class Menu extends React.Component {
           <div className="menu__panel__items_container">
             <div className="menu__panel__section menu__panel__section-internal">
               <button className="menu__panel__action"
-                onClick={() => this.navTo('/', { focusSearch: true })}
+                onClick={() => { this.navTo('/', { focusSearch: true }); }}
               >
                 <img
                   className="menu__panel__action__icon"
@@ -96,12 +96,12 @@ export default class Menu extends React.Component {
                 <span>{_('Search', 'menu')}</span>
               </button>
               {isDirectionActive &&
-                <button className="menu__panel__action" onClick={() => this.navTo('/routes/')}>
+                <button className="menu__panel__action" onClick={() => { this.navTo('/routes/'); }}>
                   <i className="menu__panel__action__icon icon-corner-up-right" />
                   <span>{_('Directions', 'menu')}</span>
                 </button>
               }
-              <button className="menu__panel__action" onClick={() => this.navTo('/favs/')}>
+              <button className="menu__panel__action" onClick={() => { this.navTo('/favs/'); }}>
                 <i className="menu__panel__action__icon icon-icon_star" />
                 <span>{_('Favorites', 'menu')}</span>
               </button>

--- a/src/panel/direction/RoadMap.jsx
+++ b/src/panel/direction/RoadMap.jsx
@@ -14,9 +14,9 @@ const RoadMap = ({ steps = [], origin }) =>
     {steps.map((step, index) => <RoadMapStep
       key={index}
       step={step}
-      onMouseOver={() => fire('highlight_step', index)}
-      onMouseOut={() => fire('unhighlight_step', index)}
-      onClick={() => fire('zoom_step', step)}
+      onMouseOver={() => { fire('highlight_step', index); }}
+      onMouseOut={() => { fire('unhighlight_step', index); }}
+      onClick={() => { fire('zoom_step', step); }}
     />)}
   </div>;
 

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -7,8 +7,8 @@ const Route = ({
   openDetails, openPreview, selectRoute, hoverRoute,
 }) =>
   <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
-    onMouseEnter={() => hoverRoute(id, true)}
-    onMouseLeave={() => hoverRoute(id, false)}
+    onMouseEnter={() => { hoverRoute(id, true); }}
+    onMouseLeave={() => { hoverRoute(id, false); }}
   >
     <RouteSummary id={id} route={route}
       openDetails={openDetails}


### PR DESCRIPTION
## Description
Add an exception to the [`brace-style`](https://eslint.org/docs/rules/brace-style#options) ESLint rule to allow single line functions to be written inline.
Also "fix" some existing components that "cheated" with this rule, using no brace at all, possibly returning a value which may have side effects.
 
## Why
This is a very common pattern, especially in React, to attach event listeners as one-line functions. This rule could impair the readability by forcing unnecessary line breaks.

```jsx
// not very readable
<div className="blabla tototo" onClick={() => {
   doSomething();
}} />

// easier to read
<div className="blabla tototo" onClick={() => { doSomething(); }} />
```

And this is not mandatory to write inline if you prefer line-breaks.