### PR TITLE
QMAPS-doc explain how to fix random DNS errors on W10

### DIFF
--- a/docs/src/windows.md
+++ b/docs/src/windows.md
@@ -94,3 +94,11 @@ npm start
 ```
 npm watch
 ```
+
+- If W10's Linux Bash stops resolving domain names, here's a fix ([source](https://github.com/microsoft/WSL/issues/3268#issuecomment-485096972)):
+
+```
+sudo rm /etc/resolv.conf
+echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+sudo chmod 444 /etc/resolv.conf
+```

--- a/docs/src/windows.md
+++ b/docs/src/windows.md
@@ -99,6 +99,8 @@ npm watch
 
 ```
 sudo rm /etc/resolv.conf
-echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf
 sudo chmod 444 /etc/resolv.conf
 ```
+
+(you can replace "1.1.1.1" with your favourite DNS)


### PR DESCRIPTION
## Description
Explain how to re-set DNS on windows 10's doc

## Why
Linux subsystem randomly forgets what dns to use
The public doc sets 8.8.8.8, but internally we use our own dns
