### PR TITLE
[Routes] Add a 'TEST' label to public transport option

### DIFF
--- a/src/panel/direction/VehicleSelector.jsx
+++ b/src/panel/direction/VehicleSelector.jsx
@@ -1,16 +1,23 @@
+/* global _ */
 import React from 'react';
 import classnames from 'classnames';
 import { getVehicleIcon } from 'src/libs/route_utils';
 
 const VehicleSelector = ({ vehicles, activeVehicle, onSelectVehicle }) =>
-  <div className="itinerary_vehicles">
-    {vehicles.map(vehicle => <span
+  <div className={classnames('itinerary_vehicles',
+    { 'itinerary_vehicles--withPublicTransport': vehicles.length > 3 }
+  )}>
+    {vehicles.map(vehicle => <button
+      type="button"
       key={vehicle}
-      className={classnames(`itinerary_button_label ${getVehicleIcon(vehicle)}`,
-        { 'label_active': vehicle === activeVehicle }
+      className={classnames(`itinerary_vehicle_button ${getVehicleIcon(vehicle)}`,
+        { 'itinerary_vehicle_button--active': vehicle === activeVehicle }
       )}
       onClick={() => onSelectVehicle(vehicle)}
-    />)}
+      aria-label={vehicle}
+    >
+      {vehicle === 'publicTransport' && <span className="testLabel">{_('Test')}</span>}
+    </button>)}
   </div>;
 
 export default VehicleSelector;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -118,25 +118,61 @@ input:valid:focus + .itinerary__field__clear {
 }
 
 .itinerary_vehicles {
-  text-align: center;
+  display: flex;
+  justify-content: center;
   padding: 15px;
 }
 
-.itinerary_button_label {
-  display: inline-block;
+.itinerary_vehicle_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-width: 50px;
   height: 28px;
-  margin: 0 18px;
-  padding-top: 5px;
   border-radius: 14px;
   color: $secondary_text;
   cursor: pointer;
   font-size: 18px;
+  margin: 0 18px;
+  border: 1px solid transparent;
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
+  &:focus {
+    border-color: $secondary_text;
+  }
+
+  &.icon-public-transport {
+    padding: 0 6px 0 9px;
+  }
+
+  &--active {
+    background: $secondary_text;
+    color: $background;
+  }
+
+  .testLabel {
+    font-family: Asap;
+    font-size: 12px;
+    font-weight: bold;
+    color: white;
+    background-color: red;
+    border-radius: 20px;
+    padding: 3px 6px;
+    margin-left: 6px;
+    text-transform: uppercase;
+  }
 }
 
-.label_active {
-  background: $secondary_text;
-  color: $background;
+.itinerary_vehicles--withPublicTransport {
+  margin: 0 18px;
+  justify-content: space-between;
+
+  .itinerary_vehicle_button {
+    margin: 0;
+  }
 }
 
 .itinerary_suggest_your_position {

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -135,7 +135,7 @@ test('origin & destination & mode', async () => {
   expect(directionEndInput).toEqual('47.40000 : 7.59741');
 
   const activeLabel = await page.evaluate(() => {
-    return Array.from(document.querySelector('.label_active').classList).join(',');
+    return Array.from(document.querySelector('.itinerary_vehicle_button--active').classList).join(',');
   });
   expect(activeLabel).toContain('icon-foot');
 });


### PR DESCRIPTION
## Description
Add a 'TEST' label to the public transport mode button.

I also took the opportunity to improve markup & CSS a bit (better element and class name, flex for more adaptative layout, instead of alignment using absolute paddings & margins).
Notably, now the vehicle buttons are truly `<button>` elements, which enables keyboard navigation for free, whereas it was impossible before. I just added special styling to show the currently keyboard-focused button.

## Screenshots
|Before|After|
|---|---|
|![maps dev qwant ninja_maps_routes__mode=driving pt=true(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/74934374-5f057c80-53e6-11ea-8af6-40693bf6daea.png)|![localhost_3000_routes__mode=driving pt=true(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/74934379-63ca3080-53e6-11ea-844b-aadec5c5939f.png)|
|![maps dev qwant ninja_maps_routes__mode=driving pt=true(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/74934388-69277b00-53e6-11ea-994c-7aa15d7c4385.png)|![localhost_3000_routes__mode=driving pt=true(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/74934399-6d539880-53e6-11ea-8ded-6bb4d35a6f34.png)|
|![maps dev qwant ninja_maps_routes__mode=driving pt=true](https://user-images.githubusercontent.com/243653/74934526-b4da2480-53e6-11ea-9ce4-c5363941b902.png)|![localhost_3000_routes__mode=driving pt=true](https://user-images.githubusercontent.com/243653/74934530-b9064200-53e6-11ea-8903-cff6953d8df5.png)|