### PR TITLE
Check mapStyle environment variables at server start

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -3,7 +3,9 @@
 const configBuilt = require('@qwant/nconf-builder');
 const App = require('./app');
 const config = configBuilt.get();
-const PORT = config.PORT;
 
-const appServer = new App(config);
-appServer.start(PORT);
+if (config) {
+  const PORT = config.PORT;
+  const appServer = new App(config);
+  appServer.start(PORT);
+}

--- a/local_modules/nconf_builder/index.js
+++ b/local_modules/nconf_builder/index.js
@@ -7,13 +7,13 @@ const PREFIX = 'TILEVIEW_'
 nconf
   .env({
     transform : (configObject) => {
-      if(configObject.value === 'false') {
+      if (configObject.value === 'false') {
         configObject.value = false
       }
-      if(configObject.value === 'true') {
+      if (configObject.value === 'true') {
         configObject.value = true
       }
-      if(configObject.key.indexOf(PREFIX) === 0) {
+      if (configObject.key.indexOf(PREFIX) === 0) {
         configObject.key = configObject.key.replace(PREFIX, '')
         return configObject
       }
@@ -22,6 +22,39 @@ nconf
   })
   .file({file : path.resolve(`${__dirname}/../../config/default_config.yml`), format : nconfYml})
 
+function check_is_json_var(toCheck, name) {
+  try {
+    JSON.parse(toCheck);
+  } catch (error) {
+    console.error(`Error: \`${name}\` environment variable should be valid JSON!`);
+    console.error(`JSON error: "${error.message}"`);
+    return 1;
+  }
+  return 0;
+}
+
+class ConfigChecker {
+  constructor(conf) {
+    this.conf = conf;
+  }
+
+  check(confToCheck) {
+    let errors = 0;
+
+    errors += check_is_json_var(confToCheck.mapStyle.poiMapUrl, 'TILEVIEW_mapStyle_poiMapUrl');
+    errors += check_is_json_var(confToCheck.mapStyle.baseMapUrl, 'TILEVIEW_mapStyle_baseMapUrl');
+    return errors;
+  }
+
+  get() {
+    const confToCheck = this.conf.get();
+    if (this.check(confToCheck) !== 0) {
+      return null;
+    }
+    return confToCheck;
+  }
+}
+
 module.exports = (function() {
-  return nconf
+  return new ConfigChecker(nconf);
 })()

--- a/local_modules/nconf_builder/index.js
+++ b/local_modules/nconf_builder/index.js
@@ -47,11 +47,15 @@ class ConfigChecker {
   }
 
   get() {
-    const confToCheck = this.conf.get();
+    const confToCheck = this.get_without_check();
     if (this.check(confToCheck) !== 0) {
       return null;
     }
     return confToCheck;
+  }
+
+  get_without_check() {
+    return this.conf.get();
   }
 }
 

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -29,7 +29,7 @@ nock(/idunn_test\.test/)
   .get(/osm:way:2403/)
   .reply(404);
 
-const config = configBuilder.get();
+const config = configBuilder.get_without_check();
 
 // Specific config values for tests
 config.mapStyle.baseMapUrl = '[]';

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -3,7 +3,7 @@ import { storePoi } from '../favorites_tools';
 import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
 const configBuilder = require('@qwant/nconf-builder');
-const config = configBuilder.get();
+const config = configBuilder.get_without_check();
 
 const SUGGEST_MAX_ITEMS = config.services.geocoder.maxItems;
 

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -5,7 +5,7 @@ module.exports = {
   verbose: true,
   collectCoverage: false,
   globals: {
-    __config: require('@qwant/nconf-builder').get(),
+    __config: require('@qwant/nconf-builder').get_without_check(),
   },
   transform: {
     '\\.yml$': 'yaml-jest',


### PR DESCRIPTION
The goal of this PR is to make errors easier to understand. Currently, you only discover that those two variables are badly set only when the server has started when getting a JS error on the web page.

I also had to add the `get_without_check` method for the tests because they add those two variables' value \*after\* getting the object.