### PR TITLE
Fix route destination marker anchor

### DIFF
--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -128,6 +128,7 @@ export default class SceneDirection {
       this.markerDestination = new Marker({
         element: markerDestination,
         draggable: true,
+        anchor: 'bottom',
       })
         .setLngLat(lastStepCoords[lastStepCoords.length - 1])
         .addTo(this.map)

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -323,7 +323,6 @@
   background-size: cover;
   width: 30px;
   height: 37px;
-  margin: -10px 0 0 4px;
   cursor: pointer;
   z-index: 2;
 }


### PR DESCRIPTION
## Description
Fix the anchor of the route destination marker so it points precisely to the end point of the itinerary. The CSS class is used only by this element so it's safe to remove the strange margin rule.

## Why
The marker appears not correctly aligned nor anchored to the right point.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2019-11-28 17-19-41](https://user-images.githubusercontent.com/243653/69821227-547e8100-1203-11ea-82be-831fab0ae1d2.png)|![Capture d’écran de 2019-11-28 17-19-13](https://user-images.githubusercontent.com/243653/69821273-7bd54e00-1203-11ea-9b11-b6df00e3c7cf.png)|
