### PR TITLE
Public transport: skip WAIT parts for summary

### DIFF
--- a/src/panel/direction/RouteVia.jsx
+++ b/src/panel/direction/RouteVia.jsx
@@ -10,13 +10,16 @@ const RouteVia = ({ route, vehicle }) => {
   }
 
   return <div className="routeVia">
-    {route.summary.map((summary, idx) =>
-      <span key={idx} className="routeVia-step">
-        {summary.mode === 'WALK'
-          ? <i className="icon-foot" />
-          : <PublicTransportLine mode={summary.mode} info={summary.info} />
-        }
-      </span>)
+    {route.summary
+      .filter(summaryPart => summaryPart.mode !== 'WAIT')
+      .map((summaryPart, idx) =>
+        <span key={idx} className="routeVia-step">
+          {summaryPart.mode === 'WALK'
+            ? <i className="icon-foot" />
+            : <PublicTransportLine mode={summaryPart.mode} info={summaryPart.info} />
+          }
+        </span>
+      )
     }
   </div>;
 };


### PR DESCRIPTION
## Description
Our public transport API results can now include route sections indicating the user has to wait for some time.
We have to filter them out when rendering the summary.
![Capture d’écran de 2019-10-30 10-59-44](https://user-images.githubusercontent.com/243653/67848164-6ede1580-fb04-11e9-8af0-ee7ce3962cbf.png)

## Why
Routes including 'WAIT' sections result in an error when rendering the compact summary component.