### PR TITLE
Fix: Remove map routes when origin or dest is removed

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -85,12 +85,6 @@ Scene.prototype.initMapBox = function() {
   this.mb.on('load', () => {
     this.onHashChange();
     new SceneDirection(this.mb);
-    listen('set_route', () => {
-      this.routeDisplayed = true;
-    });
-    listen('clean_route', () => {
-      this.routeDisplayed = false;
-    });
     new SceneCategory(this.mb);
     new SceneEvent(this.mb);
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -126,6 +126,7 @@ export default class DirectionPanel extends React.Component {
       }
     } else {
       this.setState({ isDirty: false, routes: [] });
+      fire('clean_route');
     }
   }
 


### PR DESCRIPTION
## Description
Correctly remove the route results from the map view when one of the points (origin or destination) is cleared from the form.
The roadmap results were already removed, but the map still displayed the paths, which is inconsistent
UX.

This is probably a regression introduced when the DirectionPanel was migrated to React.

Also remove 2 related listeners in `scene.js`, obsolete since https://github.com/QwantResearch/erdapfel/pull/523 has been merged.
