### PR TITLE
Lint .jsx files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
     "parser": "babel-eslint",
     "parserOptions": {
         "ecmaVersion": 2018,
-        "sourceType": "module"
+        "sourceType": "module",
+        "ecmaFeatures": { "jsx": true }
     },
     "rules": {
         "indent": [

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "msgmerge": "node local_modules/merge-po/index",
     "prepare": "npm run build-map-fonts && node build/before_build.js",
     "build-map-fonts": "node build/build_map_fonts.js",
-    "lint": "eslint src bin build tests",
-    "lint-fix": "eslint --fix src bin build tests"
+    "lint": "eslint src bin build tests --ext '.js,.jsx'",
+    "lint-fix": "eslint --fix src bin build tests --ext '.js,.jsx'"
   },
   "repository": {
     "type": "git",

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -137,7 +137,9 @@ export default class Panel extends React.Component {
       style={{ height: currentHeight && `${currentHeight}px` }}
       ref={panel => this.panelDOMElement = panel}
     >
-      {close && <div className="panel-close" onClick={() => { close(); }}><i className="icon-x" /></div>}
+      {close && <div className="panel-close" onClick={() => { close(); }}>
+        <i className="icon-x" />
+      </div>}
       <div
         className={classnames('panel-header', { 'panel-resizeHandle': resizable })}
         {...resizeHandlers}

--- a/src/panel/ServicePanel.jsx
+++ b/src/panel/ServicePanel.jsx
@@ -16,9 +16,9 @@ class ServicePanel extends React.Component {
         {
           CategoryService.getCategories().map(item =>
             <button className="service_panel__category" type="button" key={item.name}
-              onClick={() => { window.app.navigateTo(`/places/?type=${item.name}`) }}>
+              onClick={() => { window.app.navigateTo(`/places/?type=${item.name}`); }}>
               <div className="service_panel__category__icon"
-                style={{background: item.backgroundColor}}>
+                style={{ background: item.backgroundColor }}>
                 <span className={`icon icon-${item.iconName}`}/>
               </div>
               <div className="service_panel__category__title">{item.label}</div>
@@ -33,7 +33,7 @@ class ServicePanel extends React.Component {
 
         {
           nconf.get().direction.enabled && <button
-            onClick={() => { window.app.navigateTo('/routes/') }}
+            onClick={() => { window.app.navigateTo('/routes/'); }}
             className="service_panel__action service_panel__item__direction">
             <div className="service_panel__action__icon">
               <span className="icon-corner-up-right"/>
@@ -43,7 +43,7 @@ class ServicePanel extends React.Component {
         }
 
         <button className="service_panel__action service_panel__item__fav"
-          onClick={() => { window.app.navigateTo('/favs') }}>
+          onClick={() => { window.app.navigateTo('/favs'); }}>
           <div className="service_panel__action__icon">
             <span className="icon-icon_star"/>
           </div>

--- a/src/panel/menu/MenuItem.jsx
+++ b/src/panel/menu/MenuItem.jsx
@@ -22,6 +22,6 @@ const MenuItem = ({ menuItem: { uri, sectionName, links, icon } }) => <div>
       {link.name}
     </a>)}
   </div>}
-</div>
+</div>;
 
 export default MenuItem;


### PR DESCRIPTION
## Description
Properly configure ESLint to examine files with the `*.jsx` extension and fix errors that got merged.

## Why
I noticed some linting errors in merged files and understood `*.jsx` where just ignored.
ESLint errors were correctly reported in IDE (they must have conf overrides) which explains we didn't catch it before.