### PR TITLE
Ensure visibility of route results on map

### DIFF
--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -25,18 +25,18 @@ export default class SceneDirection {
     this.addMapImage(`${iconsBaseUrl}/walking_bullet_active.png`, 'walking_bullet_active');
     this.addMapImage(`${iconsBaseUrl}/walking_bullet_inactive.png`, 'walking_bullet_inactive');
 
-    listen('set_route', ({ routes, vehicle, move }) => {
+    listen('set_routes', ({ routes, vehicle, move }) => {
       this.reset();
       this.routes = routes;
       this.vehicle = vehicle;
       this.displayRoute(move);
     });
 
-    listen('toggle_route', mainRouteId => {
-      this.setMainRoute(mainRouteId);
+    listen('set_main_route', routeId => {
+      this.setMainRoute(routeId);
     });
 
-    listen('clean_route', () => {
+    listen('clean_routes', () => {
       this.reset();
     });
 

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -25,15 +25,15 @@ export default class SceneDirection {
     this.addMapImage(`${iconsBaseUrl}/walking_bullet_active.png`, 'walking_bullet_active');
     this.addMapImage(`${iconsBaseUrl}/walking_bullet_inactive.png`, 'walking_bullet_inactive');
 
-    listen('set_routes', ({ routes, vehicle, move }) => {
+    listen('set_routes', ({ routes, vehicle }) => {
       this.reset();
       this.routes = routes;
       this.vehicle = vehicle;
-      this.displayRoute(move);
+      this.displayRoute();
     });
 
-    listen('set_main_route', routeId => {
-      this.setMainRoute(routeId);
+    listen('set_main_route', ({ routeId, fitView }) => {
+      this.setMainRoute(routeId, fitView);
     });
 
     listen('clean_routes', () => {
@@ -72,7 +72,7 @@ export default class SceneDirection {
     }
   }
 
-  setMainRoute(routeId) {
+  setMainRoute(routeId, fitView) {
     let mainRoute = null;
     this.routes.forEach(route => {
       const isActive = route.id === routeId;
@@ -93,6 +93,9 @@ export default class SceneDirection {
       });
     });
     this.updateMarkers(mainRoute);
+    if (fitView) {
+      fire('fit_map', this.computeBBox(mainRoute));
+    }
   }
 
   updateMarkers(mainRoute) {
@@ -123,19 +126,14 @@ export default class SceneDirection {
     this.routeMarkers.push(destinationMarker);
   }
 
-  displayRoute(move) {
+  displayRoute() {
     if (this.routes && this.routes.length > 0) {
       this.mapFeaturesByRoute = {};
       this.routes.forEach(route => {
         this.mapFeaturesByRoute[route.id] = this.addRouteFeatures(route);
       });
       const mainRoute = this.routes.find(route => route.isActive);
-      this.setMainRoute(mainRoute.id);
-
-      const bbox = this.computeBBox(mainRoute);
-      if (move !== false) {
-        fire('fit_map', bbox);
-      }
+      this.setMainRoute(mainRoute.id, true);
     }
   }
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -72,7 +72,7 @@ export default class DirectionPanel extends React.Component {
   }
 
   componentWillUnmount() {
-    fire('clean_route');
+    fire('clean_routes');
     window.unListen(this.dragPointHandler);
     window.unListen(this.setPointHandler);
     document.body.classList.remove('directions-open');
@@ -123,17 +123,17 @@ export default class DirectionPanel extends React.Component {
         }));
         this.setState({ isLoading: false, error: 0, routes });
         window.execOnMapLoaded(() => {
-          fire('set_route', { routes, vehicle, origin, destination });
+          fire('set_routes', { routes, vehicle });
         });
       } else {
         // Error or empty response
         this.setState({ isLoading: false, error: directionResponse.error });
-        fire('clean_route');
+        fire('clean_routes');
       }
     } else {
       // When both fields are not filled yet or not filled anymore
       this.setState({ isLoading: false, isDirty: false, error: 0, routes: [] });
-      fire('clean_route');
+      fire('clean_routes');
     }
   }
 

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -42,7 +42,7 @@ export default class RouteResult extends React.Component {
     if (routeId === this.state.activeRouteId) {
       return;
     }
-    fire('set_main_route', routeId);
+    fire('set_main_route', { routeId, fitView: true });
     this.setState({ activeRouteId: routeId });
   }
 
@@ -50,14 +50,14 @@ export default class RouteResult extends React.Component {
     if (routeId === this.state.activeRouteId) {
       return;
     }
-    fire('set_main_route', highlightMapRoute ? routeId : this.state.activeRouteId);
+    fire('set_main_route', { routeId: highlightMapRoute ? routeId : this.state.activeRouteId });
   }
 
   toggleRouteDetails = routeId => {
     if (this.state.activeRouteId === routeId) {
       this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
     } else {
-      fire('set_main_route', routeId);
+      fire('set_main_route', { routeId, fitView: true });
       this.setState({
         activeRouteId: routeId,
         activeDetails: true,

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -42,7 +42,7 @@ export default class RouteResult extends React.Component {
     if (routeId === this.state.activeRouteId) {
       return;
     }
-    fire('toggle_route', routeId);
+    fire('set_main_route', routeId);
     this.setState({ activeRouteId: routeId });
   }
 
@@ -50,14 +50,14 @@ export default class RouteResult extends React.Component {
     if (routeId === this.state.activeRouteId) {
       return;
     }
-    fire('toggle_route', highlightMapRoute ? routeId : this.state.activeRouteId);
+    fire('set_main_route', highlightMapRoute ? routeId : this.state.activeRouteId);
   }
 
   toggleRouteDetails = routeId => {
     if (this.state.activeRouteId === routeId) {
       this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
     } else {
-      fire('toggle_route', routeId);
+      fire('set_main_route', routeId);
       this.setState({
         activeRouteId: routeId,
         activeDetails: true,

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -15,7 +15,14 @@ export function getMapPaddings({ isMobile, isDirectionsActive }) {
   if (!isMobile) {
     return DESKTOP_SIDE_PANEL;
   }
-  return isDirectionsActive ? MOBILE_FULL_SCREEN_PANEL : MOBILE_CARD;
+  if (isDirectionsActive) {
+    const resultPanel = document.querySelector('.directionResult_panel');
+    const bottomPadding = resultPanel
+      ? resultPanel.clientHeight + (ADDITIONAL_PADDING / 2)
+      : MOBILE_FULL_SCREEN_PANEL.bottom;
+    return { ...MOBILE_FULL_SCREEN_PANEL, bottom: bottomPadding };
+  }
+  return MOBILE_CARD;
 }
 
 export function getMapCenterOffset({ isMobile }) {


### PR DESCRIPTION
## Description
Ensure the active route of a direction result is always fully visible on the map :
- when we display the result
- when we change the active route
On mobile specifically, it requires retrieving the current height of the bottom result panel. This is done in the dedicated function so it doesn't get in the way, but it involves some coupling as we need to select the DOM element which is rendered by React.

(Also rename some related events first, to better distinguish between multiple or single route actions)

## Screencasts
|Before|After|
|---|---|
|![Peek 18-02-2020 11-44](https://user-images.githubusercontent.com/243653/74736367-d904fc80-5252-11ea-962c-9edf8a930b16.gif)|![Peek 18-02-2020 11-45](https://user-images.githubusercontent.com/243653/74736372-dd311a00-5252-11ea-8a10-1ccbbbd7a858.gif)|