### PR TITLE
[Clean up][Tests] Remove arbitrary `wait` calls in integration suite

### DIFF
--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser, wait } from '../tools';
+import { clearStore, initBrowser } from '../tools';
 import { storePoi } from '../favorites_tools';
 import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
@@ -66,8 +66,6 @@ test('keyboard navigation', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait(TypedSearch);
-  await wait(100);
-
   await autocompleteHelper.pressDown();
   await autocompleteHelper.pressDown();
 
@@ -105,12 +103,11 @@ test('keyboard navigation', async () => {
 
   /* select suggestion via Enter, should close the container */
   await page.keyboard.press('Enter');
-  await wait(300);
-  await page.waitForSelector('div.autocomplete_suggestions', { hidden: true, timeout: 1000 });
+  await page.waitForSelector('div.autocomplete_suggestions', { hidden: true });
 
   /* type another char */
   await autocompleteHelper.typeAndWait('a');
-  await wait(300);
+  await page.waitFor(300);
   selectElemPosition = await autocompleteHelper.getSelectedElementPos();
   expect(selectElemPosition).toEqual(-1);
 });
@@ -120,8 +117,6 @@ test('mouse navigation', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait(TypedSearch);
-  await wait(100);
-
   await autocompleteHelper.hoverResult(1);
 
   const selectElemPosition = await autocompleteHelper.getSelectedElementPos();
@@ -143,8 +138,7 @@ test('move to on click', async () => {
   const map_position_before = await page.evaluate(() => {
     return window.MAP_MOCK.center;
   });
-  await page.keyboard.type('Hello');
-  await page.waitForSelector('.autocomplete_suggestion');
+  await autocompleteHelper.typeAndWait('Hello');
   await page.click('.autocomplete_suggestion:nth-child(3)');
   const map_position_after = await page.evaluate(() => {
     return window.MAP_MOCK.center;
@@ -159,7 +153,6 @@ test('bbox & center', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
   await page.keyboard.type('Hello');
-  await wait(100);
   await page.waitForSelector('.autocomplete_suggestion');
   await page.click('.autocomplete_suggestion:nth-child(1)');
   const { center, zoom } = await page.evaluate(() => {
@@ -169,7 +162,7 @@ test('bbox & center', async () => {
   expect(zoom).toEqual(18);
 
   await page.keyboard.type('Hello');
-  await wait(100);
+  await page.waitFor(100);
   await page.waitForSelector('.autocomplete_suggestion');
   await page.click('.autocomplete_suggestion:nth-child(2)');
   const newCenter = await page.evaluate(() => {
@@ -194,10 +187,9 @@ test('submit key', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await page.goto(APP_URL);
   /* submit with data already loaded */
-  await page.keyboard.type('Hello');
-  await wait(150);
+  await autocompleteHelper.typeAndWait('Hello');
   await page.keyboard.press('Enter');
-  await wait(30);
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
 
   let center = await page.evaluate(() => {
     return window.MAP_MOCK.getCenter();
@@ -211,8 +203,7 @@ test('submit key', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=paris/);
   await page.keyboard.type('paris');
   await page.keyboard.press('Enter');
-
-  await wait(150);
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
 
   center = await page.evaluate(() =>
     window.MAP_MOCK.getCenter()
@@ -227,7 +218,6 @@ test('check template', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=type/);
   await page.goto(APP_URL);
   await page.keyboard.type('type');
-  await wait(100);
   await page.waitForSelector('.autocomplete_suggestion');
 
   const lines = await page.evaluate(() => {

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser, wait } from '../tools';
+import { clearStore, initBrowser } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 
 let browser;
@@ -36,16 +36,16 @@ test('menu open favorite', async () => {
   page.waitForSelector('.menu__button');
 
   page.click('.menu__button');
-  await wait(600);
-
+  await page.waitForSelector('.menu__panel__action');
   page.click('.menu__panel__action:nth-child(2)');
+
   const itinerary = await page.waitForSelector('.direction_panel');
   expect(itinerary).not.toBeNull();
-  await wait(600);
+
   page.click('.menu__button');
-  await wait(600);
+  await page.waitForSelector('.menu__panel__action');
   page.click('.menu__panel__action:nth-child(3)');
-  await wait(600);
+
   const favorites = await page.waitForSelector('.favorite_panel');
   expect(favorites).not.toBeNull();
 });

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -1,7 +1,7 @@
 const poiMock = require('../../__data__/poi.json');
 
 import ResponseHandler from '../helpers/response_handler';
-import { initBrowser, getText, wait, clearStore } from '../tools';
+import { initBrowser, getText, clearStore } from '../tools';
 import { getFavorites, toggleFavoritePanel, storePoi } from '../favorites_tools';
 import { languages } from '../../../config/constants.yml';
 
@@ -122,7 +122,6 @@ test('open poi from autocomplete selection', async () => {
   await page.keyboard.type('test');
   await page.waitForSelector('.autocomplete_suggestion');
   await page.click('.autocomplete_suggestion:nth-child(2)');
-  await wait(300);
   const location = await page.evaluate(() => {
     return document.location;
   });
@@ -141,7 +140,6 @@ test('center the map to the poi on a poi click', async () => {
   await page.evaluate(() => {
     window.MAP_MOCK.flyTo({ center: { lat: 0, lng: 0 }, zoom: 10 });
   });
-  await wait(300);
   await page.click('.poi_panel__content .poi_panel__description_container');
   const center = await page.evaluate(() => {
     return window.MAP_MOCK.getCenter();
@@ -164,7 +162,6 @@ test('display details about the poi on a poi click', async () => {
   expect(infoTitle.trim()).toEqual('Accessible en fauteuil roulant.');
   await page.click('.poi_panel__block__collapse');
 
-  await wait(300);
   infoTitle = await page.evaluate(() => {
     return document.querySelector('.poi_panel__sub_block__title').innerText;
   });
@@ -256,7 +253,6 @@ async function selectPoiLevel(page, level) {
   const mockPoiBounds = await page.$('#mock_poi').then(e => e.boundingBox());
   // Click on the top-left corner
   await page.mouse.click(mockPoiBounds.x, mockPoiBounds.y);
-  await wait(300);
 }
 
 test('add a poi as favorite and find it back in the favorite menu', async () => {

--- a/tests/integration/tools.js
+++ b/tests/integration/tools.js
@@ -1,14 +1,6 @@
 /* globals puppeteerArguments */
 import puppeteer from 'puppeteer';
 
-export const wait = async function wait(t = 1000) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(t);
-    }, t);
-  });
-};
-
 export const getText = async function(page, selector) {
   return await page.evaluate(selector => {
     return document.querySelector(selector).textContent;


### PR DESCRIPTION
## Description
Remove most of the imperative calls to a `wait` function in the integration tests.
- Most of them are useless as they are followed by a normal `waitForSelector` call which is already waiting for something to happen and is much cleaner.
- For two tests which I couldn't make work without an explicit wait time (I don't know why…), replace our custom `wait` util by the [Puppeteer native version](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagewaitforselectororfunctionortimeout-options-args), no need to re-invent the wheel

## Why
 - Simplify and speed up tests, as some incompressible run times will be removed.
 - Remove the use of arbitrary wait values which have no precise meaning, so it's easier to focus on the test case logic