### PR TITLE
CI: test each i18n language separately

### DIFF
--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -297,9 +297,9 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
 });
 
 
-test('Poi hour i18n', async () => {
-  await Promise.all(languages.supportedLanguages.map(async language => {
-    return new Promise(async resolve => {
+describe('Poi hour i18n', () => {
+  languages.supportedLanguages.forEach(language => {
+    test(`Poi hour i18n [${language.locale}]`, async () => {
       const langPage = await browser.newPage();
       await langPage.setExtraHTTPHeaders({
         'accept-language': `${language.locale},${language.code},en;q=0.8`,
@@ -316,9 +316,8 @@ test('Poi hour i18n', async () => {
       } else {
         expect(hourData[1][1]).toEqual('09:30 - 18:00');
       }
-      resolve();
     });
-  }));
+  });
 });
 
 afterEach(async () => {


### PR DESCRIPTION
## Description
Refactor a test of the integration suite so it doesn't test every language in the same test case but as separate and dedicated test cases.

## Why
The CI often fails on this test because it reaches the Jest time out for a single test. This will only get worse if we add other languages. 

## Screenshots
![Capture d’écran de 2019-10-09 16-57-14](https://user-images.githubusercontent.com/243653/66493184-e4326980-eab5-11e9-91b5-fb4182cb17e4.png)
