### PR TITLE
[Routes] Fix focus behavior of input fields

### DIFF
--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DirectionInput from './DirectionInput';
 import VehicleSelector from './VehicleSelector';
-import { DeviceContext } from 'src/libs/device';
+import { isMobileDevice } from 'src/libs/device';
 
 export default class DirectionForm extends React.Component {
   static propTypes = {
@@ -22,12 +22,31 @@ export default class DirectionForm extends React.Component {
     destinationInputText: '',
   }
 
+  constructor(props) {
+    super(props);
+    this.originRef = React.createRef();
+    this.destinationRef = React.createRef();
+  }
+
   static getDerivedStateFromProps(props, state) {
     const { origin, destination } = props;
     return {
       originInputText: origin ? origin.getInputValue() : state.originInputText,
       destinationInputText: destination ? destination.getInputValue() : state.destinationInputText,
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (isMobileDevice() || this.props.isInitializing) {
+      return;
+    }
+    const { originInputText, destinationInputText } = this.state;
+    const { origin, destination } = this.props;
+    if (!originInputText && (prevProps.destination !== destination || prevProps.isInitializing)) {
+      this.originRef.current.focus();
+    } else if (!destinationInputText && prevProps.origin !== origin) {
+      this.destinationRef.current.focus();
+    }
   }
 
   onChangePoint = (which, textInput, point) => {
@@ -49,41 +68,36 @@ export default class DirectionForm extends React.Component {
 
   render() {
     const { originInputText, destinationInputText } = this.state;
-    const {
-      origin, destination, isInitializing,
-      vehicles, activeVehicle, onSelectVehicle,
-    } = this.props;
+    const { vehicles, activeVehicle, onSelectVehicle } = this.props;
 
-    return <DeviceContext.Consumer>
-      {isMobile => <div className="itinerary_form">
-        <div className="itinerary_fields">
-          <form noValidate>
-            <DirectionInput
-              value={originInputText}
-              pointType="origin"
-              onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
-              claimFocus={!isMobile && !isInitializing && !originInputText && !destination}
-            />
-            <div className="itinerary__form__separator" />
-            <DirectionInput
-              value={destinationInputText}
-              pointType="destination"
-              onChangePoint={(input, point) => this.onChangePoint('destination', input, point)}
-              claimFocus={!isMobile && !isInitializing && origin && !destinationInputText}
-            />
-            <div
-              className="itinerary_invert_origin_destination icon-reverse"
-              onClick={this.onReverse}
-              title={_('Invert start and end', 'direction')}
-            />
-          </form>
-        </div>
-        <VehicleSelector
-          vehicles={vehicles}
-          activeVehicle={activeVehicle}
-          onSelectVehicle={onSelectVehicle}
-        />
-      </div>}
-    </DeviceContext.Consumer>;
+    return <div className="itinerary_form">
+      <div className="itinerary_fields">
+        <form noValidate>
+          <DirectionInput
+            value={originInputText}
+            pointType="origin"
+            onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
+            ref={this.originRef}
+          />
+          <div className="itinerary__form__separator" />
+          <DirectionInput
+            value={destinationInputText}
+            pointType="destination"
+            onChangePoint={(input, point) => this.onChangePoint('destination', input, point)}
+            ref={this.destinationRef}
+          />
+          <div
+            className="itinerary_invert_origin_destination icon-reverse"
+            onClick={this.onReverse}
+            title={_('Invert start and end', 'direction')}
+          />
+        </form>
+      </div>
+      <VehicleSelector
+        vehicles={vehicles}
+        activeVehicle={activeVehicle}
+        onSelectVehicle={onSelectVehicle}
+      />
+    </div>;
   }
 }

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -6,17 +6,12 @@ import NavigatorGeolocalisationPoi, { navigatorGeolocationStatus } from
 import Suggest from 'src/adapters/suggest';
 import Error from 'src/adapters/error';
 
-export default class DirectionInput extends React.Component {
+class DirectionInput extends React.Component {
   static propTypes = {
     value: PropTypes.string,
     onChangePoint: PropTypes.func.isRequired,
     pointType: PropTypes.oneOf(['origin', 'destination']).isRequired,
-    claimFocus: PropTypes.bool,
-  }
-
-  constructor(props) {
-    super(props);
-    this.inputRef = React.createRef();
+    inputRef: PropTypes.object.isRequired,
   }
 
   componentDidMount() {
@@ -26,15 +21,6 @@ export default class DirectionInput extends React.Component {
       prefixes: [ NavigatorGeolocalisationPoi.getInstance() ],
       menuClass: 'direction_suggestions',
     });
-    if (this.props.claimFocus) {
-      this.focus();
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.props.claimFocus) {
-      this.focus();
-    }
   }
 
   componentWillUnmount() {
@@ -77,7 +63,7 @@ export default class DirectionInput extends React.Component {
   }
 
   focus = () => {
-    setTimeout(() => { this.inputRef.current.focus(); }, 0);
+    setTimeout(() => { this.props.inputRef.current.focus(); }, 0);
   }
 
   clear = () => {
@@ -86,12 +72,12 @@ export default class DirectionInput extends React.Component {
   }
 
   render() {
-    const { pointType } = this.props;
+    const { pointType, inputRef } = this.props;
 
     return <div className="itinerary_field" >
       <div className={`itinerary_icon itinerary_icon_${pointType}`} />
       <input
-        ref={this.inputRef}
+        ref={inputRef}
         id={`itinerary_input_${pointType}`}
         className="itinerary_input"
         type="search"
@@ -109,3 +95,10 @@ export default class DirectionInput extends React.Component {
     </div>;
   }
 }
+
+const DirectionInputWithRef =
+  React.forwardRef((props, ref) => <DirectionInput {...props} inputRef={ref} />);
+
+DirectionInputWithRef.displayName = 'DirectionInput';
+
+export default DirectionInputWithRef;


### PR DESCRIPTION
## Description
Change the way we manage the "smart" focus of direction input fields, i.e. when the focus goes automatically to one of the fields depending of the context (which field is already filled, etc.).

**Fixes the bug of typing in the destination field and having the focus jump to the origin field after the first letter.**

Instead of using a prop `claimFocus` to control focus somewhat declaratively, we do it more clearly from the form component, when some state/props values have changed, using `componentDidUpdate`.

This PR uses the React mechanism of ref forwarding (see doc)(https://fr.reactjs.org/docs/forwarding-refs.html), created for this kind of rare cases when it's useful to control directly the DOM rendered by some child components.

Now the focus conditions are clearer, a field is focused if:
 - it is empty
**AND**
 - the other field just got filled with a valid point, which can happen in all those cases:
   * when selecting an address/poi in the suggest
   * when coming from the POI panel after clicking "Directions"
   * when clicking on the map
   * when restoring a point from the url
