### PR TITLE
Allow formating of <5m distances

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -25,10 +25,7 @@ export function formatDistance(m) {
   if (m > 1000) {
     return `${(m / 1000).toFixed(1).replace('.', ',')} km`;
   }
-  if (m > 5) {
-    return `${m.toFixed(0)} m`;
-  }
-  return '';
+  return `${m.toFixed(0)} m`;
 }
 
 export function getVehicleIcon(vehicle) {

--- a/tests/units/route_utils.js
+++ b/tests/units/route_utils.js
@@ -21,7 +21,7 @@ describe('route_utils', () => {
 
   describe('formatDistance', () => {
     const cases = [
-      { meters: 0, result: '' },
+      { meters: 0, result: '0 m' },
       { meters: 15, result: '15 m' },
       { meters: 500, result: '500 m' },
       { meters: 1234, result: '1,2 km' },


### PR DESCRIPTION
## Description
Just drop the hard-coded rule that distances less than 5 meters are formatted as an empty string. This shouldn't be the job of a low-level util function to decide that, as it causes formatting bugs upstream, like `Marchez sur` followed by nothing.
Let calling code handle special rules.