### PR TITLE
Fix no panel rendered when no trailing slash

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -48,5 +48,5 @@ export function joinPath(parts) {
 
 export function getCurrentUrl() {
   const { pathname, search, hash } = window.location;
-  return `${pathname}${search}${hash}`;
+  return `${joinPath([ pathname, search ])}${hash}`;
 }


### PR DESCRIPTION
## Description
Fixes the App not displaying any panel on startup when the url has no trailing slash, like `https://www.qwant.com/maps`.
Ensures the relative url string used by the router for matching always has a slash.

## Why
The matching system in the simple router is not robust enough.
We didn't detect the bug before the service panel react migration in https://github.com/QwantResearch/erdapfel/pull/403, because the dotJs version always displayed itself on startup.
