### PR TITLE
QMAPS-1156 show address before GPS coordinates, if available

### DIFF
--- a/src/panel/poi/PoiHeader.jsx
+++ b/src/panel/poi/PoiHeader.jsx
@@ -1,3 +1,4 @@
+/* global _ */
 import React from 'react';
 import ReviewScore from 'src/components/ReviewScore';
 import poiSubClass from 'src/mapbox/poi_subclass';
@@ -9,7 +10,9 @@ const PoiHeader = ({ poi }) => {
 
   return <div>
     {subClassName === 'latlon' && <div>
-      <div className="poi_panel__pre_title">{_('Close to', 'poi')}</div>
+      {address && address.label &&
+        <div className="poi_panel__pre_title">{ _('Close to', 'poi')}</div>
+      }
       <h4 className="poi_panel__title">
         <span className="poi_panel__title__main">
           {address && address.label ? address.label : title}

--- a/src/panel/poi/PoiHeader.jsx
+++ b/src/panel/poi/PoiHeader.jsx
@@ -18,7 +18,9 @@ const PoiHeader = ({ poi }) => {
           {address && address.label ? address.label : title}
         </span>
       </h4>
-      {<p className="poi_panel__address">{address && address.label ? title : ''}</p>}
+      {address && address.label &&
+        <p className="poi_panel__address">{ title }</p>
+      }
     </div>}
 
     {subClassName !== 'latlon' && <div>

--- a/src/panel/poi/PoiHeader.jsx
+++ b/src/panel/poi/PoiHeader.jsx
@@ -8,15 +8,28 @@ const PoiHeader = ({ poi }) => {
   const title = name || localName || poiSubClass(subClassName);
 
   return <div>
-    <h4 className="poi_panel__title">
-      <span className="poi_panel__title__main">{title}</span>
-      {name && localName && localName !== name &&
+    {subClassName === 'latlon' && <div>
+      <div className="poi_panel__pre_title">{_('Close to', 'poi')}</div>
+      <h4 className="poi_panel__title">
+        <span className="poi_panel__title__main">
+          {address && address.label ? address.label : title}
+        </span>
+      </h4>
+      {<p className="poi_panel__address">{address && address.label ? title : ''}</p>}
+    </div>}
+
+    {subClassName !== 'latlon' && <div>
+      <h4 className="poi_panel__title">
+        <span className="poi_panel__title__main">{title}</span>
+        {name && localName && localName !== name &&
         <p className="poi_panel__title__alternative">{localName}</p>
-      }
-    </h4>
-    {subClassName && <p className="poi_panel__description">{poiSubClass(subClassName)}</p>}
-    {address && address.label && <p className="poi_panel__address">{address.label}</p>}
-    {grades && <ReviewScore reviews={grades} poi={poi} />}
+        }
+      </h4>
+      {subClassName && <p className="poi_panel__description">{poiSubClass(subClassName)}</p>}
+      {address && address.label && <p className="poi_panel__address">{address.label}</p>}
+      {grades && <ReviewScore reviews={grades} poi={poi} />}
+    </div>}
+
   </div>;
 };
 

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -115,6 +115,12 @@ $HEADER_SIZE: 40px;
 }
 
 /* wrap it into an element and then put padding on this new element instead */
+.poi_panel__pre_title {
+  margin: 0 0 3px;
+  font-style: italic;
+  color: $secondary_text;
+}
+
 .poi_panel__title {
   font-family: Asap;
   font-weight: 700;


### PR DESCRIPTION
## Description
Show "Close to [address]" before showing GPS coordinates in POI-anywhere's
But keep GPS coords in bold if no address / nearest city is available

## Why
Address is more useful than GPS coords

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/70638530-5a2f8a00-1c39-11ea-970c-e2b111d8075d.png)

![image](https://user-images.githubusercontent.com/1225909/70638744-b2668c00-1c39-11ea-86c4-2a7d07142d4d.png)

