### PR TITLE
Fix focused search bar appearing on top of menu button

### DIFF
--- a/src/scss/includes/z_index.scss
+++ b/src/scss/includes/z_index.scss
@@ -38,8 +38,10 @@
   z-index: 3;
 }
 
-.top_bar--search_focus {
-  z-index: 4;
+@media (max-width: 640px) {
+  .top_bar--search_focus {
+    z-index: 4;
+  }
 }
 
 .menu__overlay {


### PR DESCRIPTION
## Description
Only allow focused top bar to overlap the hamburger menu button on mobile layout.

Fix this bug (small viewport but still wide enough to use the desktop layout):
![Capture d’écran de 2020-01-07 14-54-41](https://user-images.githubusercontent.com/243653/71900373-02177500-315e-11ea-8702-0751ea29daf6.png)



