### PR TITLE
Fix js error in category_panel, related to obsolete service_panel

### DIFF
--- a/src/panel/category_panel.js
+++ b/src/panel/category_panel.js
@@ -90,8 +90,6 @@ export default class CategoryPanel {
     window.execOnMapLoaded(() => {
       this.panelResizer.updateMapUiPosition();
     });
-
-    document.querySelector('.service_panel').classList.remove('service_panel--active');
   }
 
   async open(options = {}) {


### PR DESCRIPTION
## Description
Following #348 the service_panel is not present in the DOM if it's not already visible. 
 
Manual control of the panel was probably no longer necessary anyway, since the app router ensures that a single panel is open at any time.