### PR TITLE
[Route] icon fixes and simplifications

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -44,8 +44,8 @@ export function getVehicleIcon(vehicle) {
 }
 
 export function getStepIcon(step) {
-  if (step.maneuver.type === 'depart') {
-    return 'depart';
+  if (step.maneuver.type === 'depart' || step.maneuver.type === 'arrive') {
+    return step.maneuver.type;
   }
   return (step.maneuver.modifier || step.maneuver.type).replace(/\s/g, '-');
 }

--- a/src/panel/direction/RoadMap.jsx
+++ b/src/panel/direction/RoadMap.jsx
@@ -5,9 +5,7 @@ import RoadMapStep from './RoadMapStep';
 const RoadMap = ({ steps = [], origin }) =>
   <div className="itinerary_roadmap">
     <div className="itinerary_roadmap_step">
-      <div className="itinerary_roadmap_icon itinerary_roadmap_icon_origin">
-        <div className="itinerary_icon_origin_inner" />
-      </div>
+      <div className="itinerary_roadmap_icon itinerary_roadmap_icon_origin" />
       <div className="itinerary_roadmap_instruction">{`${_('Start')} ${origin}`}</div>
       <div className="itinerary_roadmap_distance" />
     </div>

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -87,18 +87,18 @@
   height: 38px;
 }
 
-.itinerary_icon_origin {
-  font-size: 16px;
-  padding: 15px 11px;
-}
-
-.itinerary_icon_origin_inner {
+@mixin icon_origin {
   width: 16px;
   height: 16px;
   background: #4ba2ea;
   border: 2px solid #fff;
   border-radius: 50%;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.14);
+}
+
+.itinerary_icon_origin {
+  @include icon_origin;
+  margin: 15px 11px;
 }
 
 .itinerary_icon_destination {
@@ -311,13 +311,10 @@
 }
 
 .itinerary_marker_origin {
+  @include icon_origin;
+  cursor: pointer;
   width: 20px;
   height: 20px;
-  border-radius: 50%;
-  background: #4ba2ea;
-  border: 2px solid $background;
-  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.14);
-  cursor: pointer;
   z-index: 2;
 }
 
@@ -358,7 +355,13 @@
 }
 
 .itinerary_roadmap_icon_origin {
-  padding: 5px;
+  &:after {
+    @include icon_origin;
+    content: '';
+    display: block;
+    box-sizing: border-box;
+  }
+  padding: 4px;
 }
 
 .itinerary_roadmap_step {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -365,7 +365,7 @@
   display: flex;
   align-items: center;
   margin-top: 1px;
-  padding-left: 18px;
+  padding-left: 13px;
   border-left: 4px solid $secondary_text;
 }
 
@@ -377,11 +377,6 @@
 .itinerary_roadmap {
   .itinerary_roadmap_step:last-of-type .itinerary_roadmap_instruction {
     border-bottom: none;
-  }
-
-  .itinerary_roadmap_step:last-of-type .itinerary_roadmap_icon {
-    background-image: url(../images/direction_icons/pin.png);
-    background-size: contain;
   }
 }
 
@@ -442,6 +437,7 @@
 
 .itinerary_roadmap_icon_arrive {
   background-image: url('../images/direction_icons/pin.png');
+  background-size: contain;
 }
 
 .itinerary_roadmap_icon_slight-left {

--- a/src/views/direction/direction.dot
+++ b/src/views/direction/direction.dot
@@ -9,9 +9,7 @@
     <div class="itinerary_fields">
       <form onsubmit="fire('submit_direction_origin');return false" novalidate>
         <div class="itinerary_field_origin">
-          <div class="itinerary_icon itinerary_icon_origin">
-            <div class="itinerary_icon_origin_inner"></div>
-          </div>
+          <div class="itinerary_icon itinerary_icon_origin"></div>
           <input id="itinerary_input_origin" type="search" autocomplete="off" spellcheck="false" value="{{= this.origin ? this.origin.getInputValue() : '' }}" required placeholder="{{= _('Start point', 'direction') }}">
           <button class="icon-x itinerary__field__clear" type="button" {{= mousedown(this.clearOrigin, this) }}></button>
         </div>


### PR DESCRIPTION
## Description
- Fixes a minor alignment issue of the roadmap step icons with the transport type icon (see screenshot)
- Make the `arrive` icon be displayed only when an `arrive` step maneuver is detected (previously this was controlled by CSS only so for public transport where there is a sub-level of roadmap there were multiple arrivals icons appearing)
- Factorize the style of the `origin` icon using a Sass mixin and simplify the required DOM markup so it's not a special case with a child element.

## Why
Annoying stuff met when developing the public transport feature.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 86741_2 28920 destination=osm_node_3545028502@A2pas mode=driving](https://user-images.githubusercontent.com/243653/68305256-9f472600-00a7-11ea-8bb9-77cdae87465a.png)|![localhost_3000_routes__origin=latlon_48 86741_2 28920 destination=osm_node_3545028502@A2pas mode=publicTransport](https://user-images.githubusercontent.com/243653/68305265-a3734380-00a7-11ea-95b0-c24f631e0da8.png)


