### PR TITLE
Fix POI title image size

### DIFF
--- a/src/panel/poi/PoiTitleImage.jsx
+++ b/src/panel/poi/PoiTitleImage.jsx
@@ -4,13 +4,17 @@ import { toCssUrl } from 'src/libs/url_utils';
 
 const defaultIcon = { iconClass: 'location', color: '#444648' };
 
-const PoiTitleImage = ({ poi }) => {
+const PoiTitleImage = ({ poi, iconOnly }) => {
+  if (poi.topImageUrl && !iconOnly) {
+    return <div
+      className="poiTitleImage poiTitleImage--image"
+      style={{ backgroundImage: toCssUrl(poi.topImageUrl) }}
+    />;
+  }
+
   const icon = IconManager.get(poi) || defaultIcon;
   return <div className="poiTitleImage">
-    {poi.topImageUrl && <div className="poiTitleImage-image"
-      style={{ backgroundImage: toCssUrl(poi.topImageUrl) }} />}
-    <div className={`poiTitleImage-icon icon icon-${icon.iconClass}`}
-      style={{ color: icon.color }} />
+    <div className={`icon icon-${icon.iconClass}`} style={{ color: icon.color }} />
   </div>;
 };
 

--- a/src/panel/poi_panel.js
+++ b/src/panel/poi_panel.js
@@ -22,7 +22,8 @@ const store = new Store();
 const masqFavoriteModal = new MasqFavoriteModal();
 
 const headerPartial = poi => renderStaticReact(<PoiHeader poi={poi} />);
-const titleImagePartial = poi => renderStaticReact(<PoiTitleImage poi={poi} />);
+const titleImagePartial = (poi, iconOnly = false) =>
+  renderStaticReact(<PoiTitleImage poi={poi} iconOnly={iconOnly} />);
 const openingHourPartial = poi => renderStaticReact(<OpeningHour poi={poi} />);
 const osmContributionPartial = poi => renderStaticReact(<OsmContribution poi={poi} />);
 

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -43,6 +43,7 @@
     float: right;
     width: 65px;
     height: 65px;
+    display: flex;
     align-items: center;
     justify-content: center;
   }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -587,14 +587,6 @@ $HEADER_SIZE: 40px;
   margin: 0;
   flex-direction: row-reverse;
   justify-content: flex-end;
-
-  .poiTitleImage-image {
-    display: none;
-
-    & + .poiTitleImage-icon {
-      display: block;
-    }
-  }
 }
 
 @media (max-width: 640px) {
@@ -680,8 +672,6 @@ $HEADER_SIZE: 40px;
       font-size: 12px;
     }
     .poiTitleImage {
-      width: auto;
-      height: auto;
       margin-top: -6px;
     }
   }

--- a/src/scss/includes/poiTitleImage.scss
+++ b/src/scss/includes/poiTitleImage.scss
@@ -1,23 +1,13 @@
 .poiTitleImage {
-  width: 100px;
-  height: 100px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
-
-  &-image {
-    width: 100%;
-    height: 100%;
+  &--image {
+    width: 100px;
+    height: 100px;
     background-size: cover;
     background-position: center center;
     background-color: white;
-
-    & + .icon {
-      display: none;
-    }
   }
 
-  &-icon {
+  .icon {
     font-size: 45px;
   }
 }

--- a/src/views/poi_panel.dot
+++ b/src/views/poi_panel.dot
@@ -60,7 +60,7 @@
           {{= this.headerPartial(this.poi) }}
           {{= this.openingHourPartial(this.poi) }}
         </div>
-        {{= this.titleImagePartial(this.poi) }}
+        {{= this.titleImagePartial(this.poi, true /* iconOnly */) }}
       </div>
       <div class="poi_panel__content__card__action__container">
         {{? this.isDirectionActive }}


### PR DESCRIPTION
## Description
Fix a vertical white space that appeared recently in the POI panel when displaying an icon instead of an image.
I simplified the component in the process. Previously the component could render the image *and* the icon, even if it displayed only the image, which lead to uselessly complex DOM and CSS. Now this is simpler, and the case when we only want the icon is made explicit with a prop.

## Why
Visual Bug introduced by https://github.com/QwantResearch/erdapfel/pull/397

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2019-11-04 à 17 31 48](https://user-images.githubusercontent.com/243653/68138580-1b672f80-ff29-11e9-8ff5-f20cc54e3931.png)|![Capture d’écran 2019-11-04 à 17 31 20](https://user-images.githubusercontent.com/243653/68138597-1efab680-ff29-11e9-83ea-468053e8a0f2.png)|

(no changes on all other cases: icon/image, mobile/desktop, list/single POI, etc.)