### PR TITLE
Public transports: roadmap UI improvements

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -90,3 +90,7 @@ export const originDestinationCoords = route => {
     destination: last(last(fc.features).geometry.coordinates),
   };
 };
+
+export function sanitizeStationName(name) {
+  return (name || '').replace(/\s*\(.*\)$/, '');
+}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -211,6 +211,7 @@ export default class DirectionPanel extends React.Component {
       error={error}
       routes={routes}
       origin={origin && origin.getInputValue()}
+      destination={destination && destination.getInputValue()}
       openMobilePreview={this.openMobilePreview}
       previewRoute={activePreviewRoute}
     />;

--- a/src/panel/direction/LegLine.jsx
+++ b/src/panel/direction/LegLine.jsx
@@ -6,7 +6,7 @@ const LegLine = ({ mode, info }) => {
   }
   return <div
     className="itinerary_roadmap_line itinerary_roadmap_line--transportLine"
-    style={{ backgroundColor: '#' + info.lineColor }}
+    style={{ backgroundColor: info.lineColor ? `#${info.lineColor}` : 'black' }}
   />;
 };
 

--- a/src/panel/direction/LegLine.jsx
+++ b/src/panel/direction/LegLine.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const LegLine = ({ mode, info }) => {
+  if (mode === 'WALK') {
+    return <div className="itinerary_roadmap_line itinerary_roadmap_line--walk" />;
+  }
+  return <div
+    className="itinerary_roadmap_line itinerary_roadmap_line--transportLine"
+    style={{ backgroundColor: '#' + info.lineColor }}
+  />;
+};
+
+export default LegLine;

--- a/src/panel/direction/PublicTransportLine.jsx
+++ b/src/panel/direction/PublicTransportLine.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Color from 'color';
+import classnames from 'classnames';
 
 const PublicTransportLine = ({ mode, info }) => {
   // @TODO: translate
@@ -15,7 +17,16 @@ const PublicTransportLine = ({ mode, info }) => {
   } else if (mode.indexOf('TRAIN') !== -1) {
     type = `train ${info.network}`;
   }
-  return <span className="routePtLine">{type} {info.num}</span>;
+  const lineColor = info.lineColor ? Color('#' + info.lineColor) : Color('white');
+  return <span
+    className={classnames('routePtLine', { 'routePtLine--dark': lineColor.isDark() })}
+    style={{
+      backgroundColor: lineColor.hex(),
+      borderColor: lineColor.rgbNumber() === 0xffffff ? 'black' : lineColor.hex(),
+    }}
+  >
+    {type} {info.num}
+  </span>;
 };
 
 export default PublicTransportLine;

--- a/src/panel/direction/PublicTransportRoadMap.jsx
+++ b/src/panel/direction/PublicTransportRoadMap.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import WalkLeg from './WalkLeg';
 import TransportLineLeg from './TransportLineLeg';
 import RoadMapItem from './RoadMapItem';
