### PR TITLE
directions: Focus start field only if both start and end are empty

### DIFF
--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -96,7 +96,7 @@ export default class DirectionPanel {
       }
     };
 
-    if (!this.origin && !Device.isMobile()) {
+    if (!this.origin && !this.destination && !Device.isMobile()) {
       this.searchInputStart.focus();
     }
   }


### PR DESCRIPTION
## Description
On desktop when opening directions panel, "start" field should not be focused if "end" field is not empty.

## Why
On focus, the suggestions for "start" field would hide the content of the "end" field.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/4726554/66921991-7db5ca00-f026-11e9-9aa1-aa8e2f4282c0.png)|![image](https://user-images.githubusercontent.com/4726554/66922215-ee5ce680-f026-11e9-95bf-3d85332facd8.png)|



