### PR TITLE
Fix toCssUrl function to properly escape URLs with multiple quotes

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -52,6 +52,6 @@ export function getCurrentUrl() {
 }
 
 export function toCssUrl(url) {
-  const escapedUrl = url.replace("'", "\\'");
+  const escapedUrl = url.replace(/'/g, "\\'");
   return `url('${escapedUrl}')`;
 }


### PR DESCRIPTION
## Description
Fix introduced in #430 does not handle URLs with multiple `'`
