### PR TITLE
Routes: have a single style for origin marker

### DIFF
--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -107,8 +107,7 @@ export default class SceneDirection {
       this.setMainRoute(mainRoute.id);
 
       const markerOrigin = document.createElement('div');
-      markerOrigin.className = this.vehicle === 'walking' ?
-        'itinerary_marker_origin_walking' : 'itinerary_marker_origin';
+      markerOrigin.className = 'itinerary_marker_origin';
       this.markerOrigin = new Marker({
         element: markerOrigin,
         draggable: true,

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -89,15 +89,16 @@
 
 .itinerary_icon_origin {
   font-size: 16px;
-  padding: 15px 12px;
+  padding: 15px 11px;
 }
 
 .itinerary_icon_origin_inner {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   background: #4ba2ea;
-  border: 1px solid #fff;
+  border: 2px solid #fff;
   border-radius: 50%;
+  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.14);
 }
 
 .itinerary_icon_destination {
@@ -310,23 +311,12 @@
 }
 
 .itinerary_marker_origin {
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background: #4ba2ea;
-  border: 1px solid $background;
+  border: 2px solid $background;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.14);
-  cursor: pointer;
-  z-index: 2;
-}
-
-.itinerary_marker_origin_walking {
-  width: 19px;
-  height: 19px;
-  border-radius: 50%;
-  background: $background;
-  border: 2px solid #4ba2ea;
-  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.25);
   cursor: pointer;
   z-index: 2;
 }


### PR DESCRIPTION
## Description
Improve and standardize the style of the route starting marker across all modes. Use a larger marker to increase visibility and usability. Also tweaks it in the form to reflect it.

## Why
Simplification, usability, and make sure the starting point is always visible in the public transport mode, whether it starts with a pedestrian part or a transport line part.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2019-10-17 11-27-36](https://user-images.githubusercontent.com/243653/66996514-291b5900-f0d1-11e9-8086-2e793955ac28.png)|![Capture d’écran de 2019-10-17 11-27-15](https://user-images.githubusercontent.com/243653/66996574-42bca080-f0d1-11e9-8529-8ff92c403573.png)|
|![Capture d’écran de 2019-10-17 11-23-08](https://user-images.githubusercontent.com/243653/66996310-cf1a9380-f0d0-11e9-8302-d1163ee1176b.png)|![Capture d’écran de 2019-10-17 11-22-46](https://user-images.githubusercontent.com/243653/66996327-d641a180-f0d0-11e9-9f54-b20c4dfa38cf.png)|
|![Capture d’écran de 2019-10-17 11-23-15](https://user-images.githubusercontent.com/243653/66996336-db9eec00-f0d0-11e9-86ef-d1c6af9dbe63.png)|![Capture d’écran de 2019-10-17 11-23-49](https://user-images.githubusercontent.com/243653/66996356-e22d6380-f0d0-11e9-89bb-620b35c0a579.png)|
