### PR TITLE
Limit Map zoom to 20 (instead of 22)

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -56,6 +56,7 @@ Scene.prototype.initMapBox = function() {
     zoom: this.zoom,
     center: this.center,
     hash: false,
+    maxZoom: 20,
   });
 
   this.popup.init(this.mb);


### PR DESCRIPTION
## Description
Set map max zoom to 20 instead of the default Mapbox-GL setting (22).

## Why
For our tiles and data, zoom levels beyond 20 are useless, often resulting in completely empty views even in the center of cities. For example, this is the side of the Avenue d'Italie in Paris at zoom 22 :smile: 
![Screenshot_2019-10-18 Qwant Maps(1)](https://user-images.githubusercontent.com/243653/67083705-ed00fa80-f19b-11e9-9269-bc77577dc57b.png)

At least we still see some elements at level 20:
![Screenshot_2019-10-18 Qwant Maps(2)](https://user-images.githubusercontent.com/243653/67083888-3fdab200-f19c-11e9-988d-f03136fbfbae.png)


Moreover, there are strange performance problems when the user reaches the level 22 and zooms out.