### PR TITLE
Escape quotes in URLs used in inline style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,8 @@
         ],
         "quotes": [
             "error",
-            "single"
+            "single",
+            "avoid-escape"
         ],
         "semi": [
             "error",

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -50,3 +50,8 @@ export function getCurrentUrl() {
   const { pathname, search, hash } = window.location;
   return `${joinPath([ pathname, search ])}${hash}`;
 }
+
+export function toCssUrl(url) {
+  const escapedUrl = url.replace("'", "\\'");
+  return `url('${escapedUrl}')`;
+}

--- a/src/panel/poi/PoiTitleImage.jsx
+++ b/src/panel/poi/PoiTitleImage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import IconManager from 'src/adapters/icon_manager';
+import { toCssUrl } from 'src/libs/url_utils';
 
 const defaultIcon = { iconClass: 'location', color: '#444648' };
 
@@ -7,7 +8,7 @@ const PoiTitleImage = ({ poi }) => {
   const icon = IconManager.get(poi) || defaultIcon;
   return <div className="poi_panel__title_image">
     {poi.topImageUrl && <div className="poi_panel__image"
-      style={{ backgroundImage: `url('${poi.topImageUrl}')` }} />}
+      style={{ backgroundImage: toCssUrl(poi.topImageUrl) }} />}
     <div className={`poi_panel__title__symbol icon icon-${icon.iconClass}`}
       style={{ color: icon.color }} />
   </div>;


### PR DESCRIPTION
## Description
Define `toCssUrl` function to be used when a URL is used in inline style and quotes need to be escaped. 



