### PR TITLE
Public transport: API results changes

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -90,7 +90,3 @@ export const originDestinationCoords = route => {
     destination: last(last(fc.features).geometry.coordinates),
   };
 };
-
-export function sanitizeStationName(name) {
-  return (name || '').replace(/\s*\(.*\)$/, '');
-}

--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -6,9 +6,7 @@ import { getTransportTypeIcon } from 'src/libs/route_utils';
 
 const TransportLineLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
-  const { mode, info = {}, stops = [] } = leg;
-  const from = stops[0];
-  const to = stops[stops.length - 1];
+  const { mode, info = {}, stops = [], from, to } = leg;
 
   return <RoadMapItem
     icon={getTransportTypeIcon(leg)}
@@ -28,7 +26,9 @@ const TransportLineLeg = ({ leg }) => {
       <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />
     </div>
     {detailsOpen && <div className="itinerary_roadmap_substeps">
+      <div>{from.name}</div>
       {stops.map((stop, index) => <div key={index}>{stop.name}</div>)}
+      <div>{to.name}</div>
     </div>}
   </RoadMapItem>;
 };

--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import RoadMapItem from './RoadMapItem';
 import PublicTransportLine from './PublicTransportLine';
 import LegLine from './LegLine';
-import { getTransportTypeIcon, sanitizeStationName } from 'src/libs/route_utils';
+import { getTransportTypeIcon } from 'src/libs/route_utils';
 
 const TransportLineLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
@@ -22,17 +22,13 @@ const TransportLineLeg = ({ leg }) => {
       <div>
         <PublicTransportLine mode={mode} info={info} />
         {!detailsOpen && from.name && to.name && <div>
-          {sanitizeStationName(from.name)}{' '}
-          <i className="icon-chevrons-right" />{' '}
-          {sanitizeStationName(to.name)}
+          {from.name} <i className="icon-chevrons-right" /> {to.name}
         </div>}
       </div>
       <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />
     </div>
     {detailsOpen && <div className="itinerary_roadmap_substeps">
-      {stops.map((stop, index) => <div key={index}>
-        {sanitizeStationName(stop.name)}
-      </div>)}
+      {stops.map((stop, index) => <div key={index}>{stop.name}</div>)}
     </div>}
   </RoadMapItem>;
 };


### PR DESCRIPTION
## Description
The public transport route results had some changes. This PR adapt the front code to two of them:
- The stop names don't include the city name anymore, so we can remove our sanitation function.
- The first and last stops of a leg are now attached to the leg object itself and are not present in the array of intermediary stops.

## Why
Follow up to https://github.com/QwantResearch/idunn/pull/104