### PR TITLE
Simplify map layout and padding management

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -33,14 +33,6 @@ languages:
         - es_ES
   defaultLanguage: *default
 
-layout:
-  sizes:
-    panelWidth : 400
-    topBarHeight: 100
-    sideBarWidth: 96
-  mobile:
-    breakPoint: 640
-
 # Map
 map:
   zoom: 2

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -3,7 +3,7 @@ import PoiPopup from './poi_popup';
 import MobileCompassControl from '../mapbox/mobile_compass_control';
 import ExtendedControl from '../mapbox/extended_nav_control';
 import { map } from 'config/constants.yml';
-import { getMapPaddings, getMapCenterOffset, isPositionUnderPanel } from 'src/panel/layouts';
+import { getMapPaddings, getMapCenterOffset, isPositionUnderUI } from 'src/panel/layouts';
 import nconf from '@qwant/nconf-getter';
 import MapPoi from './poi/map_poi';
 import LocalStore from '../libs/local_store';
@@ -262,7 +262,7 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
   }
   const isMobile = isMobileDevice();
   if (!options.centerMap) {
-    const isPoiUnderPanel = isPositionUnderPanel(this.mb.project(poi.latLon), { isMobile });
+    const isPoiUnderPanel = isPositionUnderUI(this.mb.project(poi.latLon), { isMobile });
     if (this.isWindowedPoi(poi) && !isPoiUnderPanel) {
       return;
     }

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -304,12 +304,7 @@ Scene.prototype.cleanMarker = async function() {
 };
 
 Scene.prototype.isWindowedPoi = function(poi) {
-  const windowBounds = this.mb.getBounds();
-  /* simple way to clone value */
-  const originalWindowBounds = windowBounds.toArray();
-  const poiCenter = new LngLat(poi.latLon.lng, poi.latLon.lat);
-  windowBounds.extend(poiCenter);
-  return compareBoundsArray(windowBounds.toArray(), originalWindowBounds);
+  return this.mb.getBounds().contains(new LngLat(poi.latLon.lng, poi.latLon.lat));
 };
 
 Scene.prototype.getLocationHash = function() {
@@ -352,12 +347,5 @@ Scene.prototype.moveMobileBottomUI = function(bottom = 0) {
     });
   }
 };
-
-/* private */
-
-function compareBoundsArray(boundsA, boundsB) {
-  return boundsA[0][0] === boundsB[0][0] && boundsA[0][1] === boundsB[0][1] &&
-         boundsA[1][0] === boundsB[1][0] && boundsA[1][1] === boundsB[1][1];
-}
 
 export default Scene;

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -2,7 +2,6 @@ import { Marker } from 'mapbox-gl--ENV';
 import constants from '../../config/constants.yml';
 import { createIcon } from '../adapters/icon_manager';
 import Telemetry from 'src/libs/telemetry';
-import layouts from 'src/panel/layouts.js';
 import { toUrl } from 'src/libs/pois';
 
 export default class SceneCategory {
@@ -46,7 +45,6 @@ export default class SceneCategory {
       poi,
       isFromCategory: true,
       sourceCategory: categoryName,
-      layout: layouts.LIST,
       centerMap: true,
     });
     this.highlightPoiMarker(poi, true);

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -2,7 +2,6 @@ import { Marker, LngLatBounds } from 'mapbox-gl--ENV';
 import bbox from '@turf/bbox';
 import { normalizeToFeatureCollection } from 'src/libs/geojson';
 import { map } from '../../config/constants.yml';
-import layouts from '../panel/layouts.js';
 import LatLonPoi from '../adapters/poi/latlon_poi';
 import { prepareRouteColor, getRouteStyle, setActiveRouteStyle } from './route_styles';
 import { getAllSteps, getAllStops, originDestinationCoords } from 'src/libs/route_utils';
