### PR TITLE
Route: Adapt roadmap to the new public transport format

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,7 +78,7 @@
         ],
         "comma-dangle": ["error", "always-multiline"],
         "comma-style": ["error", "last"],
-        "max-len": ["error", { "code": 100, "tabWidth": 2 }],
+        "max-len": ["error", { "code": 100, "tabWidth": 2, "ignoreComments": true }],
         "eol-last": ["error", "always"],
         "no-extra-parens": "error",
         "arrow-parens": ["error", "as-needed"],

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -6,6 +6,7 @@ import Device from '../libs/device';
 import layouts from '../panel/layouts.js';
 import LatLonPoi from '../adapters/poi/latlon_poi';
 import { getRouteStyle, setActiveRouteStyle } from './route_styles';
+import { getAllSteps } from 'src/libs/route_utils';
 
 export default class SceneDirection {
   constructor(map) {
@@ -83,7 +84,7 @@ export default class SceneDirection {
     if (!mainRoute) {
       return;
     }
-    this.steps = mainRoute.legs[0].steps;
+    this.steps = getAllSteps(mainRoute);
     // Clean previous markers (if any)
     this.markersSteps.forEach(step => {
       step.remove();

--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -46,3 +46,9 @@ export function getVehicleIcon(vehicle) {
 export function getStepIcon(step) {
   return (step.maneuver.modifier || step.maneuver.type).replace(/\s/g, '-');
 }
+
+export function getAllSteps(route) {
+  // Note: this is a flatMap operation
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Alternative
+  return route.legs.reduce((acc, leg) => acc.concat(leg.steps), []);
+}

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import RouteSummary from './RouteSummary';
 import RoadMap from './RoadMap';
+import { getAllSteps } from 'src/libs/route_utils';
 
 const Route = ({
   id, route, vehicle, showDetails, origin, isActive,
@@ -16,7 +17,7 @@ const Route = ({
       selectRoute={selectRoute}
       vehicle={vehicle}
     />
-    {showDetails && <RoadMap steps={route.steps} origin={origin} />}
+    {showDetails && <RoadMap steps={getAllSteps(route)} origin={origin} />}
   </div>;
 
 export default Route;

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Route from './Route';
-import { getVehicleIcon } from 'src/libs/route_utils';
+import { getVehicleIcon, getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
 
 export default class RouteResult extends React.Component {
@@ -99,13 +99,13 @@ export default class RouteResult extends React.Component {
     }
 
     if (this.state.previewRoute) {
-      return <MobileRoadMapPreview steps={this.state.previewRoute.legs[0].steps} />;
+      return <MobileRoadMapPreview steps={getAllSteps(this.state.previewRoute)} />;
     }
 
     return this.props.routes.map((route, index) => <Route
       key={index}
       id={index}
-      route={route.legs[0]}
+      route={route}
       origin={this.props.origin}
       vehicle={this.props.vehicle}
       isActive={this.state.activeRouteId === index}

--- a/src/panel/direction/RouteVia.jsx
+++ b/src/panel/direction/RouteVia.jsx
@@ -5,20 +5,16 @@ import PublicTransportLine from './PublicTransportLine';
 const RouteVia = ({ route, vehicle }) => {
   if (vehicle !== 'publicTransport') {
     return <div className="routeVia">
-      {_('Via', 'direction')} {route.summary.replace(/^(.*), (.*)$/, '$1')}
+      {_('Via', 'direction')} {route.legs[0].summary.replace(/^(.*), (.*)$/, '$1')}
     </div>;
   }
 
   return <div className="routeVia">
-    {route.steps
-      // removes multiple 'WALK' parts
-      .filter((step, index, steps) =>
-        !(step.mode === 'WALK' && index > 0 && steps[index - 1].mode === 'WALK')
-      )
-      .map((step, idx) => <span key={idx} className="routeVia-step">
-        {step.mode === 'WALK'
+    {route.summary.map((summary, idx) =>
+      <span key={idx} className="routeVia-step">
+        {summary.mode === 'WALK'
           ? <i className="icon-foot" />
-          : <PublicTransportLine mode={step.mode} info={step.info} />
+          : <PublicTransportLine mode={summary.mode} info={summary.info} />
         }
       </span>)
     }


### PR DESCRIPTION
## Description
Changes the route road map components that assumed routes always had one "leg", to support routes with multiple legs.
As we operate mostly on "steps", it's done by facilitating iteration on all steps, ignoring the legs.

## Why
The public transport route provider changed its API, there is now one route leg by transport type section.