### PR TITLE
[REACT] Start of "action buttons" migration to react

### DIFF
--- a/src/components/ActionButtons.jsx
+++ b/src/components/ActionButtons.jsx
@@ -1,0 +1,57 @@
+/* global _ */
+import React from 'react';
+import classnames from 'classnames';
+
+export default class ActionButtons extends React.Component {
+  constructor(props) {
+    super(props);
+    this.elem = props.elem;
+    this.poi = props.poi;
+    this.favoriteClick = this.favoriteClick.bind(this);
+  }
+
+  favoriteClick() {
+    console.log('hello!');
+    click(this.elem.toggleStorePoi, this.elem);
+  }
+
+  render() {
+    const elem = this.elem;
+    const poi = this.poi;
+    const phoneLinkStyle = elem.shouldPhoneBeHidden() ? { display: 'none' } : null;
+    const phone = poi.blocksByType && poi.blocksByType.phone && elem.shouldPhoneBeHidden() &&
+      <button className="poi_panel__action icon-icon_phone poi_phone_container_hidden"
+        onClick={ () => click(elem.showPhone, elem) }>
+        <div>{ _('SHOW NUMBER', 'poi') }</div>
+      </button>;
+
+    return <div className="poi_panel__actions">
+      <button className={classnames('poi_panel__action', 'poi_panel__actions__icon__store', {
+          'icon-icon_star-filled': poi.stored,
+          'icon-icon_star': !poi.stored,
+        })}
+        onClick={ this.favoriteClick }
+      >
+        <div>{ poi.stored ? _('SAVED', 'poi') : _('FAVORITES', 'poi') }</div>
+      </button>
+      <button className="poi_panel__action icon-share-2" onClick={ () => click(elem.openShare, elem) }>
+        <div>{ _('SHARE', 'poi') }</div>
+      </button>
+      { elem.isDirectionActive &&
+        <button className="poi_panel__action icon-corner-up-right"
+          onClick={ () => click(elem.openDirection, elem) }>
+          <div>{ _('DIRECTIONS', 'poi') }</div>
+        </button>
+      }
+      { phone }
+      { poi.blocksByType && poi.blocksByType.phone &&
+        <a style={ phoneLinkStyle }
+          className="poi_panel__action icon-icon_phone poi_phone_container_revealed"
+          data-rel="external"
+          rel="noopener noreferrer" href={ poi.blocksByType.phone.url }>
+          <div>{ elem.htmlEncode(poi.blocksByType.phone.local_format) }</div>
+        </a>
+      }
+    </div>;
+  }
+}

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import renderStaticReact from 'src/libs/renderStaticReact';
 import PoiHeader from 'src/panel/poi/PoiHeader';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import OpeningHour from 'src/components/OpeningHour';
 import OsmContribution from 'src/components/OsmContribution';
+import ActionButtons from 'src/components/ActionButtons';
 import PoiPanelView from '../views/poi_panel.dot';
 import Panel from '../libs/panel';
 import Store from '../adapters/store';
@@ -25,6 +27,10 @@ const headerPartial = poi => renderStaticReact(<PoiHeader poi={poi} />);
 const titleImagePartial = poi => renderStaticReact(<PoiTitleImage poi={poi} />);
 const openingHourPartial = poi => renderStaticReact(<OpeningHour poi={poi} />);
 const osmContributionPartial = poi => renderStaticReact(<OsmContribution poi={poi} />);
