### PR TITLE
Optim: use a single data source for drawing route and outline

### DIFF
--- a/src/adapters/route_styles.js
+++ b/src/adapters/route_styles.js
@@ -2,29 +2,20 @@ import Color from 'color';
 
 const darkenColor = hex => Color(hex).mix(Color('black'), 0.33).hex();
 
-const INACTIVE_ROUTE_COLOR = '#c8cbd3';
 const ACTIVE_ROUTE_COLOR = '#4ba2ea';
-const DYNAMIC_COLOR_EXPRESSION = ['case', ['has', 'lineColor'],
-  ['concat', '#', ['get', 'lineColor']],
-  ACTIVE_ROUTE_COLOR,
-];
+const INACTIVE_ROUTE_COLOR = '#c8cbd3';
 const INACTIVE_ROUTE_COLOR_OUTLINE = darkenColor(INACTIVE_ROUTE_COLOR);
-const ACTIVE_ROUTE_COLOR_OUTLINE = darkenColor(ACTIVE_ROUTE_COLOR);
 
-export function getOutlineFeature(feature) {
+export function prepareRouteColor(feature) {
   const properties = { ...feature.properties };
-  properties.lineColor = properties.lineColor
-    ? darkenColor('#' + properties.lineColor).substring(1)
-    : ACTIVE_ROUTE_COLOR_OUTLINE.substring(1);
-  return {
-    ...feature,
-    properties,
-  };
+  properties.lineColor = properties.lineColor ? `#${properties.lineColor}` : ACTIVE_ROUTE_COLOR;
+  properties.outlineColor = darkenColor(properties.lineColor);
+  return { ...feature, properties };
 }
 
 function getColorExpression(isActive, isOutline) {
   if (isActive) {
-    return DYNAMIC_COLOR_EXPRESSION;
+    return isOutline ? ['get', 'outlineColor'] : ['get', 'lineColor'];
   }
   return isOutline ? INACTIVE_ROUTE_COLOR_OUTLINE : INACTIVE_ROUTE_COLOR;
 }


### PR DESCRIPTION
## Description
Changes the way we draw route outlines.
They are still separate layers with a darker color, drawn below the main ones, but now both use the same GeoJSON data source, instead of requiring it to be duplicated.

## Why
Reducing map operations and mem footprint for the route features, especially when displaying complex routes. 
We also get a bit of simplification with how the colors themselves are managed, with less fiddling between hex strings with or without '#'.