### PR TITLE
Set custom baseUrl in tests, and fix bug related to trailing slash 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -105,6 +105,9 @@
             "env": {
                 "jest": true,
                 "node": true
+            },
+            "globals": {
+                "APP_URL": "readonly"
             }
         }
     ]

--- a/bin/metrics_builder.js
+++ b/bin/metrics_builder.js
@@ -5,7 +5,7 @@ const { body, validationResult } = require('express-validator');
 const promClient = require('prom-client');
 const events = require('@qwant/telemetry').events;
 
-module.exports = (app, config, registry) => {
+module.exports = (router, config, registry) => {
   const counters = {};
   events.forEach(eventType => {
     counters[eventType] = new promClient.Counter({
@@ -15,7 +15,7 @@ module.exports = (app, config, registry) => {
     });
   });
 
-  app.post('/events',
+  router.post('/events',
     express.json({ strict: true, limit: config.server.maxBodySize }),
     [
       body('type')

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -12,6 +12,8 @@ server:
       timeout: 2000 # ms
   logger:
     headersWhitelistEnabled: true
+  routerBaseUrl: / # path prefix expected by the express server
+  # NB: `routerBaseUrl` may be different from `system.baseUrl` if a proxy is responsible for rewriting URLs
 
 app:
   versionFlag: Beta
@@ -30,7 +32,7 @@ services:
 
 # System
 system:
-  baseUrl: /
+  baseUrl: / # path prefix used in the application URLs (ends with '/')
   timeout: 3
 
 # Store

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -48,5 +48,5 @@ export function joinPath(parts) {
 
 export function getCurrentUrl() {
   const { pathname, search, hash } = window.location;
-  return `${joinPath([ pathname, search ])}${hash}`;
+  return `${pathname}${search}${hash}`;
 }

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -123,7 +123,7 @@ export default class AppPanel {
     });
 
     // Default matching route
-    this.router.addRoute('Services', '(?:/?)', (_, options = {}) => {
+    this.router.addRoute('Services', '/?', (_, options = {}) => {
       this.resetLayout();
       if (options.focusSearch) {
         SearchInput.select();

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -13,5 +13,6 @@ module.exports = {
   },
   globals: {
     puppeteerArguments: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+    APP_URL: 'http://localhost:3000/maps',
   },
 };

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -29,11 +29,6 @@ nock(/idunn_test\.test/)
   .get(/osm:way:2403/)
   .reply(404);
 
-nock(/idunn_test\.test/)
-  .persist(true)
-  .get(/osm:way:2403/)
-  .reply(404, { status: 'not found' });
-
 const config = configBuilder.get();
 
 // Specific config values for tests
@@ -46,6 +41,8 @@ config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox forma
 config.category.enabled = true;
 config.events.enabled = true;
 config.masq.enabled = false;
+config.system.baseUrl = '/maps/';
+config.server.routerBaseUrl = '/maps/';
 
 global.appServer = new App(config);
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -4,7 +4,6 @@ import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
 const configBuilder = require('@qwant/nconf-builder');
 const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 
 const SUGGEST_MAX_ITEMS = config.services.geocoder.maxItems;
 

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -1,9 +1,6 @@
 /* eslint-disable max-len */
 import { initBrowser } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
-const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 const ROUTES_PATH = 'routes';
 const mockAutocomplete = require('../../__data__/autocomplete.json');
 const mockMapBox = require('../../__data__/mapbox.json');

--- a/tests/integration/tests/favorite.js
+++ b/tests/integration/tests/favorite.js
@@ -1,6 +1,3 @@
-const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 import { initBrowser, clearStore } from '../tools';
 import { toggleFavoritePanel, storePoi } from '../favorites_tools';
 

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -1,7 +1,4 @@
 import { initBrowser } from '../tools';
-const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 let browser;
 let page;
 

--- a/tests/integration/tests/map.js
+++ b/tests/integration/tests/map.js
@@ -1,7 +1,4 @@
 import { initBrowser, store, clearStore } from '../tools';
-const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 let browser;
 let page;
 

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -1,8 +1,5 @@
 import { clearStore, initBrowser, wait } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
-const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 
 let browser;
 let page;

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -15,6 +15,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   page = await browser.newPage();
+  page.setDefaultTimeout(3000);
   await page.setExtraHTTPHeaders({
     'accept-language': 'fr_FR,fr,en;q=0.8', /* force fr header */
   });
@@ -23,7 +24,7 @@ beforeEach(async () => {
 
   const autocompleteMock = require('../../__data__/autocomplete.json');
   responseHandler.addPreparedResponse(autocompleteMock, /autocomplete/);
-  responseHandler.addPreparedResponse(poiMock, /places\/osm:way:63178753/);
+  responseHandler.addPreparedResponse(poiMock, /places\/osm:way:63178753(\?.*)?$/);
 });
 
 test('click on a poi', async () => {
@@ -39,6 +40,20 @@ test('click on a poi', async () => {
 test('load a poi from url', async () => {
   expect.assertions(2);
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
+  await page.waitForSelector('.poi_panel__title');
+  const { title, address } = await page.evaluate(() => {
+    return {
+      title: document.querySelector('.poi_panel__title').innerText,
+      address: document.querySelector('.poi_panel__address').innerText,
+    };
+  });
+  expect(title).toMatch(/Musée d'Orsay/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur \(Paris\)/);
+});
+
+test('load a poi from url with simple id', async () => {
+  expect.assertions(2);
+  await page.goto(`${APP_URL}/place/osm:way:63178753`);
   await page.waitForSelector('.poi_panel__title');
   const { title, address } = await page.evaluate(() => {
     return {

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -1,7 +1,4 @@
 const poiMock = require('../../__data__/poi.json');
-const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
-const APP_URL = `http://localhost:${config.PORT}`;
 
 import ResponseHandler from '../helpers/response_handler';
 import { initBrowser, getText, wait, clearStore } from '../tools';
@@ -215,15 +212,12 @@ test('Test 24/7', async () => {
   expect(hours).toEqual('Ouvert 24h/24 et 7j/7');
 });
 
-test('check pre-loaded Poi error handling', async () => {
-
-  expect.assertions(1);
-
+test('check invalid Poi URL redirects to base URL', async () => {
   await page.goto(`${APP_URL}/place/osm:way:2403`);
   const pathname = await page.evaluate(() => {
     return location.pathname;
   });
-  expect(pathname).toEqual('/');
+  expect(pathname).toEqual('/maps/');
 });
 
 async function selectPoiLevel(page, level) {

--- a/tests/integration/tests/server.js
+++ b/tests/integration/tests/server.js
@@ -3,7 +3,7 @@ import request from 'supertest';
 let server;
 
 beforeAll(async () => {
-  server = request('http://localhost:3000');
+  server = request(APP_URL);
 });
 
 test('responds to /', done => {


### PR DESCRIPTION
## Description
Tests now run with `/maps/` as path prefix, and should check URL parsing more reliably. 
This PR also reverts #427 and proposes another fix in the regex used by the default route.

## Why
#427 caused side-effects about routes that can't end with trailing slash, such as `/place/<poi_id>`.
(A trailing slash was added to the `poi_id` sent to the server).   
A test case is added to `tests/integration/tests/poi.js` to catch this bug.
