### PR TITLE
Fix horizontal scroll on Safari

### DIFF
--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -1,12 +1,11 @@
 /* globals _ */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { menu as menuItems } from '../../config/constants.yml';
 import nconf from '@qwant/nconf-getter';
 import MenuItem from './menu/MenuItem';
 import MenuButton from './menu/MenuButton';
 import MasqStatus from './menu/MasqStatus';
 import Store from '../adapters/store';
-import classnames from 'classnames';
 
 const isDirectionActive = nconf.get().direction.enabled;
 const isMasqEnabled = nconf.get().masq.enabled;
@@ -62,19 +61,13 @@ export default class Menu extends React.Component {
       return null;
     }
 
-    return <div>
-      <div
-        className={classnames('menu__overlay', {
-          'menu__overlay--active': this.state.isOpen,
-          'menu__overlay--fade_active': this.state.isOpen,
-        })}
-        onClick={this.close}
-      />
-
+    return <Fragment>
       <MenuButton masqUser={this.state.masqUser} onClick={this.open} />
 
-      <div className="menu">
-        <div className={classnames('menu__panel', { 'menu__panel--active': this.state.isOpen })}>
+      {this.state.isOpen && <div className="menu">
+        <div className="menu__overlay" onClick={this.close} />
+
+        <div className="menu__panel">
           <div className="menu__panel__top">
             <h2 className="menu__panel__top__title">
               <i className="menu__panel__top__icon icon-map" />
@@ -118,7 +111,7 @@ export default class Menu extends React.Component {
             {menuItems.map(menuItem => <MenuItem key={menuItem.sectionName} menuItem={menuItem} />)}
           </div>
         </div>
-      </div>
-    </div>;
+      </div>}
+    </Fragment>;
   }
 }

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -1,41 +1,33 @@
+@keyframes appearMenu {
+  0% { transform: translateX(460px); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes appearOverlay {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
 .menu__overlay {
-  display: none;
+  display: block;
   height: 100%;
   width: 100vw;
   position: absolute;
   top:0;
   left: 0;
   background: linear-gradient(to bottom, rgba(108,118,148,0.98),rgba(53,60,82,0.98));
-}
-
-.menu__overlay--active {
-  display: block;
-  opacity: 0;
-  transition: opacity .6s;
-
-  .menu {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-}
-
-.menu__overlay--fade_active {
-  opacity: 1;
+  animation: appearOverlay 0.3s forwards;
 }
 
 .menu__panel {
   position: absolute;
   width: 460px;
   height: 100%;
-  right: -460px;
-  transition: right .3s;
+  right: 0;
   background: #fff;
-  visibility: hidden;
   display: flex;
   flex-direction: column;
+  animation: appearMenu 0.3s forwards;
 }
 
 .menu__panel__items_container {
@@ -74,11 +66,6 @@
   top: 18px;
   padding: 5px;
   color: $primary_clear;
-}
-
-.menu__panel--active {
-  visibility: visible;
-  right: 0;
 }
 
 .menu__panel__section__icon {
@@ -182,7 +169,7 @@
     }
   }
 
-  .menu__panel--active {
+  .menu__panel {
     width: 100%;
   }
 }

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -14,31 +14,23 @@ beforeAll(async () => {
 });
 
 
-test('test menu template', async () => {
-  expect.assertions(2);
+test('test menu toggling', async () => {
+  expect.assertions(3);
   await page.goto(APP_URL);
   page.waitForSelector('.menu__button');
-
-  let panelPosition = await page.evaluate(() => {
-    return window.innerWidth - document.querySelector('.menu__panel').offsetLeft;
-  });
-
-  expect(panelPosition).toEqual(0);
+  let panel = await page.waitForSelector('.menu__panel', { hidden: true });
+  expect(panel).toBeNull();
 
   await page.click('.menu__button');
-  await wait(600);
-
-  panelPosition = await page.evaluate(() => {
-    return window.innerWidth - document.querySelector('.menu__panel').offsetLeft;
-  });
+  panel = await page.waitForSelector('.menu__panel', { visible: true });
+  expect(panel).not.toBeNull();
 
   await page.click('.menu__panel__top__close');
-  await wait(600);
-  expect(panelPosition).toEqual(460);
+  panel = await page.waitForSelector('.menu__panel', { hidden: true });
+  expect(panel).toBeNull();
 });
 
 test('menu open favorite', async () => {
-  await page.goto(APP_URL);
   expect.assertions(2);
   await page.goto(APP_URL);
   page.waitForSelector('.menu__button');


### PR DESCRIPTION
Fix the iOS Safari bug where the site content could be "swiped" to the left.
It was due to the way we managed our app menu appearance animation: the menu panel was rendered in the DOM but hidden and positioned in absolute on the right side of the viewport with a `right` negative value, waiting to be translated to the left on activation. This caused Safari to think the body content included this hidden menu, so it was possible to scroll to where it was.

This PR changes how we manage the menu apparition in several ways:
1) the menu panel and overlay are not rendered anymore by React when closed, as it should, resulting in a simpler component and DOM
2) as a result, we don't need to change their visibility and use separate classes for fading status. We just use a `forwards` animation which is played once when the element is added to the DOM.
3) instead of using the `right` property to animate the panel translation, we use `translateX`, which has the benefit of being GPU-accelerated, reducing the risk of a laggy transition on old devices.