### PR TITLE
[Routes] Fix mobile panel display in case of errors

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -256,7 +256,7 @@ export default class DirectionPanel extends React.Component {
             {title}
             {!activePreviewRoute && form}
           </div>
-          {(routes.length > 0 || isLoading) && !activePreviewRoute &&
+          {!activePreviewRoute && origin && destination &&
             <Panel className="directionResult_panel">
               {result}
             </Panel>}

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -670,6 +670,10 @@ input:valid:focus + .itinerary__field__clear {
     padding: 9px 0 6px;
   }
 
+  .itinerary_no-result {
+    background-color: transparent;
+  }
+
   .panel.directionResult_panel {
     height: auto;
 


### PR DESCRIPTION
## Description
Two small bug fixes for error cases on the mobile route result panel:
- ensure the panel is displayed when origin and destination are filled, not based on result content and errors. Otherwise the panel disappears when there is no result and no error feedback is displayed to the user.
- No forced white background on mobile as it looks like a UI bug.