### PR TITLE
Mobile/Routes: Fix click on map behavior

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -108,7 +108,8 @@ Scene.prototype.initMapBox = function() {
     });
 
     this.mb.on('click', e => {
-      if (!e._interactiveClick && Device.isMobile()) {
+      if (!e._interactiveClick && Device.isMobile()
+          && !document.querySelector('.directions-open')) {
         window.app.navigateTo('/');
       }
       // Disable POI anywhere feature on mobile until we opt for an adapted UX


### PR DESCRIPTION
## Description
Restores touch on map behavior when in the context of the direction feature.
- Don't close the direction panel
- Allow to switch between alternatives by clicking on them