### PR TITLE
Shorten public transport line names

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -44,7 +44,7 @@ export function getVehicleIcon(vehicle) {
   }
 }
 
-export function getTransportTypeIcon({ mode = '', info = {} }) {
+export function getTransportTypeIcon({ mode = '' }) {
   if (mode.startsWith('WALK')) {
     return 'walk';
   }
@@ -57,7 +57,7 @@ export function getTransportTypeIcon({ mode = '', info = {} }) {
   if (mode.startsWith('TRAM')) {
     return 'tram';
   }
-  if (info.network === 'RER' || mode.indexOf('TRAIN') !== -1) {
+  if (mode.indexOf('TRAIN') !== -1) {
     return 'train';
   }
   return null;

--- a/src/panel/direction/PublicTransportLine.jsx
+++ b/src/panel/direction/PublicTransportLine.jsx
@@ -7,15 +7,17 @@ const PublicTransportLine = ({ mode, info }) => {
   // @TODO: use network-specific iconography where possible
   let type = 'ligne';
   if (mode.startsWith('BUS')) {
-    type = `bus ${info.network}`;
+    type = 'bus';
   } else if (mode.startsWith('SUBWAY')) {
     type = 'métro';
   } else if (mode.startsWith('TRAM')) {
     type = 'tram';
-  } else if (info.network === 'RER') {
-    type = 'RER';
   } else if (mode.indexOf('TRAIN') !== -1) {
-    type = `train ${info.network}`;
+    if (info.num.startsWith('RER')) {
+      type = '';
+    } else {
+      type = `train ${info.network}`;
+    }
   }
   const lineColor = info.lineColor ? Color('#' + info.lineColor) : Color('white');
   return <span


### PR DESCRIPTION
## Description
Simplify and shorten public transit line names, by removing some unnecessary details.

## Why
- Reclaim space and improve readability
- Result data changed since the first implementation.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 79332_2 32458 destination=latlon_48 85126_2 42249 mode=publicTransport(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/74140680-d6245f00-4bf5-11ea-913b-5d4bcb8c7595.png)|![localhost_3000_routes__origin=latlon_48 79332_2 32458 destination=latlon_48 85126_2 42249 mode=publicTransport(iPhone 6_7_8 Plus) (2)](https://user-images.githubusercontent.com/243653/74140688-d9b7e600-4bf5-11ea-805d-4c1f5f4124e0.png)|
|![localhost_3000_routes__origin=latlon_48 83123_2 36914 destination=latlon_48 82609_2 29466 mode=publicTransport(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/74140710-e2102100-4bf5-11ea-807a-58c46575e6bd.png)|![localhost_3000_routes__origin=latlon_48 79332_2 32458 destination=latlon_48 85126_2 42249 mode=publicTransport(iPhone 6_7_8 Plus) (3)](https://user-images.githubusercontent.com/243653/74140716-e5a3a800-4bf5-11ea-8193-973fe2be1f04.png)|