+import LegLine from './LegLine';
 
 const Leg = ({ leg }) => {
   // @TODO: decide what to do with waiting parts. For now just ignore.
@@ -16,8 +17,8 @@ const Leg = ({ leg }) => {
 };
 
 const PublicTransportRoadMap = ({ route, origin, destination }) => {
-  return <div className="itinerary_roadmap">
-    <RoadMapItem icon="origin">
+  return <div className="itinerary_roadmap itinerary_roadmap--publicTransport">
+    <RoadMapItem icon="origin" line={<LegLine mode="WALK" />}>
       {`${_('Start')} ${origin}`}
     </RoadMapItem>
     {route.legs.map((leg, index) => <Leg key={index} leg={leg} />)}

--- a/src/panel/direction/RoadMapItem.jsx
+++ b/src/panel/direction/RoadMapItem.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const RoadMapItem = ({ children, icon, distance, ...rest }) =>
-  <div className="itinerary_roadmap_item" {...rest}>
+const RoadMapItem = ({ children, icon, distance, className, ...rest }) =>
+  <div className={classnames('itinerary_roadmap_item', className)} {...rest}>
     <div className={classnames('itinerary_roadmap_icon', {
       [`itinerary_roadmap_icon_${icon}`]: icon,
     })} />

--- a/src/panel/direction/RoadMapItem.jsx
+++ b/src/panel/direction/RoadMapItem.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const RoadMapItem = ({ children, icon, distance, className, ...rest }) =>
+const RoadMapItem = ({ children, icon, distance, className, line, ...rest }) =>
   <div className={classnames('itinerary_roadmap_item', className)} {...rest}>
+    {line}
     <div className={classnames('itinerary_roadmap_icon', {
       [`itinerary_roadmap_icon_${icon}`]: icon,
     })} />

--- a/src/panel/direction/RouteVia.jsx
+++ b/src/panel/direction/RouteVia.jsx
@@ -12,6 +12,7 @@ const RouteVia = ({ route, vehicle }) => {
   return <div className="routeVia">
     {route.summary
       .filter(summaryPart => summaryPart.mode !== 'WAIT')
+      .filter(summaryPart => summaryPart.mode !== 'WALK' || summaryPart.distance > 100)
       .map((summaryPart, idx) =>
         <span key={idx} className="routeVia-step">
           {summaryPart.mode === 'WALK'

--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -16,7 +16,7 @@ const TransportLineLeg = ({ leg }) => {
     line={<LegLine info={info} mode={mode} />}
   >
     <div
-      className="itinerary_roadmap_item_summary"
+      className="itinerary_roadmap_item_summary itinerary_roadmap_item_summary--openable"
       onClick={() => setDetailsOpen(!detailsOpen)}
     >
       <div>

--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import RoadMapItem from './RoadMapItem';
 import PublicTransportLine from './PublicTransportLine';
+import LegLine from './LegLine';
 import { getTransportTypeIcon, sanitizeStationName } from 'src/libs/route_utils';
 
 const TransportLineLeg = ({ leg }) => {
@@ -12,6 +13,7 @@ const TransportLineLeg = ({ leg }) => {
   return <RoadMapItem
     icon={getTransportTypeIcon(leg)}
     className="itinerary_roadmap_item--transportLine"
+    line={<LegLine info={info} mode={mode} />}
   >
     <div
       className="itinerary_roadmap_item_summary"

--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -1,7 +1,7 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState } from 'react';
 import RoadMapItem from './RoadMapItem';
 import PublicTransportLine from './PublicTransportLine';
-import { getTransportTypeIcon } from 'src/libs/route_utils';
+import { getTransportTypeIcon, sanitizeStationName } from 'src/libs/route_utils';
 
 const TransportLineLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
@@ -9,26 +9,30 @@ const TransportLineLeg = ({ leg }) => {
   const from = stops[0];
   const to = stops[stops.length - 1];
 
-  return <Fragment>
-    <RoadMapItem icon={getTransportTypeIcon(leg)}>
-      <div
-        className="itinerary_roadmap_item_summary"
-        onClick={() => setDetailsOpen(!detailsOpen)}
-      >
-        <div>
-          <PublicTransportLine mode={mode} info={info} />
-          {from.name && to.name && <div className="itinerary_roadmap_fromTo">
-            {`${from.name} => ${to.name}`}
-          </div>}
-        </div>
-        <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />
+  return <RoadMapItem
+    icon={getTransportTypeIcon(leg)}
+    className="itinerary_roadmap_item--transportLine"
+  >
+    <div
+      className="itinerary_roadmap_item_summary"
+      onClick={() => setDetailsOpen(!detailsOpen)}
+    >
+      <div>
+        <PublicTransportLine mode={mode} info={info} />
+        {!detailsOpen && from.name && to.name && <div>
+          {sanitizeStationName(from.name)}{' '}
+          <i className="icon-chevrons-right" />{' '}
+          {sanitizeStationName(to.name)}
+        </div>}
       </div>
-    </RoadMapItem>
-    {detailsOpen && stops.map((stop, index) =>
-      <RoadMapItem key={index} icon="stop">
-        {stop.name}
-      </RoadMapItem>)}
-  </Fragment>;
+      <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />
+    </div>
+    {detailsOpen && <div className="itinerary_roadmap_substeps">
+      {stops.map((stop, index) => <div key={index}>
+        {sanitizeStationName(stop.name)}
+      </div>)}
+    </div>}
+  </RoadMapItem>;
 };
 
 export default TransportLineLeg;

--- a/src/panel/direction/WalkLeg.jsx
+++ b/src/panel/direction/WalkLeg.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { formatDistance } from 'src/libs/route_utils';
 import RoadMapItem from './RoadMapItem';
+import LegLine from './LegLine';
 
 const WalkLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
@@ -8,7 +9,11 @@ const WalkLeg = ({ leg }) => {
   const summary = `Walk on ${formatDistance(leg.distance)}`;
   const hasSteps = leg.steps.length > 1;
 
-  return <RoadMapItem icon="walk" className="itinerary_roadmap_item--walk">
+  return <RoadMapItem
+    icon="walk"
+    className="itinerary_roadmap_item--walk"
+    line={<LegLine mode="WALK" />}
+  >
     <div
       className="itinerary_roadmap_item_summary"
       onClick={() => { if (hasSteps) { setDetailsOpen(!detailsOpen); } } }

--- a/src/panel/direction/WalkLeg.jsx
+++ b/src/panel/direction/WalkLeg.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { formatDistance } from 'src/libs/route_utils';
 import RoadMapItem from './RoadMapItem';
 import LegLine from './LegLine';
+import classnames from 'classnames';
 
 const WalkLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
@@ -15,7 +16,9 @@ const WalkLeg = ({ leg }) => {
     line={<LegLine mode="WALK" />}
   >
     <div
-      className="itinerary_roadmap_item_summary"
+      className={classnames('itinerary_roadmap_item_summary', {
+        'itinerary_roadmap_item_summary--openable': hasSteps,
+      })}
       onClick={() => { if (hasSteps) { setDetailsOpen(!detailsOpen); } } }
     >
       <div>{summary}</div>

--- a/src/panel/direction/WalkLeg.jsx
+++ b/src/panel/direction/WalkLeg.jsx
@@ -1,25 +1,27 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState } from 'react';
 import { formatDistance } from 'src/libs/route_utils';
-import RoadMapStep from './RoadMapStep';
 import RoadMapItem from './RoadMapItem';
 
 const WalkLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
   // @TODO: build and translate a complete summary
   const summary = `Walk on ${formatDistance(leg.distance)}`;
+  const hasSteps = leg.steps.length > 1;
 
-  return <Fragment>
-    <RoadMapItem icon="walk">
-      <div
-        className="itinerary_roadmap_item_summary"
-        onClick={() => setDetailsOpen(!detailsOpen)}
-      >
-        <div>{summary}</div>
-        <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />
-      </div>
-    </RoadMapItem>
-    {detailsOpen && leg.steps.map((step, index) => <RoadMapStep key={index} step={step} />)}
-  </Fragment>;
+  return <RoadMapItem icon="walk" className="itinerary_roadmap_item--walk">
+    <div
+      className="itinerary_roadmap_item_summary"
+      onClick={() => { if (hasSteps) { setDetailsOpen(!detailsOpen); } } }
+    >
+      <div>{summary}</div>
+      {hasSteps && <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />}
+    </div>
+    {detailsOpen && <div className="itinerary_roadmap_substeps">
+      {leg.steps.map((step, index) => <div key={index}>
+        {step.maneuver.instruction}
+      </div>)}
+    </div>}
+  </RoadMapItem>;
 };
 
 export default WalkLeg;

--- a/src/panel/direction/WalkLeg.jsx
+++ b/src/panel/direction/WalkLeg.jsx
@@ -1,3 +1,4 @@
+/* global _ */
 import React, { useState } from 'react';
 import { formatDistance } from 'src/libs/route_utils';
 import RoadMapItem from './RoadMapItem';
@@ -6,8 +7,9 @@ import classnames from 'classnames';
 
 const WalkLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
-  // @TODO: build and translate a complete summary
-  const summary = `Walk on ${formatDistance(leg.distance)}`;
+  const summary = _('Walk on {walkDistance}', 'direction', {
+    walkDistance: formatDistance(leg.distance),
+  });
   const hasSteps = leg.steps.length > 1;
 
   return <RoadMapItem

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -317,9 +317,9 @@ input:valid:focus + .itinerary__field__clear {
   height: 24px;
   background-position: center center;
   background-repeat: no-repeat;
-  vertical-align: top;
-  margin: 0 24px 0 12px;
+  margin: 12px 24px 0 12px;
   flex-shrink: 0;
+  align-self: flex-start;
 }
 
 .itinerary_roadmap_icon_origin {
@@ -357,12 +357,30 @@ input:valid:focus + .itinerary__field__clear {
   column-gap: 12px;
 }
 
+.itinerary_roadmap_substeps {
+  >div {
+    position: relative;
+
+    &:before {
+      content: '';
+      border: 1px $primary_text solid;
+      border-radius: 50%;
+      width: 8px;
+      height: 8px;
+      position: absolute;
+      top: 6px;
+      left: -41px;
+    }
+  }
+}
+
 .itinerary_roadmap_instruction {
   font-size: 14px;
   color: $primary_text;
   padding: 14px 0;
   border-bottom: 1px solid #e0e1e6;
   flex-grow: 1;
+  line-height: 1.5em;
 }
 
 .itinerary_roadmap_instruction_light {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -338,6 +338,7 @@ input:valid:focus + .itinerary__field__clear {
   margin-top: 1px;
   padding-left: 13px;
   border-left: 4px solid $secondary_text;
+  position: relative;
 }
 
 .itinerary_roadmap_item:hover {
@@ -348,6 +349,10 @@ input:valid:focus + .itinerary__field__clear {
   .itinerary_roadmap_item:last-of-type .itinerary_roadmap_instruction {
     border-bottom: none;
   }
+
+  &--publicTransport .itinerary_roadmap_item {
+    border-left: 4px solid transparent;
+  }
 }
 
 .itinerary_roadmap_item_summary {
@@ -357,20 +362,19 @@ input:valid:focus + .itinerary__field__clear {
   column-gap: 12px;
 }
 
-.itinerary_roadmap_substeps {
-  >div {
-    position: relative;
+.itinerary_roadmap_item--transportLine .itinerary_roadmap_substeps > div {
+  position: relative;
 
-    &:before {
-      content: '';
-      border: 1px $primary_text solid;
-      border-radius: 50%;
-      width: 8px;
-      height: 8px;
-      position: absolute;
-      top: 6px;
-      left: -41px;
-    }
+  &:before {
+    background: white;
+    content: '';
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
+    border-radius: 50%;
+    width: 5px;
+    height: 5px;
+    position: absolute;
+    top: 6px;
+    left: -38px;
   }
 }
 
@@ -383,8 +387,18 @@ input:valid:focus + .itinerary__field__clear {
   line-height: 1.5em;
 }
 
-.itinerary_roadmap_instruction_light {
-  color: $secondary_text;
+.itinerary_roadmap_line {
+  position: absolute;
+  width: 7px;
+  left: 34px;
+  height: calc(100% - 28px);
+  top: 38px;
+  border-radius: 3px;
+
+  &--walk {
+    background: url(../images/direction_icons/walking_bullet_active.png) repeat space;
+    background-size: 7px;
+  }
 }
 
 .itinerary_roadmap_distance {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -189,7 +189,6 @@ input:valid:focus + .itinerary__field__clear {
 
 .itinerary_leg {
   position: relative;
-  cursor: pointer;
   background: $background;
 
   &:not(:last-child):after {
@@ -211,6 +210,7 @@ input:valid:focus + .itinerary__field__clear {
   display: flex;
   padding: 20px;
   align-items: center;
+  cursor: pointer;
 }
 
 .itinerary_leg_icon {
@@ -339,6 +339,7 @@ input:valid:focus + .itinerary__field__clear {
   padding-left: 13px;
   border-left: 4px solid $secondary_text;
   position: relative;
+  cursor: pointer;
 }
 
 .itinerary_roadmap_item:hover {
@@ -352,6 +353,7 @@ input:valid:focus + .itinerary__field__clear {
 
   &--publicTransport .itinerary_roadmap_item {
     border-left: 4px solid transparent;
+    cursor: default;
   }
 }
 
@@ -360,6 +362,10 @@ input:valid:focus + .itinerary__field__clear {
   justify-content: space-between;
   align-items: center;
   column-gap: 12px;
+
+  &--openable {
+    cursor: pointer;
+  }
 }
 
 .itinerary_roadmap_item--transportLine .itinerary_roadmap_substeps > div {

--- a/src/scss/includes/routes.scss
+++ b/src/scss/includes/routes.scss
@@ -1,7 +1,7 @@
 .routePtLine {
   padding: 3px 4px 2px;
   margin: 0 2px;
-  border: 1px solid black;
+  border: 1px solid transparent;
   border-radius: 3px;
   font-weight: bold;
   font-size: 10px;
@@ -10,6 +10,10 @@
   vertical-align: text-bottom;
   white-space: nowrap;
   display: inline-block;
+
+  &--dark {
+    color: white;
+  }
 }
 
 .routeVia {


### PR DESCRIPTION
## Description
As seen with PO & design teams, until we can have dedicated designs to work with, let's try by ourselves to improve the readability of the public transports roadmap. Some stuff this PR does:
- use available line colors for transport line labels
- display substeps with less visual importance
- sanitize station names, so they don't always include the city name (maybe it can be done server-side but it's quicker to do it here for a prototype)
- display a symbolic line of the itinerary with stations as steps, with the same icons as the map. 
- remove the gray/red border to avoid clutter
- filter out the smallest walk parts to avoid useless info for changes at stations
- fix the missing destination address

Notes:
 - The other routing modes are not concerned by these changes
 - Roadmap steps for public transports are still not clickable 
 - Some other things could be improved, like use of typographic hierarchy, reorganization of information, removal or change of barely used feature like sharing, etc. But we can improve on this first version.

## Why
Improve usability of the public transport feature results.
The current version suffers from a lack of information hierarchy, too much lost space, information noise, etc.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 82519_2 35688 destination=latlon_48 84842_2 40261 mode=publicTransport (1)](https://user-images.githubusercontent.com/243653/70533311-23824280-1b59-11ea-9cd8-81c7aded345c.png)|![localhost_3000_routes__origin=latlon_48 82519_2 35688 destination=latlon_48 84842_2 40261 mode=publicTransport](https://user-images.githubusercontent.com/243653/70533327-29782380-1b59-11ea-916a-29671d03aeba.png)|

