### PR TITLE
Refacto: move POI loading to POI panel

### DIFF
--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -30,7 +30,10 @@ export async function toggleFavoritePanel(page) {
   await page.waitForSelector('.favorite_panel', { visible: true, timeOut: 300 });
 }
 
-export async function storePoi(page, { id = 1, title = 'poi', coords = { lat: 43, lng: 2 } } = {}) {
+export async function storePoi(
+  page,
+  { id = 'A', title = 'poi', coords = { lat: 43, lng: 2 } } = {}
+) {
   const poi = new Poi(id, title, 'second line', 'poi', coords, '', '');
   await page.evaluate((storageKey, serializedPoi) => {
     window.localStorage.setItem(storageKey, serializedPoi);


### PR DESCRIPTION
## Description
This is a first step towards the real end the React migration, i.e. converting `app_panel` to a single React component which will get attached just once to the DOM. We'll then be able to get rid of some boilerplate and simplify the app flow.
To do that, it's good to simplify `app_panel.js` first. A big part of it is the code to load an Idunn POI from the API. But this concerns only the POI panel itself, so it can be moved there.

There is some more refactoring so the POI `getKey` function can be applied to a flat object instead of an instance of the POI class.

## Why
Simplify `app_panel` so it's easier to convert it to React.