### PR TITLE
Routes: fix repeating walk leg background on Firefox

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -438,7 +438,7 @@ input:valid:focus + .itinerary__field__clear {
 
   &--walk {
     background: url(../images/direction_icons/walking_bullet_roadmap.png) repeat space;
-    background-size: 7px;
+    background-size: 7px 10px;
   }
 }
 


### PR DESCRIPTION
## Description
Fix display of walk leg patterns on public transport roadmap, broken in recent versions of Firefox.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-02-03 à 15 17 47](https://user-images.githubusercontent.com/243653/73660742-19804a00-4699-11ea-8481-d746c574a6ca.png)|![Capture d’écran 2020-02-03 à 15 23 07](https://user-images.githubusercontent.com/243653/73660764-21d88500-4699-11ea-9a47-ca77a133a0dd.png)|
