### PR TITLE
[Mobile roadmaps] Interactive header style with scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9341,6 +9341,11 @@
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "express": "^4.16.3",
     "express-static-gzip": "^1.1.3",
     "express-validator": "^6.1.1",
+    "lodash.throttle": "^4.1.1",
     "nconf": "^0.10.0",
     "nconf-yaml": "^1.0.2",
     "nock": "^10.0.0",

--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -1,13 +1,31 @@
 /* global _ */
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import RouteVia from './RouteVia';
 import RoadMap from './RoadMap';
 import Button from 'src/components/ui/Button';
 import { formatDuration } from 'src/libs/route_utils';
+import classnames from 'classnames';
+import throttle from 'lodash.throttle';
 
 const MobileRouteDetails =
 ({ id, route, origin, destination, vehicle, toggleDetails, openPreview }) => {
-  return <div className="itinerary_legDetails">
+  const panelElement = useRef(null);
+  const [scrolledDown, setScrolledDown] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = throttle(() => {
+      setScrolledDown(panelElement.current.scrollTop > 0);
+    }, 100, { leading: true, trailing: true });
+    panelElement.current.addEventListener('scroll', handleScroll, { passive: true });
+    return () => panelElement.current.removeEventListener('scroll', handleScroll);
+  });
+
+  return <div
+    ref={panelElement}
+    className={classnames('itinerary_legDetails', {
+      ['itinerary_legDetails__scrolled']: scrolledDown,
+    })}
+  >
     <div className="itinerary_legDetails_header">
       <button className="itinerary_legDetails_back" onClick={() => { toggleDetails(id); }}>
         <i className="icon-arrow-left" />

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -843,6 +843,7 @@ input:valid:focus + .itinerary__field__clear {
       padding: 12px 18px;
       background-color: $background_active;
       z-index: 1;
+      transition: all .2s ease-out;
 
       .icon-arrow-left {
         font-size: 24px;
@@ -855,6 +856,19 @@ input:valid:focus + .itinerary__field__clear {
 
       .itinerary_leg_duration {
         margin: 0 0 0 12px;
+      }
+
+      .itinerary_legDetails__scrolled & {
+        @include card_shadow();
+        background-color: $primary_text;
+        color: white;
+        transition: all .2s ease-in;
+
+        .itinerary_leg_duration,
+        .itinerary_legDetails_back {
+          color: white;
+          transition: all .2s ease-in;
+        }
       }
     }
 

--- a/src/scss/includes/routes.scss
+++ b/src/scss/includes/routes.scss
@@ -10,9 +10,10 @@
   vertical-align: text-bottom;
   white-space: nowrap;
   display: inline-block;
+  color: black !important;
 
   &--dark {
-    color: white;
+    color: white !important;
   }
 }
 


### PR DESCRIPTION
## Description
Add a dynamic effect to the roadmap header to highlight it when the user has scrolled the view.
Listen to scroll events using the React [`useEffect` hook](https://reactjs.org/docs/hooks-effect.html) and throttle the handler using the [lodash implementation](https://lodash.com/docs/4.17.15#throttle) to prevent lagging.

## Why
UX improvement.

## Screenshots

![simplescreenrecorder-2020-02-10_17 42 52](https://user-images.githubusercontent.com/243653/74235892-4e5f5300-4cd0-11ea-8a71-a1ee742ad1fe.gif)

