### PR TITLE
[Public transports] Allow to activate feature through url

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -128,7 +128,7 @@ export default class PanelManager extends React.Component {
       if (params.q) {
         SearchInput.executeSearch(params.q);
       } else {
-        router.routeUrl.navigateTo('/');
+        router.routeUrl('/');
       }
     });
 

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -13,9 +13,9 @@ import { parseQueryString, getCurrentUrl } from 'src/libs/url_utils';
 import { isMobileDevice, mobileDeviceMediaQuery, DeviceContext } from 'src/libs/device';
 
 const performanceEnabled = nconf.get().performance.enabled;
-const directionEnabled = nconf.get().direction.enabled;
 const categoryEnabled = nconf.get().category.enabled;
 const eventEnabled = nconf.get().events.enabled;
+const directionConf = nconf.get().direction;
 
 export default class PanelManager extends React.Component {
   static propTypes = {
@@ -110,11 +110,15 @@ export default class PanelManager extends React.Component {
       });
     });
 
-    if (directionEnabled) {
+    if (directionConf.enabled) {
+      const isPublicTransportActive =
+        (directionConf.publicTransport && directionConf.publicTransport.enabled)
+        || parseQueryString(document.location.search)['pt'] === 'true';
+
       router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
         this.setState({
           ActivePanel: DirectionPanel,
-          options: { ...parseQueryString(routeParams), ...options },
+          options: { ...parseQueryString(routeParams), ...options, isPublicTransportActive },
         });
       });
     }

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -146,6 +146,9 @@ export default class DirectionPanel extends React.Component {
       routeParams.push('destination=' + poiToUrl(this.state.destination));
     }
     routeParams.push(`mode=${this.state.vehicle}`);
+    if (this.props.isPublicTransportActive) {
+      routeParams.push('pt=true');
+    }
     window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, {
       replace: true,
       routeUrl: false,

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -6,7 +6,6 @@ import DirectionForm from './DirectionForm';
 import RouteResult from './RouteResult';
 import DirectionApi, { modes } from 'src/adapters/direction_api';
 import Telemetry from 'src/libs/telemetry';
-import nconf from '@qwant/nconf-getter';
 import { toUrl as poiToUrl, fromUrl as poiFromUrl } from 'src/libs/pois';
 import { DeviceContext } from 'src/libs/device';
 import Error from 'src/adapters/error';
@@ -26,6 +25,7 @@ export default class DirectionPanel extends React.Component {
     destination: PropTypes.string,
     poi: PropTypes.object,
     mode: PropTypes.string,
+    isPublicTransportActive: PropTypes.bool,
   }
 
   constructor(props) {
@@ -42,7 +42,7 @@ export default class DirectionPanel extends React.Component {
     );
 
     this.vehicles = [modes.DRIVING, modes.WALKING, modes.CYCLING];
-    if (nconf.get().direction.publicTransport.enabled) {
+    if (this.props.isPublicTransportActive) {
       this.vehicles.splice(1, 0, modes.PUBLIC_TRANSPORT);
     }
 


### PR DESCRIPTION
## Description
Enable activation of the public transport routing mode through URL, for public testing purposes.
 - Check if the app URL contains the query param `pt=true` during the router initialization, so it will persist during the session.
 - Persist the setting in URLs of the routes feature
 - Also fix a bug that caused the app to crash when an unknown query parameter (i.e. other than `q`) what passed to the root url