### PR TITLE
Make masq avatar full height

### DIFF
--- a/src/scss/includes/masqAvatar.scss
+++ b/src/scss/includes/masqAvatar.scss
@@ -15,5 +15,7 @@
 
   &-image {
     width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 }


### PR DESCRIPTION
## Description
The Masq avatar should take fill the whole circle even if it is cropped.

## Why
Esthetics

## Screenshots
It is now looking like this with avatar that have a width greater then their height:

![Image Pasted at 2019-10-10 10-33(1)](https://user-images.githubusercontent.com/7206073/66556493-a0d90900-eb50-11e9-9cc6-42bf70de51eb.png)
![Image Pasted at 2019-10-10 10-33](https://user-images.githubusercontent.com/7206073/66556495-a0d90900-eb50-11e9-97fa-6dd65117d43a.png)

We want it to look like this:
![Screenshot from 2019-10-10 11-29-51](https://user-images.githubusercontent.com/7206073/66556908-53a96700-eb51-11e9-8aa6-d42658f8165b.png)
![Screenshot from 2019-10-10 11-30-35](https://user-images.githubusercontent.com/7206073/66556948-658b0a00-eb51-11e9-80e9-9a002d38a232.png)

