### PR TITLE
Simplify programming style for POI

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -4,7 +4,6 @@ import nconf from '@qwant/nconf-getter';
 import Error from '../../adapters/error';
 import Telemetry from '../../libs/telemetry';
 import QueryContext from 'src/adapters/query_context';
-import { isFromOSM } from 'src/libs/pois';
 
 const serviceConfig = nconf.get().services;
 const LNG_INDEX = 0;
@@ -32,11 +31,6 @@ export default class IdunnPoi extends Poi {
     this.address = IdunnPoi.getAddress(rawPoi);
     this.bbox = rawPoi.geometry.bbox;
     this.meta = rawPoi.meta || {};
-    if (isFromOSM(this)) {
-      const [_osmKey, itemKind, itemId] = rawPoi.id.split(':');
-      this.viewUrl = `https://www.openstreetmap.org/${itemKind}/${itemId}`;
-      this.editUrl = `https://www.openstreetmap.org/edit?editor=id&${itemKind}=${itemId}`;
-    }
 
     this.blocksByType = {};
     if (this.blocks) {

--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -2,7 +2,6 @@ import Poi from './poi';
 import Ajax from '../../libs/ajax';
 import nconf from '@qwant/nconf-getter';
 import Error from '../../adapters/error';
-import Telemetry from '../../libs/telemetry';
 import QueryContext from 'src/adapters/query_context';
 
 const serviceConfig = nconf.get().services;
@@ -151,21 +150,6 @@ export default class IdunnPoi extends Poi {
     }
     default:
       return rawPoi.address;
-    }
-  }
-
-  logGradesClick(template) {
-    const grades = this.blocksByType.grades;
-    if (grades && grades.url) {
-      Telemetry.add('reviews', 'poi', this.meta.source,
-        Telemetry.buildInteractionData({
-          id: this.id,
-          source: this.meta.source,
-          template,
-          zone: template === 'multiple' ? 'list' : 'detail',
-          element: 'reviews',
-        })
-      );
     }
   }
 }

--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -2,9 +2,9 @@ import Poi from './poi';
 import Ajax from '../../libs/ajax';
 import nconf from '@qwant/nconf-getter';
 import Error from '../../adapters/error';
-import { sources } from 'config/constants.yml';
 import Telemetry from '../../libs/telemetry';
 import QueryContext from 'src/adapters/query_context';
+import { isFromOSM } from 'src/libs/pois';
 
 const serviceConfig = nconf.get().services;
 const LNG_INDEX = 0;
@@ -32,7 +32,7 @@ export default class IdunnPoi extends Poi {
     this.address = IdunnPoi.getAddress(rawPoi);
     this.bbox = rawPoi.geometry.bbox;
     this.meta = rawPoi.meta || {};
-    if (this.isFromOSM()) {
+    if (isFromOSM(this)) {
       const [_osmKey, itemKind, itemId] = rawPoi.id.split(':');
       this.viewUrl = `https://www.openstreetmap.org/${itemKind}/${itemId}`;
       this.editUrl = `https://www.openstreetmap.org/edit?editor=id&${itemKind}=${itemId}`;
@@ -173,13 +173,5 @@ export default class IdunnPoi extends Poi {
         })
       );
     }
-  }
-
-  isFromOSM() {
-    return this.meta && this.meta.source === sources.osm;
-  }
-
-  isFromPagesjaunes() {
-    return this.meta && this.meta.source === sources.pagesjaunes;
   }
 }

--- a/src/adapters/poi/latlon_poi.js
+++ b/src/adapters/poi/latlon_poi.js
@@ -10,8 +10,4 @@ export default class LatLonPoi extends Poi {
     super(id, label, null, null, latLon);
     this.type = 'latlon';
   }
-
-  toUrl() {
-    return this.id;
-  }
 }

--- a/src/adapters/poi/latlon_poi.js
+++ b/src/adapters/poi/latlon_poi.js
@@ -1,11 +1,4 @@
 import Poi from './poi';
