### PR TITLE
server: Avoid mutating req headers during serialization

### DIFF
--- a/bin/serializers/request.js
+++ b/bin/serializers/request.js
@@ -25,6 +25,8 @@ const allowedHeadersRules = [
 module.exports = function(config) {
   return req => {
     const reqObject = bunyan.stdSerializers.req(req);
+    // Shallow copy headers to avoid mutating `req`
+    reqObject.headers = { ...reqObject.headers };
     const headers = reqObject.headers;
     for (const k in headers) {
       // geoip headers are utf8 encoded


### PR DESCRIPTION
While investigation client-side cache behavior, I noticed that headers such as `If-None-Match` and `If-Modified-Since` were ignored by Express.

It is due to a side-effect in the "req" serializer. Headers filtering is applied on an object that is shared with the original `req` object.

This behavior was introduced in #377. It probably doesn't have any impact in production though, as another reverse-proxy could handle this cache-related headers .

