### PR TITLE
Add more info when someone arrives on qwant maps

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -18,6 +18,7 @@ import ReactPanelWrapper from 'src/panel/reactPanelWrapper';
 import events from 'config/events.yml';
 import { parseMapHash, parseQueryString, joinPath, getCurrentUrl } from 'src/libs/url_utils';
 import DirectionPanel from 'src/panel/direction/DirectionPanel';
+import Device from '../libs/device';
 
 const performanceEnabled = nconf.get().performance.enabled;
 const directionEnabled = nconf.get().direction.enabled;
@@ -55,7 +56,10 @@ export default class AppPanel {
     }
 
     ReactDOM.render(<Menu />, document.querySelector('.react_menu__container'));
-    Telemetry.add(Telemetry.APP_START);
+    Telemetry.add(Telemetry.APP_START, null, null, {
+      'language': window.getLang(),
+      'is_mobile': Device.isMobile(),
+    });
 
     this.initRouter();
     if (performanceEnabled) {


### PR DESCRIPTION
This PR adds more info when someone arrives on Qwant maps.

I also added the screen sizes, I think it could be interesting for mobile devices which might have a very wide range of possible sizes and help us give priorities to testing.