### PR TITLE
Fix: Ensure we always work with a 'real' POI object in directions

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -10,6 +10,7 @@ import nconf from '@qwant/nconf-getter';
 import { toUrl as poiToUrl, fromUrl as poiFromUrl } from 'src/libs/pois';
 import { DeviceContext } from 'src/libs/device';
 import Error from 'src/adapters/error';
+import Poi from 'src/adapters/poi/poi.js';
 
 // this outside state is used to restore origin/destination when returning to the panel after closing
 const persistentPointState = {
@@ -49,7 +50,8 @@ export default class DirectionPanel extends React.Component {
     this.state = {
       vehicle: activeVehicle,
       origin: persistentPointState.origin || null,
-      destination: props.poi || persistentPointState.destination || null,
+      destination:
+        (props.poi && Poi.deserialize(props.poi)) || persistentPointState.destination || null,
       isLoading: false,
       isDirty: true, // useful to track intermediary states, when API update call is not made yet
       error: false,
@@ -216,7 +218,6 @@ export default class DirectionPanel extends React.Component {
       routes, error, activePreviewRoute,
       isLoading, isDirty, isInitializing,
     } = this.state;
-
     const title = <h3 className="itinerary_title">{_('directions', 'direction')}</h3>;
     const form = <DirectionForm
       origin={origin}


### PR DESCRIPTION
## Description
Fix for a bug (currently in prod) which occurs in the following conditions:
 1. click on a POI => the POI panel opens
 2. click on "Directions" => the direction panel opens with the POI auto-filled as destination point
 3. close the Direction panel by clicking on the black cross => the previous POI panel is restored 
 4. click once more on "Directions" => the direction panel crashes with a console error message `getInputValue is not a function`"

## Why
This happens because across the app, POI can exist under two different states:
 - a) as instances of the `POI` class, or one of its children, with access to some attached methods
 - b) as JS "flat" objects, after serialization, for example in the browser history
During the 3rd step listed above, the POI goes from a) to b), losing access to method such as `getInputValue`
Passing from b) to a) requires explicit serialization, which this PR adds.

This is a quick fix.
To prevent such bugs in the future, we need to finish the work started in https://github.com/QwantResearch/erdapfel/pull/491, so POI can only exist in the b) state, with external pure functions to manipulate them instead of class methods.