### PR TITLE
QMAPS-1072: use the default marker icon when clicking an OSM PoI

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -341,7 +341,7 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
 };
 
 Scene.prototype.addMarker = function(poi) {
-  const { className, subClassName, type } = poi;
+  const type = poi.type;
 
   // Create a default marker (white circle on red background) when the PoI is clicked.
   // To do so, we don't define class and subclass when we call createIcon.

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -343,7 +343,9 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
 Scene.prototype.addMarker = function(poi) {
   const { className, subClassName, type } = poi;
 
-  const element = createIcon({ className, subClassName, type });
+  // Create a default marker (white circle on red background) when the PoI is clicked.
+  // To do so, we don't define class and subclass when we call createIcon.
+  const element = createIcon({ class: '', subclass: '', type });
   element.onclick = function(e) {
     // click event should not be propagated to the map itself;
     e.stopPropagation();


### PR DESCRIPTION
## Description
use the default marker icon when clicking an OSM PoI

## Why
avoid seeing the same icon twice (map & marker)

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/67378181-27e1a480-f587-11e9-8f12-ab352a56bd34.png)
