### PR TITLE
Mapbox-GL v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5089,12 +5089,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
-    "esm": {
-      "version": "3.0.84",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
-      "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw==",
-      "dev": true
-    },
     "espree": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
@@ -6656,9 +6650,9 @@
       }
     },
     "gl-matrix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.0.0.tgz",
-      "integrity": "sha512-PD4mVH/C/Zs64kOozeFnKY8ybhgwxXXQYGWdB4h68krAHknWJgk9uKOn6z8YElh5//vs++90pb6csrTIDWnexA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.1.0.tgz",
+      "integrity": "sha512-526NA+3EA+ztAQi0IZpSWiM0fyQXIp7IbRvfJ4wS/TjjQD0uv0fVybXwwqqSOlq33UckivI0yMDlVtboWm3k7A==",
       "dev": true
     },
     "glob": {
@@ -9511,9 +9505,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.2.0.tgz",
-      "integrity": "sha512-RDo0kMuo9gs6HFX2Maj+tYO5bUT6WFTQkFbJoKdfe2pK8SY/RgyG3SNJRgZypdBR8loxGCG9geeOwc+JJqblHQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.4.1.tgz",
+      "integrity": "sha512-4Jkf1JjsBFKlZA3BHHghgIogbbOuodjVjsdOR/j4AtfLx0G4jXrPcGvwSEVcwyQ27kVECBCn6EyRb6eUNUQujw==",
       "dev": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.4.0",
@@ -9526,8 +9520,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "esm": "~3.0.84",
+        "earcut": "^2.2.0",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.0.0",
         "grid-index": "^1.1.0",
@@ -9561,6 +9554,12 @@
               "dev": true
             }
           }
+        },
+        "earcut": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
+          "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w==",
+          "dev": true
         },
         "quickselect": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jest-extended": "^0.11.2",
     "json-loader": "0.5.7",
     "klokantech-noto-sans": "git+https://github.com/QwantResearch/fonts.git#f25a802",
-    "mapbox-gl": "^1.2.0",
+    "mapbox-gl": "^1.4.1",
     "mapbox-gl-js-mock": "https://github.com/QwantResearch/mapbox-gl-js-mock.git#7eaee7b",
     "masq-lib": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.2",
     "node-sass": "^4.9.2",


### PR DESCRIPTION
## Description
Bump Mapbox-GL version from 1.2.0 to 1.4.1
Tested on mulitple desktop and mobile browsers, no problem detected.

## Why
Benefit from bug fixes and perf improvements (see changelog https://github.com/mapbox/mapbox-gl-js/releases).