### PR TITLE
Add GitHub action to track Webpack bundle sizes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,13 @@
+on: push
+name: packtracker.io
+jobs:
+  report:
+    name: report webpack stats
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: report webpack stats
+      uses: packtracker/report@2.2.7
+      env:
+        PT_PROJECT_TOKEN: ${{ secrets.packtracker_token }}
+        WEBPACK_CONFIG_PATH: ./config/webpack/production.js


### PR DESCRIPTION
## Description
In an effort to track the evolution of our app size over time, I'd like to experiment with https://app.packtracker.io.
Among other features, this should be able to display a delta of the bundle sizes for each PR, making it easy to detect features which have a bad impact on the app size.

This requires to configure a GitHub action to hook the repo to Packtracker.
As Erdapfel is open-source, Packtracker and GitHub actions are free services.

## Screenshots
When correctly configured, we should see this kind of message on PR
![assets_-LKja-OcY-MeZc8Fvr6T_-LP7HIMx5jpbhKms--BZ_-LP7HSW-xU9_TGoh8gxK_github-status](https://user-images.githubusercontent.com/243653/70318259-f0217a00-181f-11ea-9aec-91b047ca459f.png)