+const actionButtonsPartial = (elem, poi) => {
+  return ReactDOM.render(<ActionButtons elem={elem} poi={poi} />,
+    document.querySelector('.poi_panel__container'));
+};
 
 function PoiPanel() {
   this.isPoiCompliant = true;
@@ -39,6 +45,7 @@ function PoiPanel() {
   this.titleImagePartial = titleImagePartial;
   this.openingHourPartial = openingHourPartial;
   this.osmContributionPartial = osmContributionPartial;
+  this.actionButtonsPartial = actionButtonsPartial;
   this.isDirectionActive = nconf.get().direction.enabled;
   this.categories = CategoryService.getCategories();
   this.isMasqEnabled = nconf.get().masq.enabled;

--- a/src/views/poi_panel.dot
+++ b/src/views/poi_panel.dot
@@ -83,49 +83,22 @@
          {{= this.headerPartial(this.poi) }}
          {{= this.titleImagePartial(this.poi) }}
       </div>
-      <div class="poi_panel__actions">
-        <button class="poi_panel__action poi_panel__actions__icon__store
-          {{? this.poi.stored}} icon-icon_star-filled {{??}} icon-icon_star {{?}}"
-          {{= click(this.toggleStorePoi, this) }}
-        >
-          <div>{{? this.poi.stored}} {{= _('SAVED', 'poi') }} {{??}} {{= _('FAVORITES', 'poi') }} {{?}}</div>
-        </button>
-        <button class="poi_panel__action icon-share-2" {{= click(this.openShare, this) }}>
-          <div>{{= _('SHARE', 'poi') }}</div>
-        </button>
-        {{? this.isDirectionActive }}
-          <button class="poi_panel__action icon-corner-up-right" {{= click(this.openDirection, this) }}>
-            <div>{{= _('DIRECTIONS', 'poi') }}</div>
-          </button>
-        {{?}}
-        {{? this.poi.blocksByType && this.poi.blocksByType.phone}}
-          {{? this.shouldPhoneBeHidden() }}
-          <button class="poi_panel__action icon-icon_phone poi_phone_container_hidden" {{= click(this.showPhone, this) }}>
-            <div>{{= _('SHOW NUMBER', 'poi') }}</div>
-          </button>
-          {{?}}
-          <a {{? this.shouldPhoneBeHidden() }} style="display:none" {{?}}
-            class="poi_panel__action icon-icon_phone poi_phone_container_revealed" data-rel="external" rel="noopener noreferrer" href="{{= this.poi.blocksByType.phone.url }}">
-            <div>{{= this.htmlEncode(this.poi.blocksByType.phone.local_format) }}</div>
-          </a>
-        {{?}}
-      </div>
 
       {{? isAnywherePoi && this.categories }}
-          <div class="service_panel__categories--poi">
-            <h3 class="service_panel__categories_title">
-              <span class="icon-icon_compass"></span>{{= _("Search around this place", "poi") }}
-            </h3>
-            {{~ this.categories:category:index }}
-              <button class="service_panel__category" type="button" {{= click(this.openCategory, this, category) }}>
-                <div class="service_panel__category__icon" style="background: {{= category.backgroundColor }}">
-                  <span class="icon icon-{{= category.iconName }}"></span>
-                </div>
-                <div class="service_panel__category__title">{{= category.label }}</div>
-              </button>
-            {{~}}
-          </div>
-        {{?}}
+        <div class="service_panel__categories--poi">
+          <h3 class="service_panel__categories_title">
+            <span class="icon-icon_compass"></span>{{= _("Search around this place", "poi") }}
+          </h3>
+          {{~ this.categories:category:index }}
+            <button class="service_panel__category" type="button" {{= click(this.openCategory, this, category) }}>
+              <div class="service_panel__category__icon" style="background: {{= category.backgroundColor }}">
+                <span class="icon icon-{{= category.iconName }}"></span>
+              </div>
+              <div class="service_panel__category__title">{{= category.label }}</div>
+            </button>
+          {{~}}
+        </div>
+      {{?}}
 
       {{= this.PoiBlocContainer.render(this.poi) }}
 
@@ -135,5 +108,6 @@
 
     </div>
   {{?}}
+  {{= this.actionButtonsPartial(this, this.poi) }}
   </div>
 </div>


### PR DESCRIPTION
This is the start of the migration of action buttons to react. **However**, it cannot work currently because it requires events, which prevent the static generation we use currently for most elements. Therefore, we need to insert the element inside the DOM ourselves but we need to wait for the parent DOM node to be ready to do so, which is complicated.