### PR TITLE
[Public transport] Add durations on roadmap sections

### DIFF
--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -2,16 +2,17 @@ import React, { useState } from 'react';
 import RoadMapItem from './RoadMapItem';
 import PublicTransportLine from './PublicTransportLine';
 import LegLine from './LegLine';
-import { getTransportTypeIcon } from 'src/libs/route_utils';
+import { getTransportTypeIcon, formatDuration } from 'src/libs/route_utils';
 
 const TransportLineLeg = ({ leg }) => {
   const [ detailsOpen, setDetailsOpen ] = useState(false);
-  const { mode, info = {}, stops = [], from, to } = leg;
+  const { mode, info = {}, stops = [], from, to, duration } = leg;
 
   return <RoadMapItem
     icon={getTransportTypeIcon(leg)}
     className="itinerary_roadmap_item--transportLine"
     line={<LegLine info={info} mode={mode} />}
+    distance={formatDuration(duration)}
   >
     <div
       className="itinerary_roadmap_item_summary itinerary_roadmap_item_summary--openable"

--- a/src/panel/direction/WalkLeg.jsx
+++ b/src/panel/direction/WalkLeg.jsx
@@ -1,6 +1,6 @@
 /* global _ */
 import React, { useState } from 'react';
-import { formatDistance, getStepIcon } from 'src/libs/route_utils';
+import { formatDistance, formatDuration, getStepIcon } from 'src/libs/route_utils';
 import RoadMapItem from './RoadMapItem';
 import LegLine from './LegLine';
 import classnames from 'classnames';
@@ -16,6 +16,7 @@ const WalkLeg = ({ leg }) => {
     icon="walk"
     className="itinerary_roadmap_item--walk"
     line={<LegLine mode="WALK" />}
+    distance={formatDuration(leg.duration)}
   >
     <div
       className={classnames('itinerary_roadmap_item_summary', {


### PR DESCRIPTION
## Description
Add small durations indications between public transport roadmap sections, like we do with distances for other transport modes.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 89269_2 37977 destination=latlon_48 83476_2 31307 mode=publicTransport(iPhone 6_7_8 Plus) (2)](https://user-images.githubusercontent.com/243653/74548799-d2267300-4f4e-11ea-86e6-50d24767b907.png)|![localhost_3000_routes__origin=latlon_48 89269_2 37977 destination=latlon_48 83476_2 31307 mode=publicTransport(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/74548809-d6529080-4f4e-11ea-912b-65f1939c6798.png)|