### PR TITLE
Routes: path outlines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3938,6 +3938,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3950,6 +3959,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -12891,6 +12909,21 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        }
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@turf/bbox": "^6.0.1",
     "bunyan": "^1.8.12",
     "classnames": "^2.2.6",
+    "color": "^3.1.2",
     "compression": "^1.7.3",
     "ejs": "^2.6.1",
     "express": "^4.16.3",

--- a/src/adapters/route_styles.js
+++ b/src/adapters/route_styles.js
@@ -1,11 +1,35 @@
+import Color from 'color';
+
+const darkenColor = hex => Color(hex).mix(Color('black'), 0.2).hex();
+
 const INACTIVE_ROUTE_COLOR = '#c8cbd3';
 const ACTIVE_ROUTE_COLOR = '#4ba2ea';
 const DYNAMIC_COLOR_EXPRESSION = ['case', ['has', 'lineColor'],
   ['concat', '#', ['get', 'lineColor']],
   ACTIVE_ROUTE_COLOR,
 ];
+const INACTIVE_ROUTE_COLOR_OUTLINE = darkenColor(INACTIVE_ROUTE_COLOR);
+const ACTIVE_ROUTE_COLOR_OUTLINE = darkenColor(ACTIVE_ROUTE_COLOR);
 
-export function getRouteStyle(vehicle, isActive) {
+export function getOutlineFeature(feature) {
+  const properties = { ...feature.properties };
+  properties.lineColor = properties.lineColor
+    ? darkenColor('#' + properties.lineColor).substring(1)
+    : ACTIVE_ROUTE_COLOR_OUTLINE.substring(1);
+  return {
+    ...feature,
+    properties,
+  };
+}
+
+function getColorExpression(isActive, isOutline) {
+  if (isActive) {
+    return DYNAMIC_COLOR_EXPRESSION;
+  }
+  return isOutline ? INACTIVE_ROUTE_COLOR_OUTLINE : INACTIVE_ROUTE_COLOR;
+}
+
+export function getRouteStyle(vehicle, isActive, isOutline) {
   if (vehicle === 'walking') {
     return {
       type: 'symbol',
@@ -28,19 +52,18 @@ export function getRouteStyle(vehicle, isActive) {
       'visibility': 'visible',
     },
     paint: {
-      'line-color': isActive ? DYNAMIC_COLOR_EXPRESSION : INACTIVE_ROUTE_COLOR,
+      'line-color': getColorExpression(isActive, isOutline),
       'line-color-transition': { 'duration': 0 },
-      'line-width': 7,
+      'line-width': isOutline ? 7 : 5,
     },
   };
 }
 
-export function setActiveRouteStyle(map, layerId, vehicle, isActive) {
+export function setActiveRouteStyle(map, layerId, vehicle, isActive, isOutline) {
   if (vehicle === 'walking') {
     map.setLayoutProperty(layerId, 'icon-image',
       isActive ? 'walking_bullet_active' : 'walking_bullet_inactive');
   } else {
-    map.setPaintProperty(layerId, 'line-color',
-      isActive ? DYNAMIC_COLOR_EXPRESSION : INACTIVE_ROUTE_COLOR);
+    map.setPaintProperty(layerId, 'line-color', getColorExpression(isActive, isOutline));
   }
 }


### PR DESCRIPTION
## Description
Adds a darker outline effect to route paths so they stand out more visibly from the map background.

Unfortunately, Mapbox-GL hasn't been thought for that: there is no way of applying a border or shadow to line items with style only and there is now way to apply an arbitrary JS function to dynamic values extracted with style expressions.
To get around these limitations, I had to draw each line twice:
- a first one with a darker color (computed in advance using a dedicated library) and large width.
- a second one on top of the first with the normal color and a smaller width.

![Capture d’écran de 2019-11-14 11-16-18](https://user-images.githubusercontent.com/243653/68848204-36c3fe80-06d0-11ea-9c25-ebf830f18528.png)

This works and looks great but this involves some data duplication and doubles the drawing job for Mapbox-GL, which may impact performances. Maybe it's worth putting this feature behind a flag we can toggle conditionally…

**What do you think?**

## Why
Improve the legibility of route paths on the map, especially for public transport lines which can have low contrast colors and for grayed out alternatives.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2019-11-14 11-29-12](https://user-images.githubusercontent.com/243653/68849268-0c734080-06d2-11ea-8a6b-36576a5a7d76.png)|![Capture d’écran de 2019-11-14 11-28-46](https://user-images.githubusercontent.com/243653/68849274-109f5e00-06d2-11ea-8fbf-203c20d40855.png)|
|![Capture d’écran de 2019-11-14 11-21-47](https://user-images.githubusercontent.com/243653/68848862-53ad0180-06d1-11ea-86a7-26379b21831f.png)|![Capture d’écran de 2019-11-14 11-26-54](https://user-images.githubusercontent.com/243653/68849309-1b59f300-06d2-11ea-9772-a08ecb8a0cbd.png)|




