### PR TITLE
[Mobile routes] Make result panel resizable

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -23,9 +23,14 @@ export default class Panel extends React.Component {
     minimizedTitle: PropTypes.node,
     resizable: PropTypes.bool,
     initialSize: PropTypes.string,
+    marginTop: PropTypes.number,
     close: PropTypes.func,
     className: PropTypes.string,
     white: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    marginTop: 0,
   }
 
   constructor(props) {
@@ -108,7 +113,8 @@ export default class Panel extends React.Component {
       size = !previousSize ? 'minimized' : null;
     } else {
       // the resize handler was really dragged-n-dropped
-      const sizes = [0, window.innerHeight / 2, window.innerHeight];
+      const maxSize = window.innerHeight - this.props.marginTop;
+      const sizes = [0, maxSize / 2, maxSize];
       const positionIndex = getClosestIndex(sizes, currentHeight);
       if (positionIndex === 0) {
         size = 'minimized';

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -39,11 +39,11 @@ export default class Panel extends React.Component {
   }
 
   componentDidMount() {
-    this.updateMobileMapUI(this.panelDOMElement.offsetHeight);
+    this.updateMobileMapUI();
   }
 
   componentDidUpdate() {
-    this.updateMobileMapUI(this.panelDOMElement.offsetHeight);
+    this.updateMobileMapUI();
   }
 
   componentWillUnmount() {
@@ -52,7 +52,7 @@ export default class Panel extends React.Component {
     document.removeEventListener('touchmove', this.moveCallback);
   }
 
-  updateMobileMapUI = height => {
+  updateMobileMapUI = (height = this.panelDOMElement.offsetHeight) => {
     if (this.props.resizable) {
       window.execOnMapLoaded(() => {
         fire('move_mobile_bottom_ui', height);
@@ -121,11 +121,7 @@ export default class Panel extends React.Component {
       holding: false,
       size,
       currentHeight: null,
-      isTransitioning: true,
     });
-
-    // Still useful so componentDidUpdate gets called to move the map UI elements -_-
-    setTimeout(() => { this.setState({ isTransitioning: false }); }, 250);
   }
 
   render() {
@@ -146,6 +142,7 @@ export default class Panel extends React.Component {
       })}
       style={{ height: currentHeight && `${currentHeight}px` }}
       ref={panel => this.panelDOMElement = panel}
+      onTransitionEnd={() => this.updateMobileMapUI()}
     >
       {close && <div className="panel-close" onClick={() => { close(); }}>
         <i className="icon-x" />

--- a/src/panel/ServicePanel.jsx
+++ b/src/panel/ServicePanel.jsx
@@ -13,6 +13,7 @@ class ServicePanel extends React.Component {
       title={_('Qwant Maps services', 'service panel')}
       minimizedTitle={_('Show Qwant Maps services', 'service panel')}
       className="service_panel"
+      white
     >
       <CategoryList className="service_panel__categories" />
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -257,7 +257,7 @@ export default class DirectionPanel extends React.Component {
             {!activePreviewRoute && form}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel className="directionResult_panel">
+            <Panel className="directionResult_panel" resizable>
               {result}
             </Panel>}
           {activePreviewRoute &&

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -257,7 +257,7 @@ export default class DirectionPanel extends React.Component {
             {!activePreviewRoute && form}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel className="directionResult_panel" resizable>
+            <Panel className="directionResult_panel" resizable marginTop={160} >
               {result}
             </Panel>}
           {activePreviewRoute &&

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -52,6 +52,8 @@
     width: 100vw;
     height: 50%;
     position: absolute;
+    display: flex;
+    flex-direction: column;
     background: #f4f6fa;
     border-radius: 0;
     bottom: 0;
@@ -72,24 +74,27 @@
       padding: 21px;
     }
 
-    &.smooth-resize {
-      transition: all .2s ease-in-out;
+    &:not(.panel--holding) {
+      transition: height 0.2s ease-in-out;
     }
 
     &.maximized {
-      height: 100%;
+      height: calc(100% - 68px);
 
-      .panel-close {
-        top: 68px;
+      // a "fake" background area added above the panel itself,
+      // allowing height transitions without changing paddings and preventing "jumps"
+      &::before {
+        content: '';
+        display: block;
+        width: 100%;
+        height: 68px;
+        background-color: #f4f6fa;
+        position: absolute;
+        top: -68px;
       }
 
-      .panel-header {
-        padding-top: 72px;
-        height: 116px;
-      }
-
-      .panel-content {
-        height: calc(100% - 116px);
+      &.panel--white::before {
+        background-color: white;
       }
     }
 
@@ -110,6 +115,10 @@
 
     .panel-resizeHandle {
       pointer-events: all;
+      -moz-user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
       min-height: 50px;
       width: 100%;
       cursor: -webkit-grab;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -670,6 +670,10 @@ input:valid:focus + .itinerary__field__clear {
     padding: 9px 0 6px;
   }
 
+  .itinerary_result {
+    max-height: none;
+  }
+
   .itinerary_no-result {
     background-color: transparent;
   }
@@ -677,10 +681,25 @@ input:valid:focus + .itinerary__field__clear {
   .panel.directionResult_panel {
     height: auto;
 
+    &:not(.panel--holding) {
+      max-height: 50%;
+    }
+
     .panel-header {
       min-height: auto;
     }
+
+    &.maximized {
+      height: calc(100% - 160px);
+      max-height: none;
+
+      .panel-header {
+        padding-top: 9px;
+        height: auto;
+      }
+    }
   }
+
 
   .itinerary_result .itemList-item {
     overflow: hidden;

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -156,10 +156,6 @@
     font-weight: 500;
   }
 
-  .panel.service_panel.maximized .panel-header {
-    padding: 75px 16px 12px;
-  }
-
   .panel.service_panel.minimized {
     height: 50px;
   }


### PR DESCRIPTION
## Description
Add resizable behavior to the route result panel on mobile.
The biggest part of this PR is actually simplifying the `<Panel>` component lifecycle for the management of the resize events, as well as the corresponding CSS.
Hopefully this makes it easier to read, but more importantly this fixes some UX problems with mobile panels, like the handler "jumping" below the cursor/finger and animations feeling awkward.

This is hard to validate with automatic testing, so if reviewers could play a bit with it on mobile devices that would be great :)