### PR TITLE
[Routes] Display fullscreen roadmap 

### DIFF
--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import RouteVia from './RouteVia';
+import RoadMap from './RoadMap';
+import { formatDuration } from 'src/libs/route_utils';
+
+const MobileRouteDetails = ({ id, route, origin, destination, vehicle, toggleDetails }) => {
+  return <div className="itinerary_legDetails">
+    <div className="itinerary_legDetails_header">
+      <button className="itinerary_legDetails_back" onClick={() => { toggleDetails(id); }}>
+        <i className="icon-arrow-left" />
+      </button>
+      <RouteVia route={route} vehicle={vehicle} />
+      <div className="itinerary_leg_duration">
+        {formatDuration(route.duration)}
+      </div>
+    </div>
+    <RoadMap
+      route={route}
+      origin={origin}
+      destination={destination}
+      vehicle={vehicle} />
+    {vehicle === 'publicTransport' && <div className="itinerary_legDetails_source">
+      <a href="https://combigo.com/">
+        <img src="./statics/images/direction_icons/logo_combigo.svg" alt="" />
+        Combigo
+      </a>
+    </div>}
+  </div>;
+};
+
+export default MobileRouteDetails;

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -1,26 +1,41 @@
-import React from 'react';
+import React, { useContext, Fragment } from 'react';
+import MobileRouteDetails from './MobileRouteDetails';
 import RouteSummary from './RouteSummary';
 import RoadMap from './RoadMap';
+import { DeviceContext } from 'src/libs/device';
 
 const Route = ({
   id, route, vehicle, showDetails, origin, destination, isActive,
   toggleDetails, openPreview, selectRoute, hoverRoute,
-}) =>
-  <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
-    onMouseEnter={() => { hoverRoute(id, true); }}
-    onMouseLeave={() => { hoverRoute(id, false); }}
-  >
-    <RouteSummary id={id} route={route}
-      toggleDetails={toggleDetails}
-      openPreview={openPreview}
-      selectRoute={selectRoute}
-      vehicle={vehicle}
-    />
-    {showDetails && <RoadMap
+}) => {
+  const isMobile = useContext(DeviceContext);
+
+  return <Fragment>
+    <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
+      onMouseEnter={() => { hoverRoute(id, true); }}
+      onMouseLeave={() => { hoverRoute(id, false); }}
+    >
+      <RouteSummary id={id} route={route}
+        toggleDetails={toggleDetails}
+        openPreview={openPreview}
+        selectRoute={selectRoute}
+        vehicle={vehicle}
+      />
+      {!isMobile && showDetails && <RoadMap
+        route={route}
+        origin={origin}
+        destination={destination}
+        vehicle={vehicle} />}
+    </div>
+    {isMobile && showDetails && <MobileRouteDetails
+      id={id}
       route={route}
       origin={origin}
       destination={destination}
-      vehicle={vehicle} />}
-  </div>;
+      vehicle={vehicle}
+      toggleDetails={toggleDetails}
+    />}
+  </Fragment>;
+};
 
 export default Route;

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -4,14 +4,14 @@ import RoadMap from './RoadMap';
 
 const Route = ({
   id, route, vehicle, showDetails, origin, destination, isActive,
-  openDetails, openPreview, selectRoute, hoverRoute,
+  toggleDetails, openPreview, selectRoute, hoverRoute,
 }) =>
   <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
     onMouseEnter={() => { hoverRoute(id, true); }}
     onMouseLeave={() => { hoverRoute(id, false); }}
   >
     <RouteSummary id={id} route={route}
-      openDetails={openDetails}
+      toggleDetails={toggleDetails}
       openPreview={openPreview}
       selectRoute={selectRoute}
       vehicle={vehicle}

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -53,7 +53,7 @@ export default class RouteResult extends React.Component {
     fire('toggle_route', highlightMapRoute ? routeId : this.state.activeRouteId);
   }
 
