### PR TITLE
Fix size of the mobile route destination icon

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -737,7 +737,7 @@
     grid-area: icon;
     width: 48px;
     height: 48px;
-    background-size: 100%;
+    background-size: contain;
     margin: 0;
   }
   


### PR DESCRIPTION
## Description
Fix CSS rule for size of the route roadmap destination icon on mobile.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 80338_2 36314 destination=latlon_48 80626_2 35882 mode=walking(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/69881783-5a8d6400-12ce-11ea-90fe-8d97756ece2b.png)|![localhost_3000_routes__origin=latlon_48 80338_2 36314 destination=latlon_48 80626_2 35882 mode=walking(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/69881788-5feaae80-12ce-11ea-92d4-5e9b39f6e481.png)|


