### PR TITLE
Routes: adjust visibility of path outlines

### DIFF
--- a/src/adapters/route_styles.js
+++ b/src/adapters/route_styles.js
@@ -1,6 +1,6 @@
 import Color from 'color';
 
-const darkenColor = hex => Color(hex).mix(Color('black'), 0.2).hex();
+const darkenColor = hex => Color(hex).mix(Color('black'), 0.33).hex();
 
 const INACTIVE_ROUTE_COLOR = '#c8cbd3';
 const ACTIVE_ROUTE_COLOR = '#4ba2ea';


### PR DESCRIPTION
## Description
Just tweak the color of path outlines, following https://github.com/QwantResearch/erdapfel/pull/455.
Darken it a bit so they are more visible, without being too present.

## Screenshots
|Before|After|
|---|---|
|![outline_7_02_a](https://user-images.githubusercontent.com/243653/69132621-b7aa3e00-0ab4-11ea-8b96-d4a44491b928.png)|![outline_7_033_a](https://user-images.githubusercontent.com/243653/69132634-bd078880-0ab4-11ea-9a61-3659bdfd4eab.png)|
|![outline_7_02_b](https://user-images.githubusercontent.com/243653/69132644-c1cc3c80-0ab4-11ea-9bca-823415360aa5.png)|![outline_7_033_b](https://user-images.githubusercontent.com/243653/69132657-c8f34a80-0ab4-11ea-8cd8-985bf6d7f602.png)|
