### PR TITLE
[Public transport] Align roadmap step durations with intructions

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -373,9 +373,23 @@ input:valid:focus + .itinerary__field__clear {
     border-bottom: none;
   }
 
-  &--publicTransport .itinerary_roadmap_item {
-    border-left: 4px solid transparent;
-    cursor: default;
+  &--publicTransport {
+    .itinerary_roadmap_item {
+      border-left: 4px solid transparent;
+      cursor: default;
+    }
+
+    .itinerary_roadmap_distance {
+      align-self: flex-start;
+      padding-top: 14px;
+      line-height: 21px;
+    }
+
+    .icon-icon_chevron-up,
+    .icon-icon_chevron-down {
+      align-self: flex-start;
+      line-height: 21px;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
For public transport roadmaps, align step durations with the step description, and keep them aligned to the top even if the step details are opened.
Make sure the chevron, instruction text and duration are aligned.

## Why
Contrary to driving/walking/cycling roadmaps which are lists of turn-by-burn instructions, public transport roadmaps are structured by legs. So putting durations *between* them is confusing. We decided it's better to put them aligned with each leg description.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 83046_2 36838 destination=latlon_48 86668_2 27926 mode=publicTransport pt=true(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/74940604-fae8b580-53f1-11ea-95c1-33903427a3e6.png)|![localhost_3000_routes__origin=latlon_48 83046_2 36838 destination=latlon_48 86735_2 33083 mode=publicTransport pt=true(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/74940613-ff14d300-53f1-11ea-9ece-4053fa6c8457.png)|
