### PR TITLE
[Clean-up] Prevent integration test log pollution

### DIFF
--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -13,13 +13,18 @@ let autocompleteHelper;
 let responseHandler;
 const mockAutocomplete = require('../../__data__/autocomplete.json');
 const mockAutocompleteAllTypes = require('../../__data__/autocomplete_type.json');
+const mockPoi = require('../../__data__/poi.json');
 
 beforeAll(async () => {
-  const browserPage = await initBrowser();
-  page = browserPage.page;
-  browser = browserPage.browser;
-  responseHandler = await ResponseHandler.init(page);
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
   autocompleteHelper = new AutocompleteHelper(page);
+  responseHandler = new ResponseHandler(page);
+  await responseHandler.prepareResponse();
+  responseHandler.addPreparedResponse(mockPoi, /places\/*/);
 });
 
 test('search and clear', async () => {


### PR DESCRIPTION
## Description
Clean the output of the integration test suite, which was polluted with lots of error messages.
The reason was the `autocomplete` test didn't mock the HTTP calls to the Idunn API, which is done when an item is selected in the address suggestion dropdown.
So, each time the test suite did that, it tried to make the real HTTP request to Idunn and got error messages in result (but tests passed nonetheless, as it wasn't the thing we tested there).

Result, when running `npm run integration-test tests/integration/tests/autocomplete.js`:

## Before
```
Determining test suites to run...Start test on PORT : 3000
  console.log tests/integration/tools.js:22
    > Headers aren't allowed, sending query without them...

  console.log tests/integration/tools.js:22
    > Failed to load resource: net::ERR_NAME_NOT_RESOLVED

  console.log tests/integration/tools.js:22
    > JSHandle@object

  console.log tests/integration/tools.js:22
    > Failed to load resource: net::ERR_NAME_NOT_RESOLVED

  console.log tests/integration/tools.js:22
    > Headers aren't allowed, sending query without them...

  console.log tests/integration/tools.js:22
    > Failed to load resource: net::ERR_NAME_NOT_RESOLVED

  console.log tests/integration/tools.js:22
    > JSHandle@object

  console.log tests/integration/tools.js:22
    > Failed to load resource: net::ERR_NAME_NOT_RESOLVED

  console.log tests/integration/tools.js:22
    > Headers aren't allowed, sending query without them...

  console.log tests/integration/tools.js:22
    > Failed to load resource: net::ERR_NAME_NOT_RESOLVED

  console.log tests/integration/tools.js:22
    > JSHandle@object

  console.log tests/integration/tools.js:22
    > Failed to load resource: net::ERR_NAME_NOT_RESOLVED

 PASS  tests/integration/tests/autocomplete.js (6.992s)
  ✓ search and clear (582ms)
  ✓ search has lang in query (518ms)
  ✓ keyboard navigation (737ms)
  ✓ mouse navigation (389ms)
  ✓ move to on click (343ms)
  ✓ center on select (332ms)
  ✓ favorite search (313ms)
  ✓ submit key (457ms)
  ✓ check template (325ms)
  ✓ Search Query (1023ms)
  ✓ Retrieve restaurant category when we search "restau" (335ms)
  ✓ Retrieve no category when we search "barcelona", not even "bar" (320ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        7.508s, estimated 10s
```

## After
```
Determining test suites to run...Start test on PORT : 3000
 PASS  tests/integration/tests/autocomplete.js (8.874s)
  ✓ search and clear (676ms)
  ✓ search has lang in query (501ms)
  ✓ keyboard navigation (945ms)
  ✓ mouse navigation (653ms)
  ✓ move to on click (592ms)
  ✓ center on select (518ms)
  ✓ favorite search (525ms)
  ✓ submit key (616ms)
  ✓ check template (471ms)
  ✓ Search Query (1028ms)
  ✓ Retrieve restaurant category when we search "restau" (534ms)
  ✓ Retrieve no category when we search "barcelona", not even "bar" (483ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        9.379s, estimated 13s

```
