### PR TITLE
Nested parens lint rule improvement

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,7 +82,7 @@
         "comma-style": ["error", "last"],
         "max-len": ["error", { "code": 100, "tabWidth": 2, "ignoreComments": true }],
         "eol-last": ["error", "always"],
-        "no-extra-parens": "error",
+        "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false }],
         "arrow-parens": ["error", "as-needed"],
         "no-unused-vars": [
             "error",

--- a/src/adapters/poi/bragi_poi.js
+++ b/src/adapters/poi/bragi_poi.js
@@ -48,8 +48,8 @@ export default class BragiPoi extends Poi {
     switch (type) {
     case 'poi':
       name = geocodingProps.name;
-      alternativeName = address && address.label
-        || cityObj && cityObj.label
+      alternativeName = (address && address.label)
+        || (cityObj && cityObj.label)
         || [postcode, city, countryName].filter(zone => zone).join(', ');
       break;
     case 'house':


### PR DESCRIPTION
Follow-up of https://github.com/QwantResearch/erdapfel/pull/491#discussion_r360386669.

Until now, the linter was complaining when parens were used unnecessarily in conditions even though it'd make the reading better. This PR relax this rule a bit.