### PR TITLE
Declare and use a generic Button component

### DIFF
--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import classnames from 'classnames';
+
+const Button = ({ children, icon, variant, className = '', type = 'button', onClick, ...rest }) =>
+  <button
+    type={type}
+    className={classnames('button', { [`button--${variant}`]: variant }, className)}
+    onClick={onClick}
+    {...rest}
+  >
+    {icon && <span className={`button-icon icon-${icon}`} />}
+    <div className="button-content">{children}</div>
+  </button>;
+
+export default Button;

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -5,6 +5,7 @@ import Telemetry from '../../libs/telemetry';
 import { openShareModal } from 'src/modals/ShareModal';
 import { formatDuration, formatDistance, getVehicleIcon } from 'src/libs/route_utils';
 import RouteVia from './RouteVia';
+import Button from 'src/components/ui/Button';
 
 export default class RouteSummary extends React.Component {
   static propTypes = {
@@ -59,14 +60,13 @@ export default class RouteSummary extends React.Component {
       </div>
       <div className="itinerary_leg_mobileActions">
         {vehicle !== 'publicTransport' &&
-          <button className="itinerary_leg_preview" onClick={this.onClickPreview}>
-            <span className="itinerary_leg_preview_icon icon-navigation" />
+          <Button className="itinerary_leg_preview" onClick={this.onClickPreview} icon="navigation">
             {_('PREVIEW', 'direction')}
-          </button>}
+          </Button>}
         {vehicle === 'publicTransport' &&
-          <button className="itinerary_leg_details" onClick={this.onClickDetails}>
+          <Button onClick={this.onClickDetails} icon="icon_list">
             {_('DETAILS', 'direction')}
-          </button>}
+          </Button>}
       </div>
     </div>;
   }

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PoiHeader from './PoiHeader';
 import PoiTitleImage from './PoiTitleImage';
 import OpeningHour from 'src/components/OpeningHour';
+import Button from 'src/components/ui/Button';
 
 class PoiCard extends React.Component {
   constructor(props) {
@@ -35,18 +36,18 @@ class PoiCard extends React.Component {
           <i className="icon-x" />
         </div>
         { !!openDirection &&
-          <button
-            className="poi_card__action poi_card__action__direction"
+          <Button
+            className="poi_card__action__direction"
+            variant="invert"
             onClick={openDirection}
+            icon="corner-up-right"
           >
-            <span className="icon-corner-up-right" />{' '}
             { _('DIRECTIONS', 'poi panel') }
-          </button>
+          </Button>
         }
-        <button className="poi_card__action" onClick={showDetails}>
-          <span className="icon-chevrons-right" />{' '}
+        <Button onClick={showDetails} icon="chevrons-right">
           { _('SEE MORE', 'poi panel') }
-        </button>
+        </Button>
       </div>
     </div>;
   }

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -1,0 +1,35 @@
+.button {
+  background-color: white;
+  display: inline-flex;
+  align-items: center;
+  height: 35px;
+  padding: 0 9px;
+  border-radius: 18px;
+  border: 1px solid $primary_clear;
+  font-size: 12px;
+  font-weight: 600;
+  color: $primary_text;
+  pointer-events: all;
+  cursor: pointer;
+
+  &--invert {
+    background-color: $primary_text;
+    border-color: $primary_text;
+    color: white;
+  }
+
+  &-content {
+    flex-grow: 1;
+    text-align: center;
+    /* secure long content */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &-icon {
+    vertical-align: middle;
+    margin-right: 6px;
+    font-size: 16px;
+  }
+}

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -715,30 +715,7 @@ input:valid:focus + .itinerary__field__clear {
       justify-content: flex-end;
       grid-area: actions;
       margin-top: 9px;
-
-      button {
-        display: block;
-        pointer-events: all;
-        height: 35px;
-        line-height: 35px;
-        border-radius: 50px;
-        border: 1px solid #c8cbd3;
-        font-weight: bold;
-        font-size: 12px; 
-        margin-left: 6px;
-        padding: 0 9px;
-      }
     }
-  }
-  
-  .itinerary_leg_preview_icon {
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-    vertical-align: middle;
-    background-size: 100% auto;
-    margin-right: 10px;
-    font-size: 16px;
   }
   
   .itinerary_mobile_step {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -603,27 +603,11 @@ $HEADER_SIZE: 40px;
     }
   }
 
-  &__action {
-    display: block;
-    width: 112px;
-    height: 35px;
-    line-height: 35px;
-    border: 1px solid $primary_clear;
-    font-size: 12px;
-    font-weight: 600;
-    color: $primary_text;
-    border-radius: 18px;
-    cursor: pointer;
-    text-align: center;
-    /* secure  long translation */
-    white-space: nowrap;
-    overflow: hidden;
+  .button {
+    width: 120px;
+  }
 
-    &__direction {
-      background-color: $primary_text;
-      border-color: $primary_text;
-      color: #fff;
-      margin-bottom: 9px;
-    }
+  &__action__direction {
+    margin-bottom: 9px;
   }
 }

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -1,3 +1,4 @@
 @import "./components/panel";
 @import "./components/itemList";
 @import "./components/contextMenu";
+@import "./components/button";


### PR DESCRIPTION
## Description
Introduce a new shared `<Button>` component, to display this type of buttons in a unified way, with simplified support for icons, better alignment and text ellipsis, etc.
![Capture d’écran de 2020-02-07 12-04-52](https://user-images.githubusercontent.com/243653/74024397-1390ae80-49a2-11ea-946d-c15a0171e0ee.png).
Use it on the Poi card and the Route result cards.

## Why
Simplify CSS and avoid introducing look and feel inconsistencies.
This is supposed to be part of the generic Qwant design system, but it's unclear if and when we'll use it on Maps. So until then, just declare a very simple React component which avoids re-declaring the same-ish CSS everytime we want to have good looking buttons. And if we switch to the real design system, it will be straightforward to replace this one by the real stuff.