-  openRouteDetails = routeId => {
+  toggleRouteDetails = routeId => {
     if (this.state.activeRouteId === routeId) {
       this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
     } else {
@@ -118,7 +118,7 @@ export default class RouteResult extends React.Component {
               vehicle={this.props.vehicle}
               isActive={this.state.activeRouteId === index}
               showDetails={this.state.activeRouteId === index && this.state.activeDetails}
-              openDetails={this.openRouteDetails}
+              toggleDetails={this.toggleRouteDetails}
               openPreview={this.openPreview}
               selectRoute={this.selectRoute}
               hoverRoute={this.hoverRoute}

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -57,11 +57,17 @@ export default class RouteSummary extends React.Component {
       <div className="itinerary_panel__item__share" onClick={this.onClickShare}>
         <i className="icon-share-2" />
       </div>
-      {vehicle !== 'publicTransport' &&
-        <div className="itinerary_leg_preview" onClick={this.onClickPreview}>
-          <span className="itinerary_leg_preview_icon icon-navigation" />
-          {_('PREVIEW', 'direction')}
-        </div>}
+      <div className="itinerary_leg_mobileActions">
+        {vehicle !== 'publicTransport' &&
+          <button className="itinerary_leg_preview" onClick={this.onClickPreview}>
+            <span className="itinerary_leg_preview_icon icon-navigation" />
+            {_('PREVIEW', 'direction')}
+          </button>}
+        {vehicle === 'publicTransport' &&
+          <button className="itinerary_leg_details" onClick={this.onClickDetails}>
+            {_('DETAILS', 'direction')}
+          </button>}
+      </div>
     </div>;
   }
 }

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -11,7 +11,7 @@ export default class RouteSummary extends React.Component {
     id: PropTypes.number.isRequired,
     route: PropTypes.object.isRequired,
     vehicle: PropTypes.string.isRequired,
-    openDetails: PropTypes.func.isRequired,
+    toggleDetails: PropTypes.func.isRequired,
     openPreview: PropTypes.func.isRequired,
     selectRoute: PropTypes.func.isRequired,
   }
@@ -22,7 +22,7 @@ export default class RouteSummary extends React.Component {
 
   onClickDetails = event => {
     event.stopPropagation();
-    this.props.openDetails(this.props.id);
+    this.props.toggleDetails(this.props.id);
   }
 
   onClickShare = () => {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -298,7 +298,7 @@ input:valid:focus + .itinerary__field__clear {
   color: $primary_text;
 }
 
-.itinerary_leg_preview {
+.itinerary_leg_mobileActions {
   display: none;
 }
 
@@ -684,7 +684,8 @@ input:valid:focus + .itinerary__field__clear {
 
   .itinerary_leg_summary {
     display: grid;
-    grid-template-areas: "info info actions" "via via actions";
+    grid-template-areas: "info actions" "via actions";
+    padding: 15px 18px;
   }
 
   .itinerary_leg_icon,
@@ -709,18 +710,24 @@ input:valid:focus + .itinerary__field__clear {
   }
   
   .itinerary_leg--active {
-    .itinerary_leg_preview {
-      pointer-events: all;
+    .itinerary_leg_mobileActions {
+      display: flex;
+      justify-content: flex-end;
       grid-area: actions;
-      justify-self: end;
-      display: block;
-      width: 110px;
-      height: 35px;
-      line-height: 35px;
-      border-radius: 50px;
-      border: 1px solid #c8cbd3;
-      font-weight: bold;
-      font-size: 12px;
+      margin-top: 9px;
+
+      button {
+        display: block;
+        pointer-events: all;
+        height: 35px;
+        line-height: 35px;
+        border-radius: 50px;
+        border: 1px solid #c8cbd3;
+        font-weight: bold;
+        font-size: 12px; 
+        margin-left: 6px;
+        padding: 0 9px;
+      }
     }
   }
   
@@ -730,7 +737,7 @@ input:valid:focus + .itinerary__field__clear {
     display: inline-block;
     vertical-align: middle;
     background-size: 100% auto;
-    margin: 0 10px 0 10px;
+    margin-right: 10px;
     font-size: 16px;
   }
   
@@ -753,27 +760,27 @@ input:valid:focus + .itinerary__field__clear {
       grid-template-columns: 48px;
       grid-column-gap: 12px;
     }
-  }
-  
-  .itinerary_roadmap_icon {
-    grid-area: icon;
-    width: 48px;
-    height: 48px;
-    background-size: contain;
-    margin: 0;
-  }
-  
-  .itinerary_roadmap_instruction {
-    grid-area: instruction;
-    padding: 0; 
-    border: none;
-  }
-  
-  .itinerary_roadmap_distance {
-    grid-area: distance;
-    text-align: left;
-    font-size: 16px;
-    margin: 0 0 5px;
+
+    .itinerary_roadmap_icon {
+      grid-area: icon;
+      width: 48px;
+      height: 48px;
+      background-size: contain;
+      margin: 0;
+    }
+
+    .itinerary_roadmap_instruction {
+      grid-area: instruction;
+      padding: 0;
+      border: none;
+    }
+
+    .itinerary_roadmap_distance {
+      grid-area: distance;
+      text-align: left;
+      font-size: 16px;
+      margin: 0 0 5px;
+    }
   }
   
   .itinerary_mobile_step_buttons {
@@ -832,5 +839,76 @@ input:valid:focus + .itinerary__field__clear {
 
   .itinerary_source {
     display: none;
+  }
+
+  @keyframes fullscreenLegDetails {
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+  }
+
+  .itinerary_legDetails {
+    background-color: white;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    overflow: auto;
+    z-index: 3;
+    animation: fullscreenLegDetails 0.3s forwards;
+
+    &_header {
+      position: sticky;
+      top: 0;
+      display: flex;
+      align-items: center;
+      padding: 12px 18px;
+      background-color: $background_active;
+      z-index: 1;
+
+      .icon-arrow-left {
+        font-size: 24px;
+        padding-right: 18px;
+      }
+
+      .routeVia {
+        flex-grow: 1;
+      }
+
+      .itinerary_leg_duration {
+        margin: 0 0 0 12px;
+      }
+    }
+
+    .itinerary_roadmap {
+      padding-bottom: 48px;
+    }
+
+    .itinerary_roadmap_item {
+      border-left: 0;
+      padding-left: 6px;
+    }
+
+    .itinerary_roadmap_line {
+      left: 27px;
+    }
+
+    &_source {
+      padding: 9px 18px 18px;
+      font-size: 12px;
+    
+      a {
+        display: flex;
+        align-items: center;
+        color: $primary_text;
+        text-transform: uppercase;
+        justify-content: flex-end;
+      }
+    
+      img {
+        height: 18px;
+        margin-right: 9px;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description
Introduces a new component `<MobileRouteDetails />` and custom styling to display a fullscreen panel with a single route summary and roadmap.
*For now* just plug it to public transport results via a new button (so it doesn't change anything in production for other modes), but when validated it will be made accessible for all transport modes via redesigned action buttons, alongside step-by-step "navigation".

I'll probably do also another PR to plug this panel behavior to the history system, so it's possible to close it with the device back button, but let's keep this one small and easy to review.

## Why
Give access to roadmaps on mobile, as for now it wasn't possible to display them.

## Screenshots
|'Details' button|After clicking|Roadmap is scrollable and expendable|
|---|---|---|
|![localhost_3000_routes__origin=osm_way_714032736@Parc_%C3%89mile_Zola destination=osm_node_241928557@Nation mode=publicTransport(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/74016995-aa09a380-4993-11ea-87e3-5e41dce3b482.png)|![localhost_3000_routes__origin=osm_way_714032736@Parc_%C3%89mile_Zola destination=latlon_48 85948_2 40188 mode=publicTransport(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/74016822-59924600-4993-11ea-9ddf-ba45b053b004.png)|![localhost_3000_routes__origin=osm_way_714032736@Parc_%C3%89mile_Zola destination=osm_node_241928557@Nation mode=publicTransport(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/74017007-b1c94800-4993-11ea-95ab-2adf66282850.png)|