### PR TITLE
Fix modal positions in IE11

### DIFF
--- a/src/scss/includes/modals/index.scss
+++ b/src/scss/includes/modals/index.scss
@@ -17,7 +17,7 @@
 }
 
 .modal {
-  position: absolute;
+  position: relative;
   border-radius: 3px;
   overflow: auto;
 }


### PR DESCRIPTION
## Description
Fixes the position of modal on IE11.
Other browsers are not affected

## Why
On this old browser, `display: flex` doesn't play well with `position: absolute` children, and there is actually no need for `position: absolute` here. However `relative` is still needed otherwise the close cross doesn't get positioned correctly in the modal

## Screenshots
|Before|After|
|---|---|
|![VirtualBox_IE11 - Win7_22_10_2019_17_01_11](https://user-images.githubusercontent.com/243653/67301609-efdb5280-f4ef-11e9-8667-90379a0052ed.png)|![VirtualBox_IE11 - Win7_22_10_2019_17_01_27](https://user-images.githubusercontent.com/243653/67301649-fcf84180-f4ef-11e9-9da2-3cb9e58bd9de.png)|
