### PR TITLE
Routes: Migrate the vehicle selector to React

### DIFF
--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DirectionInput from './DirectionInput';
+import VehicleSelector from './VehicleSelector';
 import Device from 'src/libs/device';
 
 export default class DirectionForm extends React.Component {
@@ -10,6 +11,9 @@ export default class DirectionForm extends React.Component {
     destination: PropTypes.object,
     onChangeDirectionPoint: PropTypes.func.isRequired,
     onReversePoints: PropTypes.func.isRequired,
+    vehicles: PropTypes.array.isRequired,
+    onSelectVehicle: PropTypes.func.isRequired,
+    activeVehicle: PropTypes.string.isRequired,
   }
 
   state = {
@@ -44,30 +48,37 @@ export default class DirectionForm extends React.Component {
 
   render() {
     const { originInputText, destinationInputText } = this.state;
-    const { origin, destination } = this.props;
+    const { origin, destination, vehicles, activeVehicle, onSelectVehicle } = this.props;
     const isMobile = Device.isMobile();
 
-    return <div className="itinerary_fields">
-      <form noValidate>
-        <DirectionInput
-          value={originInputText}
-          pointType="origin"
-          onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
-          claimFocus={!isMobile && !originInputText && !destination}
-        />
-        <div className="itinerary__form__separator" />
-        <DirectionInput
-          value={destinationInputText}
-          pointType="destination"
-          onChangePoint={(input, point) => this.onChangePoint('destination', input, point)}
-          claimFocus={!isMobile && origin && !destinationInputText}
-        />
-        <div
-          className="itinerary_invert_origin_destination icon-reverse"
-          onClick={this.onReverse}
-          title={_('Invert start and end', 'direction')}
-        />
-      </form>
+    return <div>
+      <div className="itinerary_fields">
+        <form noValidate>
+          <DirectionInput
+            value={originInputText}
+            pointType="origin"
+            onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
+            claimFocus={!isMobile && !originInputText && !destination}
+          />
+          <div className="itinerary__form__separator" />
+          <DirectionInput
+            value={destinationInputText}
+            pointType="destination"
+            onChangePoint={(input, point) => this.onChangePoint('destination', input, point)}
+            claimFocus={!isMobile && origin && !destinationInputText}
+          />
+          <div
+            className="itinerary_invert_origin_destination icon-reverse"
+            onClick={this.onReverse}
+            title={_('Invert start and end', 'direction')}
+          />
+        </form>
+      </div>
+      <VehicleSelector
+        vehicles={vehicles}
+        activeVehicle={activeVehicle}
+        onSelectVehicle={onSelectVehicle}
+      />
     </div>;
   }
 }

--- a/src/panel/direction/VehicleSelector.jsx
+++ b/src/panel/direction/VehicleSelector.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import classnames from 'classnames';
+import { getVehicleIcon } from 'src/libs/route_utils';
+
+const VehicleSelector = ({ vehicles, activeVehicle, onSelectVehicle }) =>
+  <div className="itinerary_vehicles">
+    {vehicles.map(vehicle => <span
+      key={vehicle}
+      className={classnames(`itinerary_button_label ${getVehicleIcon(vehicle)}`,
+        { 'label_active': vehicle === activeVehicle }
+      )}
+      onClick={() => onSelectVehicle(vehicle)}
+    />)}
+  </div>;
+
+export default VehicleSelector;

--- a/src/views/direction/direction.dot
+++ b/src/views/direction/direction.dot
@@ -9,13 +9,5 @@
     <div id="react_itinerary_fields"></div>
   </div>
 
-  <div class="itinerary_vehicles">
-    <span class="itinerary_button_label itinerary_button_label_driving icon-drive{{= this.vehicle === this.vehicles.DRIVING ? ' label_active' : '' }}" {{= click(this.setVehicle, this, this.vehicles.DRIVING) }}></span>
-    {{? this.isPublicTransportEnabled }}
-      <span class="itinerary_button_label itinerary_button_label_publicTransport icon-public-transport{{? this.vehicle === this.vehicles.PUBLIC_TRANSPORT }} label_active {{?}}" {{= click(this.setVehicle, this, this.vehicles.PUBLIC_TRANSPORT) }}></span>
-    {{?}}
-    <span class="itinerary_button_label itinerary_button_label_walking icon-foot{{= this.vehicle === this.vehicles.WALKING ? ' label_active' : '' }}" {{= click(this.setVehicle, this, this.vehicles.WALKING) }}></span>
-    <span class="itinerary_button_label itinerary_button_label_cycling icon-bike{{= this.vehicle === this.vehicles.CYCLING ? ' label_active' : '' }}" {{= click(this.setVehicle, this, this.vehicles.CYCLING) }}></span>
-  </div>
   <div id="react_itinerary_result" class="itinerary_result"></div>
 </div>

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -137,7 +137,7 @@ test('origin & destination & mode', async () => {
   const activeLabel = await page.evaluate(() => {
     return Array.from(document.querySelector('.label_active').classList).join(',');
   });
-  expect(activeLabel).toContain('itinerary_button_label_walking');
+  expect(activeLabel).toContain('icon-foot');
 });
 
 // There is no current way with the MapBox-GL-mock to test changes of state or style


### PR DESCRIPTION
## Description
Follow-up to https://github.com/QwantResearch/erdapfel/pull/464
Migrate the vehicle mode selector to React and make it a child of `<DirectionForm>`, which already includes the text inputs for points.
Like for points, the state (`activeVehicle`) is managed upstream so the `<VehicleSelector>` component itself is stateless.
Conceptually it's a radio button group so it would be nice to change the markup to that, but let's keep it for after the migration.

## Screenshots
![localhost_3000_routes__origin=latlon_48 85631_2 38993 destination=latlon_48 86741_2 28920 mode=driving(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/69949750-69546080-14f2-11ea-9c69-822af2d34c98.png)
(No visual changes)