### PR TITLE
Fix navigation after search is triggered via URL parameter

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -135,14 +135,21 @@ export default class AppPanel {
     this.router.routeUrl(getCurrentUrl());
   }
 
-  navigateTo(url, state = {}, replaceOnly = false, replaceAndRoute = false) {
+  /**
+  * @param {string} url - The URL to navigate to.
+  * @param {Object} state - State object to associate with the history entry.
+  * @param {Object} options
+  * @param {boolean} options.replace - If true, the new state/url will replace the current state in browser history
+  * @param {boolean} options.routeUrl- If true, the new URL will be evaluated by the router.
+  */
+  navigateTo(url, state = {}, { replace = false, routeUrl = true } = {}) {
     const urlWithCurrentHash = joinPath([window.baseUrl, url]) + location.hash;
-    if (replaceOnly || replaceAndRoute) {
+    if (replace) {
       window.history.replaceState(state, null, urlWithCurrentHash);
     } else {
       window.history.pushState(state, null, urlWithCurrentHash);
     }
-    if (!replaceOnly) {
+    if (routeUrl) {
       this.router.routeUrl(urlWithCurrentHash, state);
     }
   }

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -135,12 +135,14 @@ export default class AppPanel {
     this.router.routeUrl(getCurrentUrl());
   }
 
-  navigateTo(url, state = {}, replace = false) {
+  navigateTo(url, state = {}, replaceOnly = false, replaceAndRoute = false) {
     const urlWithCurrentHash = joinPath([window.baseUrl, url]) + location.hash;
-    if (replace) {
+    if (replaceOnly || replaceAndRoute) {
       window.history.replaceState(state, null, urlWithCurrentHash);
     } else {
       window.history.pushState(state, null, urlWithCurrentHash);
+    }
+    if (!replaceOnly) {
       this.router.routeUrl(urlWithCurrentHash, state);
     }
   }

--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -278,7 +278,10 @@ export default class DirectionPanel {
       routeParams.push(this.poiToUrl('destination', this.destination));
     }
     routeParams.push(`mode=${this.vehicle}`);
-    window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, true /* replace */ );
+    window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, {
+      replace: true,
+      routeUrl: false,
+    });
   }
 
   async restoreParams(options) {

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -82,18 +82,25 @@ export default class SearchInput {
     };
   }
 
-  static executeSearch(query) {
-    window.__searchInput.suggest.preselect(query);
+  static async executeSearch(query) {
+    const searchInput = window.__searchInput;
+    const autocomplete = searchInput.suggest.autocomplete;
+    const results = await autocomplete.prefetch(query);
+    if (results && results.length > 0) {
+      const firstResult = results[0];
+      searchInput.selectItem(firstResult, true);
+    }
   }
 
-  async selectItem(selectedItem) {
+  async selectItem(selectedItem, replaceUrl = false) {
     if (selectedItem instanceof Poi) {
       window.app.navigateTo(`/place/${selectedItem.toUrl()}`, {
         poi: selectedItem.serialize(),
         centerMap: true,
-      });
+      }, false, replaceUrl);
     } else if (selectedItem instanceof Category) {
-      window.app.navigateTo(`/places/?type=${selectedItem.name}`);
+      window.app.navigateTo(`/places/?type=${selectedItem.name}`,
+        undefined, false, replaceUrl);
     }
   }
 }

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -97,10 +97,10 @@ export default class SearchInput {
       window.app.navigateTo(`/place/${selectedItem.toUrl()}`, {
         poi: selectedItem.serialize(),
         centerMap: true,
-      }, false, replaceUrl);
+      }, { replace: replaceUrl });
     } else if (selectedItem instanceof Category) {
       window.app.navigateTo(`/places/?type=${selectedItem.name}`,
-        undefined, false, replaceUrl);
+        {}, { replace: replaceUrl });
     }
   }
 }

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -42,6 +42,7 @@ config.mapStyle.poiMapUrl = '[]';
 config.services.idunn.url = 'http://idunn_test.test';
 config.services.geocoder.url = 'http://geocoder.test/autocomplete';
 config.direction.enabled = true;
+config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox format
 config.category.enabled = true;
 config.masq.enabled = false;
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -288,8 +288,8 @@ test('Search Query', async () => {
   expect(page.url()).toEqual(`${APP_URL}/place/osm:node:4872758213@test_result_1`);
 
   // "go back" navigates to previous page
-  await page.goBack({waitUntil: 'networkidle0'}); // wait for potential requests to API
-  expect(page.url()).toEqual('about:blank')
+  await page.goBack({ waitUntil: 'networkidle0' }); // wait for potential requests to API
+  expect(page.url()).toEqual('about:blank');
 
 });
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -272,15 +272,25 @@ test('check template', async () => {
 
 
 test('Search Query', async () => {
-  expect.assertions(1);
+  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
+  await page.goto('about:blank');
+
   const searchQuery = 'test';
   await page.goto(`${APP_URL}/?q=${searchQuery}`);
-
   const searchValue = await page.evaluate(() => {
     return document.querySelector('#search').value;
   });
 
+  // search input is filled with query
   expect(searchValue).toEqual(searchQuery);
+
+  // app navigates to first result from autocomplete
+  expect(page.url()).toEqual(`${APP_URL}/place/osm:node:4872758213@test_result_1`);
+
+  // "go back" navigates to previous page
+  await page.goBack({waitUntil: 'networkidle0'}); // wait for potential requests to API
+  expect(page.url()).toEqual('about:blank')
+
 });
 
 test('Retrieve restaurant category when we search "restau"', async () => {


### PR DESCRIPTION
## Description
After going to `/?q=somewhere`, the first result from is loaded and redirects to its own URL, that is pushed in the browser history. This behavior breaks the navigation: going back to the previous page leads to the URL with `?q` and has no effect. 

A **new test case** is added to "tests/integration/tests/autocomplete.js" in order to check this behavior.

This PR is a attempt to fix this bug by implementing a new **option `replaceAndRoute` for `navigateTo()`**. With this option, a URL can be routed without adding a new entry to the browser history.

However this change looks a bit clumsy to me, with several optional parameters for `navigateTo`.  
Any idea to make this implementation cleaner ? 



