### PR TITLE
Fix poiTitleImage width and add margin-left

### DIFF
--- a/src/scss/includes/poiTitleImage.scss
+++ b/src/scss/includes/poiTitleImage.scss
@@ -2,6 +2,8 @@
   &--image {
     width: 100px;
     height: 100px;
+    flex-shrink: 0;
+    margin-left: 10px;
     background-size: cover;
     background-position: center center;
     background-color: white;


### PR DESCRIPTION
## Description
Fix title image width in poi panel.

## Screenshots
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/69263806-56728f80-0bc6-11ea-9581-ca2ac20cfb9b.png) |![image](https://user-images.githubusercontent.com/4726554/69263780-48247380-0bc6-11ea-868c-560265bdcb27.png)|

