### PR TITLE
Don't update route style uselessly

### DIFF
--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -42,11 +42,17 @@ export default class RouteResult extends React.Component {
   }
 
   selectRoute = routeId => {
+    if (routeId === this.state.activeRouteId) {
+      return;
+    }
     fire('toggle_route', routeId);
     this.setState({ activeRouteId: routeId });
   }
 
   hoverRoute = (routeId, highlightMapRoute) => {
+    if (routeId === this.state.activeRouteId) {
+      return;
+    }
     fire('toggle_route', highlightMapRoute ? routeId : this.state.activeRouteId);
   }
 


### PR DESCRIPTION
## Description
Don't fire events which may result in useless route style updates when interacting with the Roadmap items.

## Why
Avoid costly operations which may have impact on the UX responsiveness.