### PR TITLE
ESLint: enforce consistent quote style in JSX

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -96,7 +96,8 @@
         "eqeqeq": "error",
         "object-curly-spacing": ["error", "always"],
         "object-shorthand": "error",
-        "react/prop-types": 0
+        "react/prop-types": 0,
+        "jsx-quotes": ["error", "prefer-double"]
     },
     "overrides": [
         {

--- a/src/panel/ServicePanel.jsx
+++ b/src/panel/ServicePanel.jsx
@@ -11,7 +11,7 @@ class ServicePanel extends React.Component {
       resizable
       title={_('Qwant Maps services', 'service panel')}
       minimizedTitle={_('Show Qwant Maps services', 'service panel')}
-      className='service_panel'
+      className="service_panel"
     >
       <div className="service_panel__categories">
         {


### PR DESCRIPTION
## Description
Add an ESLint rule to enforce double quotes as the only quote style for string literal attributes in JSX.

## Why
Consistency, following discussions with @GuillaumeGomez.