### PR TITLE
Fix: Restore broken Masq favorite option

### DIFF
--- a/src/panel/PoiPanel.jsx
+++ b/src/panel/PoiPanel.jsx
@@ -213,6 +213,7 @@ export default class PoiPanel extends React.Component {
               isDirectionActive={this.isDirectionActive}
               openDirection={this.openDirection}
               openShare={this.openShare}
+              isMasqEnabled={this.isMasqEnabled}
             />
             {poi.id.match(/latlon:/) && this.categories &&
               <div className="service_panel__categories--poi">

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -21,6 +21,7 @@ export default class ActionButtons extends React.Component {
   static propTypes = {
     poi: PropTypes.object.isRequired,
     isDirectionActive: PropTypes.bool,
+    isMasqEnabled: PropTypes.bool,
     isFromCategory: PropTypes.bool,
     isFromFavorite: PropTypes.bool,
     openDirection: PropTypes.func,
@@ -95,7 +96,7 @@ export default class ActionButtons extends React.Component {
     if (this.state.poiIsInFavorite) {
       store.del(this.props.poi);
     } else {
-      if (this.isMasqEnabled) {
+      if (this.props.isMasqEnabled) {
         const isLoggedIn = await store.isLoggedIn();
         if (!isLoggedIn) {
           const masqFavoriteModal = new MasqFavoriteModal();


### PR DESCRIPTION
## Description
Fix the option to use Masq when storing a POI as favorite, which got broken in
https://github.com/QwantResearch/erdapfel/pull/461
The flag indicating that Masq was enabled in the config was never initialized with a value in the `<ActionButtons>` component, so was always considered false.