### PR TITLE
Remove activePoiId from the global app state

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -13,6 +13,7 @@ PoiPopup.prototype.init = function(map) {
   this.map = map;
   this.popupHandle = null;
   this.timeOutHandler = null;
+  this.activePoiId = null;
 
   listen('open_popup', (poi, e) => {
     if (Device.isMobile() || isTouchEvent(e)) {
@@ -21,7 +22,8 @@ PoiPopup.prototype.init = function(map) {
     this.createPJPopup(poi, e);
   });
   listen('close_popup', () => this.close());
-
+  listen('map_mark_poi', poi => { this.activePoiId = poi.id; });
+  listen('clean_marker', () => { this.activePoiId = null; });
 };
 
 PoiPopup.prototype.addListener = function(layer) {
@@ -31,7 +33,7 @@ PoiPopup.prototype.addListener = function(layer) {
     }
     this.timeOutHandler = setTimeout(() => {
       const poi = e.features[0];
-      if (window.app.activePoiId === poi.properties.global_id) {
+      if (this.activePoiId === poi.properties.global_id) {
         return;
       }
       this.createOSMPopup(poi, e.originalEvent);

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -95,7 +95,6 @@ export default class AppPanel {
 
     this.router.addRoute('POI', '/place/(.*)', async (poiUrl, options = {}) => {
       const poiId = poiUrl.split('@')[0];
-      this.activePoiId = poiId;
       this.openPoi({ ...options, poiId });
     });
 
@@ -183,9 +182,6 @@ export default class AppPanel {
 
   _openPanel(panelToOpen, options = {}) {
     this.unminify();
-    if (panelToOpen !== this.poiPanel) {
-      this.activePoiId = null;
-    }
     this.panels
       .filter(panel => panel !== panelToOpen)
       .forEach(panel => {


### PR DESCRIPTION
## Description
Use the event system in place of a global to remember the active POI, which is used only for an exception in the popup manager to avoid displaying a popup on the currently active POI, as full info is already available in the panel.

## Why
Simplify `app_panel`, reduce globals and exception rules which lead to bugs.