### PR TITLE
[Mobile routes] Buttons to access details and preview

### DIFF
--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -9,7 +9,7 @@ const Button = ({ children, icon, variant, className = '', type = 'button', onCl
     {...rest}
   >
     {icon && <span className={`button-icon icon-${icon}`} />}
-    <div className="button-content">{children}</div>
+    {children && <div className="button-content">{children}</div>}
   </button>;
 
 export default Button;

--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -1,9 +1,12 @@
+/* global _ */
 import React from 'react';
 import RouteVia from './RouteVia';
 import RoadMap from './RoadMap';
+import Button from 'src/components/ui/Button';
 import { formatDuration } from 'src/libs/route_utils';
 
-const MobileRouteDetails = ({ id, route, origin, destination, vehicle, toggleDetails }) => {
+const MobileRouteDetails =
+({ id, route, origin, destination, vehicle, toggleDetails, openPreview }) => {
   return <div className="itinerary_legDetails">
     <div className="itinerary_legDetails_header">
       <button className="itinerary_legDetails_back" onClick={() => { toggleDetails(id); }}>
@@ -13,6 +16,16 @@ const MobileRouteDetails = ({ id, route, origin, destination, vehicle, toggleDet
       <div className="itinerary_leg_duration">
         {formatDuration(route.duration)}
       </div>
+    </div>
+    <div className="itinerary_legDetails_title">
+      <div className="u-bold">{_('DETAILS', 'direction')}</div>
+      {vehicle !== 'publicTransport' && <Button
+        onClick={() => { openPreview(id); }}
+        variant="noBorder"
+        icon="chevrons-right"
+      >
+        {_('PREVIEW', 'direction')}
+      </Button>}
     </div>
     <RoadMap
       route={route}

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -34,6 +34,7 @@ const Route = ({
       destination={destination}
       vehicle={vehicle}
       toggleDetails={toggleDetails}
+      openPreview={openPreview}
     />}
   </Fragment>;
 };

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -59,14 +59,8 @@ export default class RouteSummary extends React.Component {
         <i className="icon-share-2" />
       </div>
       <div className="itinerary_leg_mobileActions">
-        {vehicle !== 'publicTransport' &&
-          <Button className="itinerary_leg_preview" onClick={this.onClickPreview} icon="navigation">
-            {_('PREVIEW', 'direction')}
-          </Button>}
-        {vehicle === 'publicTransport' &&
-          <Button onClick={this.onClickDetails} icon="icon_list">
-            {_('DETAILS', 'direction')}
-          </Button>}
+        <Button onClick={this.onClickDetails} icon="icon_list">{_('DETAILS', 'direction')}</Button>
+        <Button onClick={this.onClickShare} icon="share-2" />
       </div>
     </div>;
   }

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -59,7 +59,9 @@ export default class RouteSummary extends React.Component {
         <i className="icon-share-2" />
       </div>
       <div className="itinerary_leg_mobileActions">
-        <Button onClick={this.onClickDetails} icon="icon_list">{_('DETAILS', 'direction')}</Button>
+        <Button className="itinerary_leg_detailsBtn" onClick={this.onClickDetails} icon="icon_list">
+          {_('DETAILS', 'direction')}
+        </Button>
         <Button onClick={this.onClickShare} icon="share-2" />
       </div>
     </div>;

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -2,7 +2,7 @@
   background-color: white;
   display: inline-flex;
   align-items: center;
-  height: 35px;
+  height: 36px;
   padding: 0 9px;
   border-radius: 18px;
   border: 1px solid $primary_clear;
@@ -18,6 +18,11 @@
     color: white;
   }
 
+  &--noBorder {
+    border-color: transparent;
+    padding: 0;
+  }
+
   &-content {
     flex-grow: 1;
     text-align: center;
@@ -29,7 +34,11 @@
 
   &-icon {
     vertical-align: middle;
-    margin-right: 6px;
     font-size: 16px;
+    width: 16px;
+  }
+
+  &-icon + &-content {
+    margin-left: 6px;
   }
 }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -684,7 +684,7 @@ input:valid:focus + .itinerary__field__clear {
 
   .itinerary_leg_summary {
     display: grid;
-    grid-template-areas: "info actions" "via actions";
+    grid-template-areas: "info" "via" "actions";
     padding: 15px 18px;
   }
 
@@ -709,12 +709,13 @@ input:valid:focus + .itinerary__field__clear {
     margin-right: 6px;
   }
   
-  .itinerary_leg--active {
-    .itinerary_leg_mobileActions {
-      display: flex;
-      justify-content: flex-end;
-      grid-area: actions;
-      margin-top: 9px;
+  .itinerary_leg_mobileActions {
+    display: flex;
+    grid-area: actions;
+    margin-top: 9px;
+
+    button {
+      margin-right: 6px;
     }
   }
   
@@ -855,6 +856,14 @@ input:valid:focus + .itinerary__field__clear {
       .itinerary_leg_duration {
         margin: 0 0 0 12px;
       }
+    }
+
+    &_title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 18px;
+      font-size: 14px;
     }
 
     .itinerary_roadmap {

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -1,0 +1,3 @@
+.u-bold {
+  font-weight: bold;
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -38,3 +38,5 @@
 @import "includes/reviewScore";
 @import "includes/openingHour";
 @import "includes/poiTitleImage";
+
+@import "includes/utils";

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -180,8 +180,8 @@ test('show itinerary roadmap on mobile', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
 
   await page.waitForSelector('.itinerary_leg');
-  await page.click('.itinerary_leg .itinerary_leg_preview');
-  await page.waitForSelector('.itinerary_mobile_step');
+  await page.click('.itinerary_leg .itinerary_leg_detailsBtn');
+  await page.waitForSelector('.itinerary_legDetails');
 
   /*
     This simulates a user action that will close


### PR DESCRIPTION
## Description
Uniformize action buttons on mobile route results:
- On cards, display "details" and "share" buttons
- The "preview" button is now available from the "details" fullscreen panel. (but still not available on public transports, as it's not ready)

## Screenshots
|Buttons on public transport cards|Buttons on car cards|Title + preview button in details|
|---|---|---|
|![localhost_3000_routes__origin=latlon_48 79272_2 35662 destination=latlon_48 83006_2 34942 mode=driving(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/74168831-9e83da00-4c2a-11ea-9e2f-8508aba758fb.png)|![localhost_3000_routes__origin=latlon_48 79272_2 35662 destination=latlon_48 83006_2 34942 mode=driving(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/74168847-a479bb00-4c2a-11ea-9575-4009fdd54629.png)|![localhost_3000_routes__origin=latlon_48 79272_2 35662 destination=latlon_48 83006_2 34942 mode=driving(iPhone 6_7_8 Plus) (2)](https://user-images.githubusercontent.com/243653/74168864-a8a5d880-4c2a-11ea-9c98-a381ef78277d.png)|



