### PR TITLE
Fix: prevent suggest list from reappearing on Firefox for Android

### DIFF
--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -290,13 +290,20 @@ export default function autoComplete(options) {
     };
     addEvent(that, 'keydown', that.keydownHandler);
 
-    that.inputHandler = function(e) {
+    that.inputHandler = function() {
       const val = that.value;
       if (val.length >= o.minChars) {
         if (val != that.last_val) {
           cancelObsolete();
           that.last_val = val;
           that.timer = setTimeout(function() {
+            // @HACK: a bug in Firefox for Android (https://bugzilla.mozilla.org/show_bug.cgi?id=1610083)
+            // triggers a redundant 'input' event on the field just before it's blurred,
+            // resulting in the suggest list re-appearing after a suggestion has been made.
+            // So we check if the element having the focus is the field before doing anything.            
+            if (document.activeElement && document.activeElement !== that) {
+              return;
+            }
             that.sourcePending = o.source(val);
             that.sourcePending.then(source => {
               that.sourcePending = null;


### PR DESCRIPTION
## Description
Fix the bug where the address/POI suggestion list reappears immediately after the user clicked on a suggestion.
The initial cause has been traced back to an already [reported bug on Firefox for Android](https://bugzilla.mozilla.org/show_bug.cgi?id=1610083), explaining while it affects only this platform.

To summarize, the browser triggers a redundant DOM `input` event on an input field just before it's blurred. As the rendering of the suggestion list is linked to a `input` events, it gets refreshed and re-displayed on this last event, even if the action resulting from the actual selection is resolved.

To fix that, I added an extra check in the input handler to make sure if the currently focused element (indicated by [`docmument.activeElement`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement)) is still the field. If not, we cancel the handler silently.
~~It also required the handler function to be put in a `setTimeout(…, 0)`, to artificially delay its execution  and make time for the browser to actually change the focus. Otherwise, the focused element will still be the field itself and the check won't work.~~ As the actual list DOM update was already in a `setTimeout`, I simply put the check in it.