@@ -42,7 +41,7 @@ export default class SceneDirection {
     });
 
     listen('zoom_step', step => {
-      fire('fit_map', this.computeBBox(step), layouts.ITINERARY);
+      fire('fit_map', this.computeBBox(step));
     });
 
     listen('highlight_step', step => {
@@ -135,7 +134,7 @@ export default class SceneDirection {
 
       const bbox = this.computeBBox(mainRoute);
       if (move !== false) {
-        fire('fit_map', bbox, layouts.ITINERARY);
+        fire('fit_map', bbox);
       }
     }
   }

--- a/src/adapters/scene_event.js
+++ b/src/adapters/scene_event.js
@@ -1,7 +1,6 @@
 import { Marker } from 'mapbox-gl--ENV';
 import { createEventIcon } from '../adapters/icon_manager';
 import Telemetry from 'src/libs/telemetry';
-import layouts from 'src/panel/layouts.js';
 import events from 'config/events.yml';
 import { toUrl } from 'src/libs/pois';
 
@@ -46,7 +45,6 @@ export default class SceneEvent {
       poi,
       isFromEvent: true,
       sourceEvent: eventName,
-      layout: layouts.LIST,
       centerMap: true,
     });
     this.highlightPoiMarker(poi, true);

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -5,7 +5,6 @@ import IconManager from 'src/adapters/icon_manager';
 import ExtendedString from 'src/libs/string';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import Telemetry from 'src/libs/telemetry';
-import layouts from 'src/panel/layouts.js';
 import ContextMenu from 'src/components/ui/ContextMenu';
 import { openShareModal } from 'src/modals/ShareModal';
 import { toAbsoluteUrl, toUrl } from 'src/libs/pois';
@@ -22,7 +21,6 @@ export default class FavoritePoi extends React.Component {
       poi: this.props.poi,
       centerMap: true,
       isFromFavorite: true,
-      layout: layouts.FAVORITE,
     });
   }
 

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -1,16 +1,22 @@
-import { isMobileDevice } from 'src/libs/device';
+import { layout } from 'config/constants.yml';
 
-// Mapbox paddings mobile / desktop
 const DESKTOP_SIDE_PANEL = { top: 100, left: 450, right: 60, bottom: 45 };
-const DESKTOP_FULL = { top: 100, left: 20, right: 60, bottom: 45 };
-const MOBILE_FULL = { top: 80, right: 70, bottom: 45, left: 20 };
 const MOBILE_CARD = { top: 80, right: 70, bottom: 130, left: 20 };
 const MOBILE_FULL_SCREEN_PANEL = { top: 184, right: 70, bottom: 130, left: 20 };
 
-export default {
-  FULL: isMobileDevice() ? MOBILE_FULL : DESKTOP_FULL,
-  FAVORITE: isMobileDevice() ? MOBILE_CARD : DESKTOP_SIDE_PANEL,
-  LIST: isMobileDevice() ? MOBILE_CARD : DESKTOP_SIDE_PANEL,
-  POI: isMobileDevice() ? MOBILE_CARD : DESKTOP_SIDE_PANEL,
-  ITINERARY: isMobileDevice() ? MOBILE_FULL_SCREEN_PANEL : DESKTOP_SIDE_PANEL,
-};
+export function getMapPaddings({ isMobile, isDirectionsActive }) {
+  if (!isMobile) {
+    return DESKTOP_SIDE_PANEL;
+  }
+  return isDirectionsActive ? MOBILE_FULL_SCREEN_PANEL : MOBILE_CARD;
+}
+
+export function getMapCenterOffset({ isMobile }) {
+  return isMobile
+    ? [0, 0]
+    : [(layout.sizes.panelWidth + layout.sizes.sideBarWidth) / 2, 0];
+}
+
+export function isPositionUnderPanel({ x }, { isMobile }) {
+  return !isMobile && x < layout.sizes.sideBarWidth + layout.sizes.panelWidth;
+}

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -1,6 +1,6 @@
-import { layout } from 'config/constants.yml';
 
-const DESKTOP_SIDE_PANEL = { top: 100, left: 450, right: 60, bottom: 45 };
+const DESKTOP_PANEL_WIDTH = 450;
+const DESKTOP_SIDE_PANEL = { top: 100, left: DESKTOP_PANEL_WIDTH, right: 60, bottom: 45 };
 const MOBILE_CARD = { top: 80, right: 70, bottom: 130, left: 20 };
 const MOBILE_FULL_SCREEN_PANEL = { top: 184, right: 70, bottom: 130, left: 20 };
 
@@ -12,11 +12,9 @@ export function getMapPaddings({ isMobile, isDirectionsActive }) {
 }
 
 export function getMapCenterOffset({ isMobile }) {
-  return isMobile
-    ? [0, 0]
-    : [(layout.sizes.panelWidth + layout.sizes.sideBarWidth) / 2, 0];
+  return isMobile ? [0, 0] : [DESKTOP_PANEL_WIDTH / 2, 0];
 }
 
 export function isPositionUnderPanel({ x }, { isMobile }) {
-  return !isMobile && x < layout.sizes.sideBarWidth + layout.sizes.panelWidth;
+  return !isMobile && x < DESKTOP_PANEL_WIDTH;
 }

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -1,6 +1,13 @@
 
