### PR TITLE
Update Masq to v0.14.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1034,9 +1034,9 @@
       }
     },
     "@clusterws/cws": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@clusterws/cws/-/cws-0.11.1.tgz",
-      "integrity": "sha512-nogWghc8OOQB+P68alPMkl/tXvRGRQgWtx426OR8T/zwG3ZGZ5JHlyY6TNOfOBuadKBZP7EuNWL1YD37TO/erw==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@clusterws/cws/-/cws-0.15.2.tgz",
+      "integrity": "sha512-nTXrmbv8IK38VBvfhdhigrxC7GvN4fsDrImCGx/b8jb3AP34e5B23cfXQCxZ2H3M3rywWbkeNdX9bGc01nX2rw==",
       "dev": true
     },
     "@cnakazawa/watch": {
@@ -5966,8 +5966,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5988,14 +5987,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6010,20 +6007,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6140,8 +6134,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6153,7 +6146,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6168,7 +6160,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6176,14 +6167,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6202,7 +6191,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6290,8 +6278,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6303,7 +6290,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6389,8 +6375,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6426,7 +6411,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6446,7 +6430,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6490,14 +6473,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7012,9 +6993,9 @@
       }
     },
     "hypercore-protocol": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.11.0.tgz",
-      "integrity": "sha512-V/0Vru8gavoO++K2QFOAXu7xgBuXcBAjURQ9BQ48DnQ/p4hK4Jy76ulRnppDHpbDthxRziMWLZfmYXncwD63Aw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.12.0.tgz",
+      "integrity": "sha512-T3oy9/7QFejqJX2RGcCUU1944e5/eKbLlSz9JPTNN1QbYFJgat/r7eTyOO8SMSLUimUmQx6YBMKhgYbdKzp7Bw==",
       "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.0.0",
@@ -9762,22 +9743,22 @@
       },
       "dependencies": {
         "es6-promisify": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
-          "integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
+          "integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==",
           "dev": true
         }
       }
     },
     "masq-lib": {
-      "version": "git+https://github.com/QwantResearch/masq-lib.git#045b8e771e89c7527da25b24981770ee9e056a63",
-      "from": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.2",
+      "version": "git+https://github.com/QwantResearch/masq-lib.git#2e3020a676a3655ff407da55b84b0c3dfe48ac0a",
+      "from": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.3",
       "dev": true,
       "requires": {
-        "masq-common": "git+https://github.com/QwantResearch/masq-common.git#v0.10.1",
-        "signalhubws": "git+https://github.com/QwantResearch/signalhubws.git#masq",
+        "masq-common": "git+https://github.com/QwantResearch/masq-common.git#3ddb9522cc69055ef9dd1cdc350befad447e6bef",
+        "signalhubws": "1.0.12",
         "uuid": "^3.3.2",
-        "webrtc-swarm": "git+https://github.com/QwantResearch/webrtc-swarm.git#masq"
+        "webrtc-swarm": "git+https://github.com/QwantResearch/webrtc-swarm.git#321a6088f09d2272eeed8452bf2ff0c9558b9ebc"
       }
     },
     "md5.js": {
@@ -11811,6 +11792,12 @@
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz",
       "integrity": "sha1-BYLgHa4lMljPV2/Co125b8qEf28="
     },
+    "queue-microtask": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.2.tgz",
+      "integrity": "sha512-F9wwNePtXrzZenAB3ax0Y8TSKGvuB7Qw16J30hspEUTbfUM+H827XyN3rlpwhVmtm5wuZtbKIHjOnwDn7MUxWQ==",
+      "dev": true
+    },
     "quickselect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
@@ -12815,8 +12802,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "signalhubws": {
-      "version": "git+https://github.com/QwantResearch/signalhubws.git#e6d75b4964504856fed5e4112db878ed7bb3738f",
-      "from": "git+https://github.com/QwantResearch/signalhubws.git#masq",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/signalhubws/-/signalhubws-1.0.12.tgz",
+      "integrity": "sha512-XQMJkLMGec9CmRE5mnC6svvDix+Teqg9kpHv7VF0lehU9IYwVC5DriRJHVI2vTP6xY1tpHHYg/z6Lu+G4vciAg==",
       "dev": true,
       "requires": {
         "@clusterws/cws": "^0.15.2",
@@ -12862,16 +12850,29 @@
       }
     },
     "simple-peer": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.3.0.tgz",
-      "integrity": "sha512-5dLDfrRomrS2LuZUuH2aO7yTGtHFEl5Eb+8ZzqM0KC0lHcYUyJudUomP9ZY/lPUKBx2broL/Eee9bQ53yycEgQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.6.0.tgz",
+      "integrity": "sha512-NYqSKPu75xhkZYKGJhCbLCG5kfBtDHf8U9ddk4EKFfYNU7XgIisov+V8wMbVVgyMCfn8pm8uOqQQmE50FPDFWA==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1",
         "get-browser-rtc": "^1.0.0",
-        "inherits": "^2.0.1",
+        "queue-microtask": "^1.1.0",
         "randombytes": "^2.0.3",
-        "readable-stream": "^2.3.4"
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "sinon": {
@@ -13090,15 +13091,31 @@
       }
     },
     "sodium-native": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.2.tgz",
-      "integrity": "sha512-qwHcUnzFpRSGSm6F49j/h5SnxPFBgSNdDwZkAqjvuAoHQIVBFOXYb+oCUTJV80K5hRqSYCihpbX06vbrtPbilg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz",
+      "integrity": "sha512-Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "ini": "^1.3.5",
-        "nan": "^2.4.0",
-        "node-gyp-build": "^3.0.0"
+        "nan": "^2.14.0",
+        "node-gyp-build": "^4.1.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true,
+          "optional": true
+        },
+        "node-gyp-build": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.0.tgz",
+          "integrity": "sha512-4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "sodium-universal": {
@@ -13916,9 +13933,9 @@
       }
     },
     "thunky": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
-      "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
     "timers-browserify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5966,7 +5966,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5987,12 +5988,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6007,17 +6010,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6134,7 +6140,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6146,6 +6153,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6160,6 +6168,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6167,12 +6176,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6191,6 +6202,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6278,7 +6290,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6290,6 +6303,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6375,7 +6389,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6411,6 +6426,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6430,6 +6446,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6473,12 +6490,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9755,10 +9774,10 @@
       "from": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.3",
       "dev": true,
       "requires": {
-        "masq-common": "git+https://github.com/QwantResearch/masq-common.git#3ddb9522cc69055ef9dd1cdc350befad447e6bef",
+        "masq-common": "git+https://github.com/QwantResearch/masq-common.git#v0.10.1",
         "signalhubws": "1.0.12",
         "uuid": "^3.3.2",
-        "webrtc-swarm": "git+https://github.com/QwantResearch/webrtc-swarm.git#321a6088f09d2272eeed8452bf2ff0c9558b9ebc"
+        "webrtc-swarm": "git+https://github.com/QwantResearch/webrtc-swarm.git#masq"
       }
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "klokantech-noto-sans": "git+https://github.com/QwantResearch/fonts.git#f25a802",
     "mapbox-gl": "^1.4.1",
     "mapbox-gl-js-mock": "https://github.com/QwantResearch/mapbox-gl-js-mock.git#7eaee7b",
-    "masq-lib": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.2",
+    "masq-lib": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.3",
     "node-sass": "^4.9.2",
     "po2json": "0.4.5",
     "postcss-import": "12.0.0",


### PR DESCRIPTION
## Description
Update Masq-lib

## Why
Updates signalhubws dependency (which removes some useless dependencies such as websocket package)
