### PR TITLE
[Mobile][Routes] Display multiple results summaries

### DIFF
--- a/src/components/ui/ItemList.jsx
+++ b/src/components/ui/ItemList.jsx
@@ -6,8 +6,8 @@ const Item = ({ children, className = '', ...rest }) =>
     {children}
   </div>;
 
-const ItemList = ({ children, className = '' }) =>
-  <div className={classnames('itemList', className)}>
+const ItemList = ({ children, hover, className = '' }) =>
+  <div className={classnames('itemList', { 'itemList--hover': hover }, className)}>
     {children}
   </div>;
 

--- a/src/panel/category/PoiCategoryItemList.jsx
+++ b/src/panel/category/PoiCategoryItemList.jsx
@@ -8,7 +8,7 @@ const PoiCategoryItems = ({
   highlightMarker,
   onShowPhoneNumber,
 }) =>
-  <ItemList className="category__panel__items">
+  <ItemList hover className="category__panel__items">
     {pois.map(poi => <Item key={poi.id}
       onClick={() => { selectPoi(poi); }}
       onMouseOver={() => { highlightMarker(poi, true); }}

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import NavigatorGeolocalisationPoi, { navigatorGeolocationStatus } from
   'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import Suggest from 'src/adapters/suggest';
+import Error from 'src/adapters/error';
 
 export default class DirectionInput extends React.Component {
   static propTypes = {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -1,5 +1,5 @@
 /* globals _ */
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'src/components/ui/Panel';
 import DirectionForm from './DirectionForm';
@@ -11,6 +11,8 @@ import { toUrl as poiToUrl, fromUrl as poiFromUrl } from 'src/libs/pois';
 import { DeviceContext } from 'src/libs/device';
 import Error from 'src/adapters/error';
 import Poi from 'src/adapters/poi/poi.js';
+import { getAllSteps } from 'src/libs/route_utils';
+import MobileRoadMapPreview from './MobileRoadMapPreview';
 
 // this outside state is used to restore origin/destination when returning to the panel after closing
 const persistentPointState = {
@@ -237,21 +239,31 @@ export default class DirectionPanel extends React.Component {
       origin={origin && origin.getInputValue()}
       destination={destination && destination.getInputValue()}
       openMobilePreview={this.openMobilePreview}
-      previewRoute={activePreviewRoute}
     />;
 
     return <DeviceContext.Consumer>
       {isMobile => isMobile
-        ? <div className="direction_panel_mobile">
-          <div className="itinerary_close_mobile" onClick={this.onClose}>
-            <span className="icon-chevron-left" />
-            {_('return', 'direction')}
+        ? <Fragment>
+          <div className="direction_panel_mobile">
+            <div className="itinerary_close_mobile" onClick={this.onClose}>
+              <span className="icon-chevron-left" />
+              {_('return', 'direction')}
+            </div>
+            {title}
+            {!activePreviewRoute && form}
           </div>
-          {title}
-          {!activePreviewRoute && form}
-          {result}
-        </div>
-        : <Panel title={title} close={this.onClose} className="direction_panel">
+          {(routes.length > 0 || isLoading) && !activePreviewRoute &&
+            <Panel className="directionResult_panel">
+              {result}
+            </Panel>}
+          {activePreviewRoute &&
+            <MobileRoadMapPreview steps={getAllSteps(activePreviewRoute)} />}
+        </Fragment>
+        : <Panel
+          title={title}
+          close={this.onClose}
+          className="direction_panel"
+        >
           {form}
           {result}
         </Panel>

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -5,6 +5,7 @@ import Route from './Route';
 import { getVehicleIcon, getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
 import classnames from 'classnames';
+import { Item, ItemList } from 'src/components/ui/ItemList';
 
 export default class RouteResult extends React.Component {
   static propTypes = {
@@ -109,20 +110,23 @@ export default class RouteResult extends React.Component {
       <div className={classnames('itinerary_result', {
         'itinerary_result--publicTransport': this.props.vehicle === 'publicTransport',
       })}>
-        {this.props.routes.map((route, index) => <Route
-          key={index}
-          id={index}
-          route={route}
-          origin={this.props.origin}
-          destination={this.props.destination}
-          vehicle={this.props.vehicle}
-          isActive={this.state.activeRouteId === index}
-          showDetails={this.state.activeRouteId === index && this.state.activeDetails}
-          openDetails={this.openRouteDetails}
-          openPreview={this.openPreview}
-          selectRoute={this.selectRoute}
-          hoverRoute={this.hoverRoute}
-        />)}
+        <ItemList>
+          {this.props.routes.map((route, index) => <Item key={index}>
+            <Route
+              id={index}
+              route={route}
+              origin={this.props.origin}
+              destination={this.props.destination}
+              vehicle={this.props.vehicle}
+              isActive={this.state.activeRouteId === index}
+              showDetails={this.state.activeRouteId === index && this.state.activeDetails}
+              openDetails={this.openRouteDetails}
+              openPreview={this.openPreview}
+              selectRoute={this.selectRoute}
+              hoverRoute={this.hoverRoute}
+            />
+          </Item>)}
+        </ItemList>
       </div>
       {this.props.vehicle === 'publicTransport' && this.props.routes.length > 0 &&
       <div className="itinerary_source">

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Route from './Route';
-import { getVehicleIcon, getAllSteps } from 'src/libs/route_utils';
-import MobileRoadMapPreview from './MobileRoadMapPreview';
+import { getVehicleIcon } from 'src/libs/route_utils';
 import classnames from 'classnames';
 import { Item, ItemList } from 'src/components/ui/ItemList';
 
@@ -15,7 +14,6 @@ export default class RouteResult extends React.Component {
     vehicle: PropTypes.string,
     isLoading: PropTypes.bool,
     error: PropTypes.bool,
-    previewRoute: PropTypes.object,
     openMobilePreview: PropTypes.func.isRequired,
   }
 
@@ -81,29 +79,29 @@ export default class RouteResult extends React.Component {
 
     if (this.props.isLoading) {
       return <div className="itinerary_result">
-        <div className="itinerary_leg itinerary_leg--placeholder">
-          <div className="itinerary_leg_summary">
-            <div className={`itinerary_leg_icon ${getVehicleIcon(this.props.vehicle)}`} />
-            <div className="itinerary_leg_via">
-              <div className="itinerary_placeholder-box" style={{ width: '133px' }} />
-              <div className="itinerary_placeholder-box" style={{ width: '165px' }} />
-              <div className="itinerary_placeholder-box" style={{ width: '70px' }} />
-            </div>
-            <div className="itinerary_leg_info">
-              <div className="itinerary_leg_duration">
-                <div className="itinerary_placeholder-box" style={{ width: '47px' }} />
+        <ItemList>
+          <Item>
+            <div className="itinerary_leg itinerary_leg--placeholder">
+              <div className="itinerary_leg_summary">
+                <div className={`itinerary_leg_icon ${getVehicleIcon(this.props.vehicle)}`} />
+                <div className="itinerary_leg_via">
+                  <div className="itinerary_placeholder-box" style={{ width: '133px' }} />
+                  <div className="itinerary_placeholder-box" style={{ width: '165px' }} />
+                  <div className="itinerary_placeholder-box" style={{ width: '70px' }} />
+                </div>
+                <div className="itinerary_leg_info">
+                  <div className="itinerary_leg_duration">
+                    <div className="itinerary_placeholder-box" style={{ width: '47px' }} />
+                  </div>
+                  <div className="itinerary_leg_distance">
+                    <div className="itinerary_placeholder-box" style={{ width: '59px' }} />
+                  </div>
+                </div>
               </div>
-              <div className="itinerary_leg_distance">
-                <div className="itinerary_placeholder-box" style={{ width: '59px' }} />
-              </div>
             </div>
-          </div>
-        </div>
+          </Item>
+        </ItemList>
       </div>;
-    }
-
-    if (this.props.previewRoute) {
-      return <MobileRoadMapPreview steps={getAllSteps(this.props.previewRoute)} />;
     }
 
     return <div>

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -57,10 +57,11 @@ export default class RouteSummary extends React.Component {
       <div className="itinerary_panel__item__share" onClick={this.onClickShare}>
         <i className="icon-share-2" />
       </div>
-      <div className="itinerary_leg_preview" onClick={this.onClickPreview}>
-        <span className="itinerary_leg_preview_icon icon-navigation" />
-        {_('PREVIEW', 'direction')}
-      </div>
+      {vehicle !== 'publicTransport' &&
+        <div className="itinerary_leg_preview" onClick={this.onClickPreview}>
+          <span className="itinerary_leg_preview_icon icon-navigation" />
+          {_('PREVIEW', 'direction')}
+        </div>}
     </div>;
   }
 }

--- a/src/panel/favorites/FavoriteItems.jsx
+++ b/src/panel/favorites/FavoriteItems.jsx
@@ -13,7 +13,7 @@ const FavoriteItems = ({ favorites = [], removeFavorite }) => {
     />;
   }
 
-  return <ItemList className="favorite_panel__items">
+  return <ItemList hover className="favorite_panel__items">
     {favorites.map(favorite => <Item key={favorite.id}>
       <FavoritePoi poi={favorite} removeFavorite={removeFavorite} />
     </Item>)}

--- a/src/scss/includes/components/itemList.scss
+++ b/src/scss/includes/components/itemList.scss
@@ -1,11 +1,5 @@
 .itemList-item {
   background: $background;
-  border-left: 4px solid $background;
-
-  &:hover {
-    background: $surface;
-    border-left: 4px solid #FF3B4A;
-  }
 
   &:not(:last-child):after {
     display: block;
@@ -17,9 +11,19 @@
   }
 }
 
+.itemList--hover .itemList-item {
+  border-left: 4px solid $background;
+
+  &:hover {
+    background: $surface;
+    border-left: 4px solid #FF3B4A;
+  }
+}
+
 @media (max-width: 640px) {
   .itemList {
     padding-bottom: 12px;
+    margin: 0 15px;
   }
 
   .itemList-item {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -202,7 +202,6 @@ input:valid:focus + .itinerary__field__clear {
 }
 
 .itinerary_result {
-  background: $background;
   overflow: auto;
   max-height: calc(100vh - 290px);
 
@@ -213,7 +212,6 @@ input:valid:focus + .itinerary__field__clear {
 
 .itinerary_leg {
   position: relative;
-  background: $background;
 
   &:not(:last-child):after {
     content: '';
@@ -672,23 +670,19 @@ input:valid:focus + .itinerary__field__clear {
     padding: 9px 0 6px;
   }
 
-  .itinerary_leg {
-    position: fixed;
-    bottom: 10px;
-    left: 10px;
-    width: calc(100vw - 20px);
-    border-radius: 3px;
-    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.16);
-    display: none;
+  .panel.directionResult_panel {
+    height: auto;
 
-    &--active {
-      display: block;
+    .panel-header {
+      min-height: auto;
     }
   }
 
+  .itinerary_result .itemList-item {
+    overflow: hidden;
+  }
+
   .itinerary_leg_summary {
-    border-left: none !important;
-    pointer-events: none;
     display: grid;
     grid-template-areas: "info info actions" "via via actions";
   }
@@ -714,17 +708,20 @@ input:valid:focus + .itinerary__field__clear {
     margin-right: 6px;
   }
   
-  .itinerary_leg_preview {
-    pointer-events: all;
-    grid-area: actions;
-    justify-self: end;
-    display: block;
-    width: 110px;
-    height: 35px;
-    line-height: 35px;
-    border-radius: 50px;
-    border: 1px solid #c8cbd3;
-    font-weight: bold;
+  .itinerary_leg--active {
+    .itinerary_leg_preview {
+      pointer-events: all;
+      grid-area: actions;
+      justify-self: end;
+      display: block;
+      width: 110px;
+      height: 35px;
+      line-height: 35px;
+      border-radius: 50px;
+      border: 1px solid #c8cbd3;
+      font-weight: bold;
+      font-size: 12px;
+    }
   }
   
   .itinerary_leg_preview_icon {
@@ -746,6 +743,7 @@ input:valid:focus + .itinerary__field__clear {
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.16);
     width: calc(100% - 30px);
     user-select: none;
+    z-index: 3;
 
     .itinerary_roadmap_item {
       border-left: 0;

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -121,13 +121,6 @@
     padding-top: 0;
   }
 
-  .category__panel__items {
-    max-height: none;
-    height: 100%;
-    width: calc(100% - 32px);
-    margin: 0 16px;
-  }
-
   .category__panel__item {
     padding: 14px 10px 14px 16px;
   }

--- a/src/scss/includes/panels/favorite_panel.scss
+++ b/src/scss/includes/panels/favorite_panel.scss
@@ -128,9 +128,4 @@ $MASQ_BANNER_HEIGHT: 93px;
   .favorite_panel__masq_footer {
     display: none;
   }
-
-  .favorite_panel__items {
-    width: calc(100% - 40px);
-    margin: 0 20px;
-  }
 }


### PR DESCRIPTION
## Description
First step of providing better access to route results on mobile, so it has the same features as the desktop: display alternative summaries, and not only the first one.
For that we use a panel, potentially scrollable, instead of just a floating card.
We also make use of the generic `ListItem` component.

The step-by-step preview button is still accessible on the active alternative. I just disabled it for public transports as it's not adapted to this mode and further development will bring a better access to the roadmap.

Another thing that could be improved is fitting the map view to the route. I can add it to this PR, or do it separately.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 79994_2 35869 destination=latlon_48 81359_2 36296 mode=driving (1)](https://user-images.githubusercontent.com/243653/73470989-fef05d00-4388-11ea-8f8e-33eee1af0b72.png)|![localhost_3000_routes__origin=latlon_48 79994_2 35869 destination=latlon_48 81359_2 36296 mode=driving](https://user-images.githubusercontent.com/243653/73471017-057ed480-4389-11ea-8b88-8f2c84c6dc57.png)|