-import ExtendedString from '../../libs/string';
-import IdunnPoi from './idunn_poi';
-
-const LAT_POSITION = 1;
-const LON_POSITION = 2;
-const LABEL_POSITION = 4;
-const DIRECTION_URL_REGEX = /^latlon:(-?\d*\.\d*):(-?\d*\.\d*)(@(.*))?/;
 
 export default class LatLonPoi extends Poi {
   constructor(latLon, label) {
@@ -20,31 +13,5 @@ export default class LatLonPoi extends Poi {
 
   toUrl() {
     return this.id;
-  }
-
-  static async fromUrl(urlParam) {
-    if (!urlParam) {
-      return Promise.reject();
-    }
-
-    if (urlParam.match(/^latlon:/)) {
-      const urlData = urlParam.match(DIRECTION_URL_REGEX);
-      const lat = urlData[LAT_POSITION];
-      const lng = urlData[LON_POSITION];
-
-      if (lat && lng) {
-        const latLng = { lat: parseFloat(lat), lng: parseFloat(lng) };
-        if (urlData[LABEL_POSITION]) {
-          return Promise.resolve(
-            new LatLonPoi(latLng, ExtendedString.htmlEncode(urlData[LABEL_POSITION]))
-          );
-        }
-        return Promise.resolve(new LatLonPoi(latLng));
-      }
-    } else {
-      const urlData = urlParam.match(/^(.*?)(@(.*))?$/);
-      const idunnId = urlData[1];
-      return IdunnPoi.poiApiLoad({ 'id': idunnId });
-    }
   }
 }

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -1,7 +1,6 @@
 /**
  * simple Poi helper
  */
-import ExtendedString from 'src/libs/string';
 
 const ZOOM_BY_POI_TYPES = [
   { type: 'street', zoom: 17 },
@@ -42,11 +41,6 @@ export default class Poi {
     } else {
       return DEFAULT_ZOOM;
     }
-  }
-
-  toUrl() {
-    const slug = ExtendedString.slug(this.name);
-    return `${this.id}@${slug}`;
   }
 
   static deserialize(raw) {

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -24,10 +24,6 @@ export default class Poi {
     this.bbox = bbox;
   }
 
-  getLngLat() {
-    return this.latLon;
-  }
-
   getInputValue() {
     return this.name;
   }

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -1,7 +1,6 @@
 /**
  * simple Poi helper
  */
-import { version } from 'config/constants.yml';
 import ExtendedString from 'src/libs/string';
 
 const ZOOM_BY_POI_TYPES = [
@@ -34,10 +33,6 @@ export default class Poi {
     return this.name;
   }
 
-  getKey() {
-    return `qmaps_v${version}_favorite_place_${this.id}`;
-  }
-
   computeZoom() {
     const zoomSetting = ZOOM_BY_POI_TYPES.find(zoomType =>
       this.type === zoomType.type
@@ -63,21 +58,6 @@ export default class Poi {
   toUrl() {
     const slug = ExtendedString.slug(this.name);
     return `${this.id}@${slug}`;
-  }
-
-  toAbsoluteUrl() {
-    const location = window.location;
-    const protocol = location.protocol;
-    const host = location.host;
-    const baseUrl = window.baseUrl;
-    const lat = this.latLon.lat.toFixed(7);
-    const lon = this.latLon.lng.toFixed(7);
-    return `${protocol}//${host}${baseUrl}place/${this.toUrl()}/#map=${this.zoom}/${lat}/${lon}`;
-  }
-
-  static isPoiCompliantKey(k) {
-    const keyPattern = new RegExp(`^qmaps_v${version}_favorite_place_.*`);
-    return k.match(keyPattern) !== null;
   }
 
   static deserialize(raw) {

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -2,13 +2,6 @@
  * simple Poi helper
  */
 
-const ZOOM_BY_POI_TYPES = [
-  { type: 'street', zoom: 17 },
-  { type: 'house', zoom: 19 },
-  { type: 'poi', zoom: 18, panel: true },
-];
-const DEFAULT_ZOOM = 16;
-
 export const POI_TYPE = 'poi';
 
 export default class Poi {
@@ -20,23 +13,11 @@ export default class Poi {
     this.latLon = latLon;
     this.className = className;
     this.subClassName = subClassName;
-    this.zoom = this.computeZoom();
     this.bbox = bbox;
   }
 
   getInputValue() {
     return this.name;
-  }
-
-  computeZoom() {
-    const zoomSetting = ZOOM_BY_POI_TYPES.find(zoomType =>
-      this.type === zoomType.type
-    );
-    if (zoomSetting) {
-      return zoomSetting.zoom;
-    } else {
-      return DEFAULT_ZOOM;
-    }
   }
 
   static deserialize(raw) {

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -44,17 +44,6 @@ export default class Poi {
     }
   }
 
-  poiStoreLiteral() {
-    const serializeKeys = ['id', 'name', 'alternativeName', 'type', 'latLon', 'className',
-      'subClassName', 'zoom', 'bbox'];
-    return Object.keys(this).reduce((poiLiteral, key) => {
-      if (serializeKeys.includes(key)) {
-        poiLiteral[key] = this[key];
-      }
-      return poiLiteral;
-    }, {});
-  }
-
   toUrl() {
     const slug = ExtendedString.slug(this.name);
     return `${this.id}@${slug}`;

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -24,11 +24,4 @@ export default class Poi {
     const { id, name, alternativeName, type, latLon, className, subClassName, bbox } = raw;
     return new Poi(id, name, alternativeName, type, latLon, className, subClassName, bbox);
   }
-
-  serialize() {
-    // In some cases the object has an `event` prop which is a low-level browser object
-    // that can't be serialized in the history state => just ignore it
-    const { event: _event, ...otherFields } = this;
-    return otherFields;
-  }
 }

--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -46,10 +46,6 @@ export default class NavigatorGeolocalisationPoi extends Poi {
     this.latLon = latLng;
   }
 
-  toUrl() {
-    return `latlon:${this.latLon.lat.toFixed(6)}:${this.latLon.lng.toFixed(6)}`;
-  }
-
   render() {
     return `
       <div data-id="${GEOLOCALISATION_NAME}" data-val="${_('Your position', 'direction')}"

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -70,7 +70,7 @@ PoiPopup.prototype.showPopup = function(poi, event) {
   };
 
   this.popupHandle = new Popup(popupOptions)
-    .setLngLat(poi.getLngLat())
+    .setLngLat(poi.latLon)
     .setHTML(renderStaticReact(<ReactPoiPopup poi={poi} />))
     .addTo(this.map);
 };

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -101,7 +101,7 @@ Scene.prototype.initMapBox = function() {
         e._interactiveClick = true;
         if (e.features && e.features.length > 0) {
           const mapPoi = new MapPoi(e.features[0]);
-          window.app.navigateTo(`/place/${toUrl(mapPoi)}`, { poi: mapPoi.serialize() });
+          window.app.navigateTo(`/place/${toUrl(mapPoi)}`, { poi: mapPoi });
         }
       });
 

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -15,6 +15,7 @@ import LatLonPoi from './poi/latlon_poi';
 import SceneEasterEgg from './scene_easter_egg';
 import Device from '../libs/device';
 import { parseMapHash, getMapHash } from 'src/libs/url_utils';
+import { toUrl } from 'src/libs/pois';
 
 const baseUrl = nconf.get().system.baseUrl;
 const easterEggsEnabled = nconf.get().app.easterEggs;
@@ -100,7 +101,7 @@ Scene.prototype.initMapBox = function() {
         e._interactiveClick = true;
         if (e.features && e.features.length > 0) {
           const mapPoi = new MapPoi(e.features[0]);
-          window.app.navigateTo(`/place/${mapPoi.toUrl()}`, { poi: mapPoi.serialize() });
+          window.app.navigateTo(`/place/${toUrl(mapPoi)}`, { poi: mapPoi.serialize() });
         }
       });
 
@@ -117,7 +118,7 @@ Scene.prototype.initMapBox = function() {
         return;
       }
       const poi = new LatLonPoi(e.lngLat);
-      window.app.navigateTo(`/place/${poi.toUrl()}`, { poi });
+      window.app.navigateTo(`/place/${toUrl(poi)}`, { poi });
     });
 
     this.mb.on('moveend', () => {

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -15,7 +15,7 @@ import LatLonPoi from './poi/latlon_poi';
 import SceneEasterEgg from './scene_easter_egg';
 import Device from '../libs/device';
 import { parseMapHash, getMapHash } from 'src/libs/url_utils';
-import { toUrl } from 'src/libs/pois';
+import { toUrl, getBestZoom } from 'src/libs/pois';
 
 const baseUrl = nconf.get().system.baseUrl;
 const easterEggsEnabled = nconf.get().app.easterEggs;
@@ -269,10 +269,12 @@ Scene.prototype.fitMap = function(item, padding) {
     if (item.bbox) { // poi Bbox
       this.fitBbox(item.bbox, padding);
     } else { // poi center
-      const flyOptions = { center: item.latLon, screenSpeed: 1.5, animate: false };
-      if (item.zoom) {
-        flyOptions.zoom = item.zoom;
-      }
+      const flyOptions = {
+        center: item.latLon,
+        zoom: getBestZoom(item),
+        screenSpeed: 1.5,
+        animate: false,
+      };
 
       if (padding) {
         flyOptions.offset = [
@@ -307,7 +309,7 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
     : [(layout.sizes.panelWidth + layout.sizes.sideBarWidth) / 2, 0];
   this.mb.flyTo({
     center: poi.latLon,
-    zoom: poi.zoom,
+    zoom: getBestZoom(poi),
     offset,
     maxDuration: 1200,
   });

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -269,7 +269,7 @@ Scene.prototype.fitMap = function(item, padding) {
     if (item.bbox) { // poi Bbox
       this.fitBbox(item.bbox, padding);
     } else { // poi center
-      const flyOptions = { center: item.getLngLat(), screenSpeed: 1.5, animate: false };
+      const flyOptions = { center: item.latLon, screenSpeed: 1.5, animate: false };
       if (item.zoom) {
         flyOptions.zoom = item.zoom;
       }
@@ -295,7 +295,7 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
     return;
   }
   if (!options.centerMap) {
-    const { x: leftPixelOffset } = this.mb.project(poi.getLngLat());
+    const { x: leftPixelOffset } = this.mb.project(poi.latLon);
     const isPoiUnderPanel = leftPixelOffset < layout.sizes.sideBarWidth + layout.sizes.panelWidth
       && window.innerWidth > layout.mobile.breakPoint;
     if (this.isWindowedPoi(poi) && !isPoiUnderPanel) {
@@ -306,7 +306,7 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
     ? [0, 0]
     : [(layout.sizes.panelWidth + layout.sizes.sideBarWidth) / 2, 0];
   this.mb.flyTo({
-    center: poi.getLngLat(),
+    center: poi.latLon,
     zoom: poi.zoom,
     offset,
     maxDuration: 1200,
@@ -329,7 +329,7 @@ Scene.prototype.addMarker = function(poi) {
   }
 
   const marker = new Marker({ element, anchor: 'bottom', offset: [0, -5] })
-    .setLngLat(poi.getLngLat())
+    .setLngLat(poi.latLon)
     .addTo(this.mb);
   this.currentMarker = marker;
   return marker;
@@ -345,7 +345,7 @@ Scene.prototype.isWindowedPoi = function(poi) {
   const windowBounds = this.mb.getBounds();
   /* simple way to clone value */
   const originalWindowBounds = windowBounds.toArray();
-  const poiCenter = new LngLat(poi.getLngLat().lng, poi.getLngLat().lat);
+  const poiCenter = new LngLat(poi.latLon.lng, poi.latLon.lat);
   windowBounds.extend(poiCenter);
   return compareBoundsArray(windowBounds.toArray(), originalWindowBounds);
 };

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -43,7 +43,7 @@ export default class SceneCategory {
       );
     }
     window.app.navigateTo(`/place/${toUrl(poi)}`, {
-      poi: poi.serialize(),
+      poi,
       isFromCategory: true,
       sourceCategory: categoryName,
       layout: layouts.LIST,

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -3,6 +3,7 @@ import constants from '../../config/constants.yml';
 import { createIcon } from '../adapters/icon_manager';
 import Telemetry from 'src/libs/telemetry';
 import layouts from 'src/panel/layouts.js';
+import { toUrl } from 'src/libs/pois';
 
 export default class SceneCategory {
   constructor(map) {
@@ -41,7 +42,7 @@ export default class SceneCategory {
         })
       );
     }
-    window.app.navigateTo(`/place/${poi.toUrl()}`, {
+    window.app.navigateTo(`/place/${toUrl(poi)}`, {
       poi: poi.serialize(),
       isFromCategory: true,
       sourceCategory: categoryName,

--- a/src/adapters/scene_event.js
+++ b/src/adapters/scene_event.js
@@ -43,7 +43,7 @@ export default class SceneEvent {
       );
     }
     window.app.navigateTo(`/place/${toUrl(poi)}`, {
-      poi: poi.serialize(),
+      poi,
       isFromEvent: true,
       sourceEvent: eventName,
       layout: layouts.LIST,

--- a/src/adapters/scene_event.js
+++ b/src/adapters/scene_event.js
@@ -3,6 +3,7 @@ import { createEventIcon } from '../adapters/icon_manager';
 import Telemetry from 'src/libs/telemetry';
 import layouts from 'src/panel/layouts.js';
 import events from 'config/events.yml';
+import { toUrl } from 'src/libs/pois';
 
 export default class SceneEvent {
   constructor(map) {
@@ -41,7 +42,7 @@ export default class SceneEvent {
         })
       );
     }
-    window.app.navigateTo(`/place/${poi.toUrl()}`, {
+    window.app.navigateTo(`/place/${toUrl(poi)}`, {
       poi: poi.serialize(),
       isFromEvent: true,
       sourceEvent: eventName,

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -194,7 +194,7 @@ export default class Store {
   async add(poi) {
     await this.checkInit();
     try {
-      await this.abstractStore.set(getKey(poi), poi.poiStoreLiteral());
+      await this.abstractStore.set(getKey(poi), poi.serialize());
       fire('poi_added_to_favs', poi);
     } catch (e) {
       Error.sendOnce('store', 'add', `error adding poi in ${this.abstractStore.storeName}`, e);

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -194,7 +194,7 @@ export default class Store {
   async add(poi) {
     await this.checkInit();
     try {
-      await this.abstractStore.set(getKey(poi), poi.serialize());
+      await this.abstractStore.set(getKey(poi), poi);
       fire('poi_added_to_favs', poi);
     } catch (e) {
       Error.sendOnce('store', 'add', `error adding poi in ${this.abstractStore.storeName}`, e);

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -4,6 +4,7 @@ import { version } from '../../config/constants.yml';
 import ExtendedString from '../libs/string';
 import LocalStore from '../libs/local_store';
 import MasqStore from '../libs/masq';
+import { getKey } from 'src/libs/pois';
 
 const masqConfig = nconf.get().masq;
 if (!MasqStore.isMasqSupported(masqConfig) && !MasqStore.isMasqForced()) {
@@ -183,7 +184,7 @@ export default class Store {
   async has(poi) {
     await this.checkInit();
     try {
-      return await this.abstractStore.has(poi.getKey());
+      return await this.abstractStore.has(getKey(poi));
     } catch (e) {
       Error.sendOnce('store', 'has',
         `error checking existing key in ${this.abstractStore.storeName}`, e);
@@ -193,7 +194,7 @@ export default class Store {
   async add(poi) {
     await this.checkInit();
     try {
-      await this.abstractStore.set(poi.getKey(), poi.poiStoreLiteral());
+      await this.abstractStore.set(getKey(poi), poi.poiStoreLiteral());
       fire('poi_added_to_favs', poi);
     } catch (e) {
       Error.sendOnce('store', 'add', `error adding poi in ${this.abstractStore.storeName}`, e);
@@ -203,7 +204,7 @@ export default class Store {
   async del(poi) {
     await this.checkInit();
     try {
-      await this.abstractStore.del(poi.getKey());
+      await this.abstractStore.del(getKey(poi));
       fire('poi_removed_from_favs', poi);
     } catch (e) {
       Error.sendOnce('store', 'del', `error deleting key from ${this.abstractStore.storeName}`, e);

--- a/src/components/OsmContribution.jsx
+++ b/src/components/OsmContribution.jsx
@@ -2,18 +2,22 @@
 import React from 'react';
 
 const OsmContribution = ({ poi }) => {
+  const [_osmKey, itemKind, itemId] = poi.id.split(':');
+  const viewUrl = `https://www.openstreetmap.org/${itemKind}/${itemId}`;
+  const editUrl = `https://www.openstreetmap.org/edit?editor=id&${itemKind}=${itemId}`;
+
   return <div className="osm_contribute">
     <div className="osm_contribute__logo" />
     <div className="osm_contribute__text_container">
       <p className="osm_contribute__title">
         {_('Qwant Maps uses OpenStreetMap data.')}
       </p>
-      <a className="osm_contribute__link" href={poi.viewUrl} rel="noopener noreferrer"
+      <a className="osm_contribute__link" href={viewUrl} rel="noopener noreferrer"
         target="_blank">
         <i className="icon-chevrons-right osm_contribute__icon" />
         <span className="osm_contribute__about">{_('VIEW')}</span>
       </a>
-      <a className="osm_contribute__link" href={poi.editUrl} rel="noopener noreferrer"
+      <a className="osm_contribute__link" href={editUrl} rel="noopener noreferrer"
         target="_blank">
         <i className="icon-chevrons-right osm_contribute__icon edit" />
         <span className="osm_contribute__about">{_('EDIT')}</span>

--- a/src/components/ReviewScore.jsx
+++ b/src/components/ReviewScore.jsx
@@ -1,11 +1,27 @@
 /* global _n */
 import React from 'react';
+import Telemetry from 'src/libs/telemetry';
 
-const ReviewScore = ({ poi, reviews: { global_grade, total_grades_count, url } }) =>
+function logGradesClick(poi, inList) {
+  const grades = poi.blocksByType.grades;
+  if (grades && grades.url) {
+    Telemetry.add('reviews', 'poi', poi.meta.source,
+      Telemetry.buildInteractionData({
+        id: poi.id,
+        source: poi.meta.source,
+        template: inList ? 'multiple' : 'single',
+        zone: inList ? 'list' : 'detail',
+        element: 'reviews',
+      })
+    );
+  }
+}
+
+const ReviewScore = ({ poi, reviews: { global_grade, total_grades_count, url }, inList }) =>
   <a className="reviewScore" rel="noopener noreferrer" href={url}
     onClick={e => {
       e.stopPropagation();
-      poi.logGradesClick('single');
+      logGradesClick(poi, inList);
     }}
   >
     <span className="reviewScore-stars">

--- a/src/libs/local_store.js
+++ b/src/libs/local_store.js
@@ -1,6 +1,6 @@
 import Error from '../adapters/error';
 import { version } from '../../config/constants.yml';
-import Poi from '../adapters/poi/poi';
+import { isPoiCompliantKey } from 'src/libs/pois';
 
 export default class LocalStore {
 
@@ -17,7 +17,7 @@ export default class LocalStore {
       return [];
     }
     const items = localStorageKeys.reduce((filtered, k) => {
-      if (Poi.isPoiCompliantKey(k)) {
+      if (isPoiCompliantKey(k)) {
         try {
           const poi = JSON.parse(localStorage.getItem(k));
           filtered.push(poi);

--- a/src/libs/masq.js
+++ b/src/libs/masq.js
@@ -3,7 +3,7 @@
 import Error from '../adapters/error';
 import { setMasqActivatingModal } from 'src/modals/MasqActivatingModal';
 import importMasq from './import_masq';
-import Poi from '../adapters/poi/poi';
+import { isPoiCompliantKey } from 'src/libs/pois';
 import { detect } from 'detect-browser';
 import Telemetry from '../libs/telemetry';
 
@@ -158,7 +158,7 @@ export default class MasqStore {
       const list = await this.masq.list();
 
       const filteredValues = Object.entries(list)
-        .filter(kv => Poi.isPoiCompliantKey(kv[0]))
+        .filter(kv => isPoiCompliantKey(kv[0]))
         .map(kv => kv[1]);
 
       return filteredValues;

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -4,6 +4,15 @@ import ExtendedString from 'src/libs/string';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import LatLonPoi from 'src/adapters/poi/latlon_poi';
 
+// POI from/to url functions
+
+export function toUrl(poi) {
+  if (poi.id === 'geolocalisation' || poi.type === 'latlon') {
+    return `latlon:${poi.latLon.lat.toFixed(5)}:${poi.latLon.lng.toFixed(5)}`;
+  }
+  return `${poi.id}@${ExtendedString.slug(poi.name)}`;
+}
+
 export function toAbsoluteUrl(poi) {
   const { protocol, host } = window.location;
   const baseUrl = window.baseUrl;
@@ -11,18 +20,6 @@ export function toAbsoluteUrl(poi) {
   const lon = poi.latLon.lng.toFixed(7);
   const mapHash = `#map=${getBestZoom(poi.zoom)}/${lat}/${lon}`;
   return `${protocol}//${host}${baseUrl}place/${toUrl(poi)}/${mapHash}`;
-}
-
-const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
-
-export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
-export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;
-
-export function toUrl(poi) {
-  if (poi.id === 'geolocalisation' || poi.type === 'latlon') {
-    return `latlon:${poi.latLon.lat.toFixed(5)}:${poi.latLon.lng.toFixed(5)}`;
-  }
-  return `${poi.id}@${ExtendedString.slug(poi.name)}`;
 }
 
 export function fromUrl(urlParam) {
@@ -38,23 +35,28 @@ export function fromUrl(urlParam) {
     return Promise.resolve(
       new LatLonPoi(latLng, label ? ExtendedString.htmlEncode(label) : null)
     );
-  } else {
-    urlData = urlParam.match(/^(.*?)(@(.*))?$/);
-    if (urlData) {
-      const idunnId = urlData[1];
-      return IdunnPoi.poiApiLoad({ id: idunnId });
-    }
+  }
+  urlData = urlParam.match(/^(.*?)(@(.*))?$/);
+  if (urlData) {
+    const idunnId = urlData[1];
+    return IdunnPoi.poiApiLoad({ id: idunnId });
   }
   return Promise.reject();
 }
 
-export function isFromPagesJaunes(poi) {
-  return poi.meta && poi.meta.source === sources.pagesjaunes;
-}
+// POI fav storage functions
 
-export function isFromOSM(poi) {
-  return poi.meta && poi.meta.source === sources.osm;
-}
+const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
+
+export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
+export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;
+
+// POI source functions
+
+export const isFromPagesJaunes = poi => poi.meta && poi.meta.source === sources.pagesjaunes;
+export const isFromOSM = poi => poi.meta && poi.meta.source === sources.osm;
+
+// POI map util functions
 
 const ZOOM_BY_POI_TYPES = {
   street: 17,

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -1,5 +1,8 @@
 
 import { version } from 'config/constants.yml';
+import ExtendedString from 'src/libs/string';
+import IdunnPoi from 'src/adapters/poi/idunn_poi';
+import LatLonPoi from 'src/adapters/poi/latlon_poi';
 
 export function toAbsoluteUrl(poi) {
   const { protocol, host } = window.location;
@@ -13,3 +16,26 @@ const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
 
 export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
 export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;
+
+export function fromUrl(urlParam) {
+  if (!urlParam) {
+    return Promise.reject();
+  }
+
+  const latLonUrlRegex = /^latlon:(-?\d*\.\d*):(-?\d*\.\d*)(?:@(.*))?/;
+  let urlData = urlParam.match(latLonUrlRegex);
+  if (urlData) {
+    const [ _, lat, lng, label ] = urlData;
+    const latLng = { lat: parseFloat(lat), lng: parseFloat(lng) };
+    return Promise.resolve(
+      new LatLonPoi(latLng, label ? ExtendedString.htmlEncode(label) : null)
+    );
+  } else {
+    urlData = urlParam.match(/^(.*?)(@(.*))?$/);
+    if (urlData) {
+      const idunnId = urlData[1];
+      return IdunnPoi.poiApiLoad({ id: idunnId });
+    }
+  }
+  return Promise.reject();
+}

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -9,7 +9,8 @@ export function toAbsoluteUrl(poi) {
   const baseUrl = window.baseUrl;
   const lat = poi.latLon.lat.toFixed(7);
   const lon = poi.latLon.lng.toFixed(7);
-  return `${protocol}//${host}${baseUrl}place/${toUrl(poi)}/#map=${poi.zoom}/${lat}/${lon}`;
+  const mapHash = `#map=${getBestZoom(poi.zoom)}/${lat}/${lon}`;
+  return `${protocol}//${host}${baseUrl}place/${toUrl(poi)}/${mapHash}`;
 }
 
 const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
@@ -53,4 +54,15 @@ export function isFromPagesJaunes(poi) {
 
 export function isFromOSM(poi) {
   return poi.meta && poi.meta.source === sources.osm;
+}
+
+const ZOOM_BY_POI_TYPES = {
+  street: 17,
+  house: 19,
+  poi: 18,
+};
+const DEFAULT_ZOOM = 16;
+
+export function getBestZoom(poi) {
+  return ZOOM_BY_POI_TYPES[poi.type] || DEFAULT_ZOOM;
 }

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -1,5 +1,5 @@
 
-import { version } from 'config/constants.yml';
+import { version, sources } from 'config/constants.yml';
 import ExtendedString from 'src/libs/string';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import LatLonPoi from 'src/adapters/poi/latlon_poi';
@@ -38,4 +38,12 @@ export function fromUrl(urlParam) {
     }
   }
   return Promise.reject();
+}
+
+export function isFromPagesJaunes(poi) {
+  return poi.meta && poi.meta.source === sources.pagesjaunes;
+}
+
+export function isFromOSM(poi) {
+  return poi.meta && poi.meta.source === sources.osm;
 }

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -1,0 +1,15 @@
+
+import { version } from 'config/constants.yml';
+
+export function toAbsoluteUrl(poi) {
+  const { protocol, host } = window.location;
+  const baseUrl = window.baseUrl;
+  const lat = poi.latLon.lat.toFixed(7);
+  const lon = poi.latLon.lng.toFixed(7);
+  return `${protocol}//${host}${baseUrl}place/${poi.toUrl()}/#map=${poi.zoom}/${lat}/${lon}`;
+}
+
+const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
+
+export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
+export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -9,13 +9,20 @@ export function toAbsoluteUrl(poi) {
   const baseUrl = window.baseUrl;
   const lat = poi.latLon.lat.toFixed(7);
   const lon = poi.latLon.lng.toFixed(7);
-  return `${protocol}//${host}${baseUrl}place/${poi.toUrl()}/#map=${poi.zoom}/${lat}/${lon}`;
+  return `${protocol}//${host}${baseUrl}place/${toUrl(poi)}/#map=${poi.zoom}/${lat}/${lon}`;
 }
 
 const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
 
 export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
 export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;
+
+export function toUrl(poi) {
+  if (poi.id === 'geolocalisation' || poi.type === 'latlon') {
+    return `latlon:${poi.latLon.lat.toFixed(5)}:${poi.latLon.lng.toFixed(5)}`;
+  }
+  return `${poi.id}@${ExtendedString.slug(poi.name)}`;
+}
 
 export function fromUrl(urlParam) {
   if (!urlParam) {

--- a/src/panel/PoiPanel.jsx
+++ b/src/panel/PoiPanel.jsx
@@ -13,7 +13,7 @@ import OsmContribution from 'src/components/OsmContribution';
 import PoiBlockContainer from './poi_bloc/PoiBlockContainer';
 import CategoryList from 'src/components/CategoryList';
 import { openShareModal } from 'src/modals/ShareModal';
-import { toAbsoluteUrl } from 'src/libs/pois';
+import { toAbsoluteUrl, isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
 
 export default class PoiPanel extends React.Component {
   static propTypes = {
@@ -115,7 +115,7 @@ export default class PoiPanel extends React.Component {
   render() {
     const { poi, isFromCategory, isFromFavorite } = this.props;
 
-    const pagesjaunes = poi.isFromPagesjaunes && poi.isFromPagesjaunes() ?
+    const pagesjaunes = isFromPagesJaunes(poi) ?
       <img className="poi_panel__back_to_list_logo"
         src="./statics/images/pagesjaunes.svg"
         alt="PagesJaunes" />
@@ -218,7 +218,7 @@ export default class PoiPanel extends React.Component {
               </h3>
               <CategoryList />
             </div>}
-            {poi.isFromOSM && poi.isFromOSM() && <OsmContribution poi={poi} />}
+            {isFromOSM(poi) && <OsmContribution poi={poi} />}
           </div>
         </div>
       </div>

--- a/src/panel/PoiPanel.jsx
+++ b/src/panel/PoiPanel.jsx
@@ -13,6 +13,7 @@ import OsmContribution from 'src/components/OsmContribution';
 import PoiBlockContainer from './poi_bloc/PoiBlockContainer';
 import CategoryList from 'src/components/CategoryList';
 import { openShareModal } from 'src/modals/ShareModal';
+import { toAbsoluteUrl } from 'src/libs/pois';
 
 export default class PoiPanel extends React.Component {
   static propTypes = {
@@ -85,7 +86,7 @@ export default class PoiPanel extends React.Component {
       Telemetry.add('share', 'poi', this.props.poi.meta.source);
     }
     if (this.props.poi) {
-      openShareModal(this.props.poi.toAbsoluteUrl());
+      openShareModal(toAbsoluteUrl(this.props.poi));
     }
   }
 

--- a/src/panel/category/PoiCategoryItem.jsx
+++ b/src/panel/category/PoiCategoryItem.jsx
@@ -19,7 +19,7 @@ const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
 
     {address.label && <p className="category__panel__address">{address.label}</p>}
 
-    {reviews && <ReviewScore reviews={reviews} poi={poi} />}
+    {reviews && <ReviewScore reviews={reviews} poi={poi} inList />}
 
     <OpeningHour poi={poi} />
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -7,7 +7,7 @@ import RouteResult from './RouteResult';
 import DirectionApi, { modes } from 'src/adapters/direction_api';
 import Telemetry from 'src/libs/telemetry';
 import nconf from '@qwant/nconf-getter';
-import LatLonPoi from 'src/adapters/poi/latlon_poi';
+import { fromUrl as poiFromUrl } from 'src/libs/pois';
 import Device from 'src/libs/device';
 import Error from 'src/adapters/error';
 
@@ -78,10 +78,10 @@ export default class DirectionPanel extends React.Component {
   restorePoints({ origin: originUrlValue, destination: destinationUrlValue }) {
     const poiRestorePromises = [
       originUrlValue
-        ? LatLonPoi.fromUrl(originUrlValue)
+        ? poiFromUrl(originUrlValue)
         : Promise.resolve(this.state.origin),
       destinationUrlValue
-        ? LatLonPoi.fromUrl(destinationUrlValue)
+        ? poiFromUrl(destinationUrlValue)
         : Promise.resolve(this.state.destination),
     ];
     Promise.all(poiRestorePromises).then(([ origin, destination ]) => {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -7,12 +7,9 @@ import RouteResult from './RouteResult';
 import DirectionApi, { modes } from 'src/adapters/direction_api';
 import Telemetry from 'src/libs/telemetry';
 import nconf from '@qwant/nconf-getter';
-import { fromUrl as poiFromUrl } from 'src/libs/pois';
+import { toUrl as poiToUrl, fromUrl as poiFromUrl } from 'src/libs/pois';
 import Device from 'src/libs/device';
 import Error from 'src/adapters/error';
-
-const poiUrlValue = poi =>
-  typeof poi.toUrl === 'function' ? poi.toUrl() : `${poi.id}@${poi.name}`;
 
 // this outside state is used to restore origin/destination when returning to the panel after closing
 const persistentPointState = {
@@ -133,10 +130,10 @@ export default class DirectionPanel extends React.Component {
   updateUrl() {
     const routeParams = [];
     if (this.state.origin) {
-      routeParams.push('origin=' + poiUrlValue(this.state.origin));
+      routeParams.push('origin=' + poiToUrl(this.state.origin));
     }
     if (this.state.destination) {
-      routeParams.push('destination=' + poiUrlValue(this.state.destination));
+      routeParams.push('destination=' + poiToUrl(this.state.destination));
     }
     routeParams.push(`mode=${this.state.vehicle}`);
     window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, {

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -19,7 +19,7 @@ export default class FavoritePoi extends React.Component {
   onClick = () => {
     Telemetry.add(Telemetry.FAVORITE_GO);
     window.app.navigateTo(`/place/${toUrl(this.props.poi)}`, {
-      poi: this.props.poi.serialize(),
+      poi: this.props.poi,
       centerMap: true,
       isFromFavorite: true,
       layout: layouts.FAVORITE,

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -8,6 +8,7 @@ import Telemetry from 'src/libs/telemetry';
 import layouts from 'src/panel/layouts.js';
 import ContextMenu from 'src/components/ui/ContextMenu';
 import { openShareModal } from 'src/modals/ShareModal';
+import { toAbsoluteUrl } from 'src/libs/pois';
 
 export default class FavoritePoi extends React.Component {
   static propTypes = {
@@ -27,7 +28,7 @@ export default class FavoritePoi extends React.Component {
 
   onShare = () => {
     Telemetry.add(Telemetry.FAVORITE_SHARE);
-    openShareModal(this.props.poi.toAbsoluteUrl());
+    openShareModal(toAbsoluteUrl(this.props.poi));
   };
 
   onDelete = () => {

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -8,7 +8,7 @@ import Telemetry from 'src/libs/telemetry';
 import layouts from 'src/panel/layouts.js';
 import ContextMenu from 'src/components/ui/ContextMenu';
 import { openShareModal } from 'src/modals/ShareModal';
-import { toAbsoluteUrl } from 'src/libs/pois';
+import { toAbsoluteUrl, toUrl } from 'src/libs/pois';
 
 export default class FavoritePoi extends React.Component {
   static propTypes = {
@@ -18,7 +18,7 @@ export default class FavoritePoi extends React.Component {
 
   onClick = () => {
     Telemetry.add(Telemetry.FAVORITE_GO);
-    window.app.navigateTo(`/place/${this.props.poi.toUrl()}`, {
+    window.app.navigateTo(`/place/${toUrl(this.props.poi)}`, {
       poi: this.props.poi.serialize(),
       centerMap: true,
       isFromFavorite: true,

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -6,6 +6,7 @@ import Telemetry from '../../libs/telemetry';
 import { openAndWaitForClose as openMasqFavModalAndWaitForClose }
   from 'src/modals/MasqFavoriteModal';
 import Store from '../../adapters/store';
+import { isFromPagesJaunes } from 'src/libs/pois';
 
 const store = new Store();
 
@@ -30,9 +31,7 @@ export default class ActionButtons extends React.Component {
   }
 
   state = {
-    showPhoneNumber:
-      !(this.props.poi.isFromPagesjaunes &&
-      this.props.poi.isFromPagesjaunes()),
+    showPhoneNumber: !isFromPagesJaunes(this.props.poi),
     poiIsInFavorite: false,
   };
 

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -1,6 +1,7 @@
 import Suggest from '../adapters/suggest';
 import Poi from '../adapters/poi/poi';
 import Category from '../adapters/category';
+import { toUrl } from 'src/libs/pois';
 
 const MAPBOX_RESERVED_KEYS = [
   'ArrowLeft', // ←
@@ -94,7 +95,7 @@ export default class SearchInput {
 
   async selectItem(selectedItem, replaceUrl = false) {
     if (selectedItem instanceof Poi) {
-      window.app.navigateTo(`/place/${selectedItem.toUrl()}`, {
+      window.app.navigateTo(`/place/${toUrl(selectedItem)}`, {
         poi: selectedItem.serialize(),
         centerMap: true,
       }, { replace: replaceUrl });

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -96,7 +96,7 @@ export default class SearchInput {
   async selectItem(selectedItem, replaceUrl = false) {
     if (selectedItem instanceof Poi) {
       window.app.navigateTo(`/place/${toUrl(selectedItem)}`, {
-        poi: selectedItem.serialize(),
+        poi: selectedItem,
         centerMap: true,
       }, { replace: replaceUrl });
     } else if (selectedItem instanceof Category) {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -14,6 +14,7 @@ module.exports = {
   globals: {
     puppeteerArguments: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
     APP_URL: 'http://localhost:3000/maps',
+    __config: require('@qwant/nconf-builder').get_without_check(),
   },
   moduleNameMapper: {
     '^src(.*)$': '<rootDir>/src$1',

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,3 +1,5 @@
+const config = require('./integration/test_config');
+
 module.exports = {
   setupFilesAfterEnv: ['jest-extended'],
   testMatch: [`${__dirname}/integration/tests/*.js`],
@@ -14,7 +16,7 @@ module.exports = {
   globals: {
     puppeteerArguments: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
     APP_URL: 'http://localhost:3000/maps',
-    __config: require('@qwant/nconf-builder').get_without_check(),
+    __config: config,
   },
   moduleNameMapper: {
     '^src(.*)$': '<rootDir>/src$1',

--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -34,5 +34,5 @@ export async function storePoi(page, { id = 1, title = 'poi', coords = { lat: 43
   const poi = new Poi(id, title, 'second line', 'poi', coords, '', '');
   await page.evaluate((storageKey, serializedPoi) => {
     window.localStorage.setItem(storageKey, serializedPoi);
-  }, getKey(poi), JSON.stringify(poi.poiStoreLiteral()));
+  }, getKey(poi), JSON.stringify(poi.serialize()));
 }

--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -34,5 +34,5 @@ export async function storePoi(page, { id = 1, title = 'poi', coords = { lat: 43
   const poi = new Poi(id, title, 'second line', 'poi', coords, '', '');
   await page.evaluate((storageKey, serializedPoi) => {
     window.localStorage.setItem(storageKey, serializedPoi);
-  }, getKey(poi), JSON.stringify(poi.serialize()));
+  }, getKey(poi), JSON.stringify(poi));
 }

--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -1,4 +1,5 @@
 import Poi from 'src/adapters/poi/poi';
+import { getKey } from 'src/libs/pois';
 
 /**
  * Prerequisite : Favorite Panel Must be open
@@ -33,5 +34,5 @@ export async function storePoi(page, { id = 1, title = 'poi', coords = { lat: 43
   const poi = new Poi(id, title, 'second line', 'poi', coords, '', '');
   await page.evaluate((storageKey, serializedPoi) => {
     window.localStorage.setItem(storageKey, serializedPoi);
-  }, poi.getKey(), JSON.stringify(poi.poiStoreLiteral()));
+  }, getKey(poi), JSON.stringify(poi.poiStoreLiteral()));
 }

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -1,6 +1,6 @@
 const App = require( './../../bin/app');
-const configBuilder = require('@qwant/nconf-builder');
 const nock = require('nock');
+const config = require('./test_config');
 
 const { ...poiNoName } = require('../__data__/poi.json');
 /* default test with matching name & local_name */
@@ -29,20 +29,6 @@ nock(/idunn_test\.test/)
   .get(/osm:way:2403/)
   .reply(404);
 
-const config = configBuilder.get_without_check();
-
-// Specific config values for tests
-config.mapStyle.baseMapUrl = '[]';
-config.mapStyle.poiMapUrl = '[]';
-config.services.idunn.url = 'http://idunn_test.test';
-config.services.geocoder.url = 'http://geocoder.test/autocomplete';
-config.direction.enabled = true;
-config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox format
-config.category.enabled = true;
-config.events.enabled = true;
-config.masq.enabled = false;
-config.system.baseUrl = '/maps/';
-config.server.routerBaseUrl = '/maps/';
 
 global.appServer = new App(config);
 

--- a/tests/integration/test_config.js
+++ b/tests/integration/test_config.js
@@ -1,0 +1,17 @@
+const configBuilder = require('@qwant/nconf-builder');
+const config = configBuilder.get_without_check();
+
+// Specific config values for tests
+config.mapStyle.baseMapUrl = '[]';
+config.mapStyle.poiMapUrl = '[]';
+config.services.idunn.url = 'http://idunn_test.test';
+config.services.geocoder.url = 'http://geocoder.test/autocomplete';
+config.direction.enabled = true;
+config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox format
+config.category.enabled = true;
+config.events.enabled = true;
+config.masq.enabled = false;
+config.system.baseUrl = '/maps/';
+config.server.routerBaseUrl = '/maps/';
+
+module.exports = config;


### PR DESCRIPTION
*:information_source: probably best reviewed commit-by-commit*

## Description
First step to move from the complex class hierarchy of POIs (POI, IdunnPoi, BragiPoi, LatLonPoi, etc.) to a simpler style inspired by functional programming.
The future goal is to manipulate POIS as plain immutable JS objects, with pure functions to manage them.

Here we simplify the different POI classes starting with their methods:
- some useless ones are simply removed
- generic ones (ex: `toUrl`) are defined as pure functions in a new module and can be imported individually
- the ones which are specific to a single use case and high-level (ex: `logGradesClick`) are moved where it's more logical

## Why
- Overall simplification of structures
- No need to test existence of a specfici function on POI instances anymore
- No need to explicitely serialize/deserialize POIs when storing them in the history or local storage
- Easier to unit test: pure functions to manipulate POI struct will be straightforward to test with clear I/O
- etc.