-const DESKTOP_PANEL_WIDTH = 450;
-const DESKTOP_SIDE_PANEL = { top: 100, left: DESKTOP_PANEL_WIDTH, right: 60, bottom: 45 };
+const DESKTOP_PANEL_WIDTH = 400;
+const DESKTOP_TOP_BAR_HEIGHT = 100;
+const ADDITIONAL_PADDING = 50;
+const DESKTOP_SIDE_PANEL = {
+  top: DESKTOP_TOP_BAR_HEIGHT + ADDITIONAL_PADDING,
+  left: DESKTOP_PANEL_WIDTH + ADDITIONAL_PADDING,
+  right: 60,
+  bottom: 45,
+};
 const MOBILE_CARD = { top: 80, right: 70, bottom: 130, left: 20 };
 const MOBILE_FULL_SCREEN_PANEL = { top: 184, right: 70, bottom: 130, left: 20 };
 
@@ -12,9 +19,13 @@ export function getMapPaddings({ isMobile, isDirectionsActive }) {
 }
 
 export function getMapCenterOffset({ isMobile }) {
-  return isMobile ? [0, 0] : [DESKTOP_PANEL_WIDTH / 2, 0];
+  return isMobile ? [0, 0] : [(DESKTOP_PANEL_WIDTH + ADDITIONAL_PADDING) / 2, 0];
 }
 
-export function isPositionUnderPanel({ x }, { isMobile }) {
-  return !isMobile && x < DESKTOP_PANEL_WIDTH;
+export function isPositionUnderUI({ x, y }, { isMobile }) {
+  return !isMobile && (
+    x < (DESKTOP_PANEL_WIDTH + ADDITIONAL_PADDING)
+    ||
+    y < (DESKTOP_TOP_BAR_HEIGHT + ADDITIONAL_PADDING)
+  );
 }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Telemetry from 'src/libs/telemetry';
 import nconf from '@qwant/nconf-getter';
-import layouts from 'src/panel/layouts.js';
 import PoiCard from './PoiCard';
 import ActionButtons from './ActionButtons';
 import PoiHeader from './PoiHeader';
@@ -28,12 +27,7 @@ export default class PoiPanel extends React.Component {
     isFromCategory: PropTypes.bool,
     sourceCategory: PropTypes.string,
     centerMap: PropTypes.bool,
-    layout: PropTypes.object,
   }
-
-  static defaultProps = {
-    layout: layouts.POI,
-  };
 
   constructor(props) {
     super(props);
@@ -62,8 +56,8 @@ export default class PoiPanel extends React.Component {
   }
 
   loadPoi = async () => {
-    const { poiId, centerMap, isFromCategory, layout } = this.props;
-    const mapOptions = { centerMap, isFromCategory, layout };
+    const { poiId, centerMap, isFromCategory } = this.props;
+    const mapOptions = { centerMap, isFromCategory };
 
     // If a POI object is provided before fetching full data,
     // we can update the map immediately for UX responsiveness
@@ -129,7 +123,7 @@ export default class PoiPanel extends React.Component {
   center = () => {
     const poi = this.getBestPoi();
     Telemetry.add('go', 'poi', poi.meta && poi.meta.source);
-    fire('fit_map', poi, layouts.POI);
+    fire('fit_map', poi);
   }
 
   openShare = () => {


### PR DESCRIPTION
## Description
Several improvements to the dynamic padding and offset management of the map.
- Mainly centralize all map layout management functions and constants in a single place, with better naming so it's easier to understand what is done and make it evolve.
- Remove the need to carry current layout everywhere in the history state. The best layout will always be computed when it's useful at the right time.
- Remove old redundant config values in YAML. They are not used by CSS for example, so there is no added value to separate them from the JS code.
- Use the new `contains` method on `LngLatBounds` objects instead of a complex way to test bounds inclusion of a position.
- Update of some values reflecting an old state of the application (ex: there is no more left sidebar)
- UX improvement: when clicking a POI too close (or under!) the top bar, it will be centered, like what's done with a position under the panel

## Why
I needed to see clearer before improving better view fit of route results.