### PR TITLE
[Integration tests] Clean POI imports

### DIFF
--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -1,8 +1,8 @@
 /**
  * simple Poi helper
  */
-import { version } from '../../../config/constants.yml';
-import ExtendedString from '../../libs/string';
+import { version } from 'config/constants.yml';
+import ExtendedString from 'src/libs/string';
 
 const ZOOM_BY_POI_TYPES = [
   { type: 'street', zoom: 17 },

--- a/src/adapters/poi/poi.js
+++ b/src/adapters/poi/poi.js
@@ -1,7 +1,7 @@
 /**
  * simple Poi helper
  */
-import { version } from 'config/constants.yml';
+import { version } from '../../../config/constants.yml';
 import ExtendedString from '../../libs/string';
 
 const ZOOM_BY_POI_TYPES = [
@@ -92,6 +92,3 @@ export default class Poi {
     return otherFields;
   }
 }
-
-// Helper used by tests.
-window.Poi = Poi;

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -15,4 +15,8 @@ module.exports = {
     puppeteerArguments: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
     APP_URL: 'http://localhost:3000/maps',
   },
+  moduleNameMapper: {
+    '^src(.*)$': '<rootDir>/src$1',
+    '^config(.*)$': '<rootDir>/config$1',
+  },
 };

--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -1,4 +1,4 @@
-import Poi from '../../src/adapters/poi/poi';
+import Poi from 'src/adapters/poi/poi';
 
 /**
  * Prerequisite : Favorite Panel Must be open

--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -1,4 +1,4 @@
-/* global Poi */
+import Poi from '../../src/adapters/poi/poi';
 
 /**
  * Prerequisite : Favorite Panel Must be open
@@ -29,7 +29,9 @@ export async function toggleFavoritePanel(page) {
   await page.waitForSelector('.favorite_panel', { visible: true, timeOut: 300 });
 }
 
-export const storePoi = ({ id = 1, title = 'poi', coords = { lat: 43, lng: 2 } } = {}) => {
+export async function storePoi(page, { id = 1, title = 'poi', coords = { lat: 43, lng: 2 } } = {}) {
   const poi = new Poi(id, title, 'second line', 'poi', coords, '', '');
-  window.localStorage.setItem(poi.getKey(), JSON.stringify(poi.poiStoreLiteral()));
-};
+  await page.evaluate((storageKey, serializedPoi) => {
+    window.localStorage.setItem(storageKey, serializedPoi);
+  }, poi.getKey(), JSON.stringify(poi.poiStoreLiteral()));
+}

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -182,7 +182,7 @@ test('favorite search', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
-  await page.evaluate(storePoi, { title: 'hello' });
+  await storePoi(page, { title: 'hello' });
   await page.keyboard.type('Hello');
   const favTitle = await page.waitForSelector('.autocomplete_suggestion__category_title');
   expect(favTitle).not.toBeNull();

--- a/tests/integration/tests/favorite.js
+++ b/tests/integration/tests/favorite.js
@@ -25,7 +25,7 @@ test('toggle favorite panel', async () => {
 test('favorite added is present in favorite panel', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
-  await page.evaluate(storePoi, { title: 'some poi' });
+  await storePoi(page, { title: 'some poi' });
   await toggleFavoritePanel(page);
   const items = await page.waitForSelector('.favorite_panel__items');
   expect(items).not.toBeNull();
@@ -35,7 +35,7 @@ test('restore favorite from localStorage', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
   const testTitle = 'demo_fav';
-  await page.evaluate(storePoi, { title: testTitle });
+  await storePoi(page, { title: testTitle });
   await page.click('.service_panel__item__fav');
   await page.waitForSelector('.favorite_panel__item__title');
   const title = await page.evaluate(() => {
@@ -47,7 +47,7 @@ test('restore favorite from localStorage', async () => {
 test('remove favorite using favorite panel', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
-  await page.evaluate(storePoi, { title: 'some poi i will remove' });
+  await storePoi(page, { title: 'some poi i will remove' });
   await toggleFavoritePanel(page);
   let items = await page.waitForSelector('.favorite_panel__items');
   expect(items).not.toBeNull();
@@ -67,7 +67,7 @@ test('center map after a favorite poi click', async () => {
     window.MAP_MOCK.flyTo({ center: { lat: 10, lng: 0 }, zoom: 10 });
   });
   const favoritePoiCoordinates = { lat: 43.5, lng: 7.18 };
-  await page.evaluate(storePoi, { coords: favoritePoiCoordinates });
+  await storePoi(page, { coords: favoritePoiCoordinates });
   await toggleFavoritePanel(page);
   await page.waitForSelector('.favorite_panel__item__title');
   await page.click('.favorite_panel__item__title');

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -87,7 +87,7 @@ test('load a poi from url on mobile', async () => {
 test('load a poi already in my favorite from url', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
-  await page.evaluate(storePoi, { id: 'osm:way:63178753' });
+  await storePoi(page, { id: 'osm:way:63178753' });
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   const plainStar = await page.waitForSelector('.icon-icon_star-filled');
   expect(plainStar).not.toBeFalsy();
@@ -106,7 +106,7 @@ test('update url after a poi click', async () => {
 test('update url after a favorite poi click', async () => {
   expect.assertions(1);
   await page.goto(APP_URL);
-  await page.evaluate(storePoi, { id: poiMock.id, title: poiMock.name });
+  await storePoi(page, { id: poiMock.id, title: poiMock.name });
   await toggleFavoritePanel(page);
   await page.waitForSelector('.favorite_panel__item__title');
   await page.click('.favorite_panel__item__title');


### PR DESCRIPTION
## Description
Change the way the POI module is used in integration tests, so we don't need to attach the POI class to `window` globally just for that. The `poi.js` can now be imported as a normal module.
Also configure Jest to manage the same module path aliases as Webpack (`src` and `config`) so don't  need to care about how files are imported.

## Why
Cleaner build and easier-to-write tests.
Should make [this PR](https://github.com/QwantResearch/erdapfel/pull/491) green and facilitate other refactos.