### PR TITLE
Fix leak: correctly unmount React route result

### DIFF
--- a/src/panel/direction/direction_panel.js
+++ b/src/panel/direction/direction_panel.js
@@ -154,7 +154,6 @@ export default class DirectionPanel {
   }
 
   closeAction() {
-    this.roadMapPanel.close();
     if (this.poiBeforeOpening) {
       const { poi, isFromCategory, isFromFavorite } = this.poiBeforeOpening;
       this.poiBeforeOpening = null;
@@ -182,6 +181,7 @@ export default class DirectionPanel {
     if (!this.active) {
       return;
     }
+    this.roadMapPanel.close();
     Telemetry.add(Telemetry.ITINERARY_CLOSE);
     document.body.classList.remove('directions-open');
     const bottomButtonGroup = document.querySelector('.map_bottom_button_group');


### PR DESCRIPTION
## Description
Moves where we explicitely unmount the React route result block so it's done for any different way of leaving the panel.

## Why
Currently the route result block is only unmounted when clicking on the close button of the direction panel, it isn't if we leave the direction panel using the back browser button. This results in instances never being unmounted and therefore a memory leak.
![Capture d’écran de 2019-11-12 10-42-37](https://user-images.githubusercontent.com/243653/68660819-3134b000-053a-11ea-8678-21a89cdaabc9.png)