### PR TITLE
[Clean-up] Remove unused poi block function

### DIFF
--- a/src/panel/poi_bloc/poi_bloc_container.js
+++ b/src/panel/poi_bloc/poi_bloc_container.js
@@ -31,15 +31,6 @@ PoiBlocContainer.getBlock = function(name) {
   return PoiBlocContainer.blockComponents[name];
 };
 
-PoiBlocContainer.setBlock = function(block) {
-  const blockComponent = PoiBlocContainer.blockComponents[block.type];
-  return new blockComponent.poiBlockConstructor.default(
-    block,
-    PoiBlocContainer.poi,
-    blockComponent.options,
-  );
-};
-
 PoiBlocContainer.renderBlock = function(block) {
   const blockComponent = getBlockComponent(block);
   if (blockComponent) {


### PR DESCRIPTION
## Description
Remove dead code in `poi_block_container`.

## Why
Cleaning easy stuff before the migration of this component to React.