### PR TITLE
Add loading placeholder for category panel with re-usable component

### DIFF
--- a/src/components/ui/PlaceholderText.jsx
+++ b/src/components/ui/PlaceholderText.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const PlaceholderText = ({ length = 10, tagName = 'div', className }) => {
+  const DomTag = tagName;
+  return <DomTag className={className}>
+    <span className="u-placeholder u-placeholder--text">
+      {Array.from({ length }).map(() => '_').join('')}
+    </span>
+  </DomTag>;
+};
+
+export default PlaceholderText;

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'src/components/ui/Panel';
 import PoiCategoryItemList from './PoiCategoryItemList';
+import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
 import CategoryPanelHeader from './CategoryPanelHeader';
 import Telemetry from 'src/libs/telemetry';
@@ -133,24 +134,24 @@ export default class CategoryPanel extends React.Component {
   render() {
     const { initialLoading, pois, dataSource } = this.state;
 
-    if (initialLoading) {
-      return null;
-    }
-
-    const hasError = !pois || pois.length === 0;
-    const zoomIn = !pois;
-
     let panelContent;
 
-    if (hasError) {
-      panelContent = <CategoryPanelError zoomIn={zoomIn} />;
+    if (initialLoading) {
+      panelContent = <PoiItemListPlaceholder />;
     } else {
-      panelContent = <PoiCategoryItemList
-        pois={pois}
-        selectPoi={this.selectPoi}
-        highlightMarker={this.highlightPoiMarker}
-        onShowPhoneNumber={this.onShowPhoneNumber}
-      />;
+      const hasError = !pois || pois.length === 0;
+      const zoomIn = !pois;
+
+      if (hasError) {
+        panelContent = <CategoryPanelError zoomIn={zoomIn} />;
+      } else {
+        panelContent = <PoiCategoryItemList
+          pois={pois}
+          selectPoi={this.selectPoi}
+          highlightMarker={this.highlightPoiMarker}
+          onShowPhoneNumber={this.onShowPhoneNumber}
+        />;
+      }
     }
 
     return <Panel

--- a/src/panel/category/PoiItemListPlaceholder.jsx
+++ b/src/panel/category/PoiItemListPlaceholder.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ItemList, Item } from 'src/components/ui/ItemList';
+import PlaceholderText from 'src/components/ui/PlaceholderText';
+
+const PoiItemPlaceholder = () =>
+  <div className="category__panel__item">
+    <div className="poiTitleImage u-placeholder" />
+    <PlaceholderText length={25} tagName="h3" className="category__panel__name"/>
+    <PlaceholderText length={15} tagName="p" className="category__panel__type" />
+    <PlaceholderText length={25} tagName="p" className="category__panel__address" />
+    <div className="openingHour"><PlaceholderText length={15} /></div>
+  </div>;
+
+const PoiItemListPlaceholder = ({ nbItems = 6 }) =>
+  <ItemList className="category__panel__items category__panel__items--placeholder">
+    {Array.from({ length: nbItems }).map((_item, index ) => <Item key={index}>
+      <PoiItemPlaceholder />
+    </Item>)}
+  </ItemList>;
+
+export default PoiItemListPlaceholder;

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -5,6 +5,7 @@ import Route from './Route';
 import { getVehicleIcon } from 'src/libs/route_utils';
 import classnames from 'classnames';
 import { Item, ItemList } from 'src/components/ui/ItemList';
+import PlaceholderText from 'src/components/ui/PlaceholderText';
 
 export default class RouteResult extends React.Component {
   static propTypes = {
@@ -98,17 +99,15 @@ export default class RouteResult extends React.Component {
               <div className="itinerary_leg_summary">
                 <div className={`itinerary_leg_icon ${getVehicleIcon(this.props.vehicle)}`} />
                 <div className="itinerary_leg_via">
-                  <div className="itinerary_placeholder-box" style={{ width: '133px' }} />
-                  <div className="itinerary_placeholder-box" style={{ width: '165px' }} />
-                  <div className="itinerary_placeholder-box" style={{ width: '70px' }} />
+                  <div className="routeVia">
+                    <PlaceholderText length={17} />
+                    <PlaceholderText length={20} />
+                  </div>
+                  <PlaceholderText length={10} className="itinerary_leg_via_details"/>
                 </div>
                 <div className="itinerary_leg_info">
-                  <div className="itinerary_leg_duration">
-                    <div className="itinerary_placeholder-box" style={{ width: '47px' }} />
-                  </div>
-                  <div className="itinerary_leg_distance">
-                    <div className="itinerary_placeholder-box" style={{ width: '59px' }} />
-                  </div>
+                  <PlaceholderText length={5} className="itinerary_leg_duration" />
+                  <PlaceholderText length={7} className="itinerary_leg_distance" />
                 </div>
               </div>
             </div>

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -169,19 +169,6 @@ input:valid:focus + .itinerary__field__clear {
   display: inline-block;
 }
 
-.itinerary_leg--placeholder .itinerary_leg_distance {
-  margin: 0;
-}
-
-.itinerary_placeholder-box {
-  margin: 0 0 7px;
-  background: #e0e1e6;
-  border-radius: 3px;
-  height: 13px;
-  display: inline-block;
-}
-
-
 .itinerary_source {
   background: $background;
   border-top: 1px solid #e0e1e6;

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -34,6 +34,10 @@
   }
 }
 
+.category__panel__items {
+  animation: appear 600ms forwards;
+}
+
 .category__panel__item {
   padding: 15px 20px;
   cursor: pointer;

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -1,3 +1,16 @@
 .u-bold {
   font-weight: bold;
 }
+
+.u-placeholder {
+  user-select: none;
+  color: transparent;
+  background-color: #e0e1e6;
+  border-radius: 3px;
+
+  &--text {
+    margin: 0 0 7px;
+    height: 13px;
+    display: inline-block;
+  }
+}


### PR DESCRIPTION
## Description
Introduce a visible loading status for the category panel, to avoid just hiding the panel while we fetch the first POIs, which resulted in the app feeling non-responsive to the user.
To avoid continuous toggling of loading state when we move the map, this loading state is used only when we enter the panel, not for other loading phases which are still done in the background.

![Capture d’écran de 2020-02-24 13-58-47](https://user-images.githubusercontent.com/243653/75154371-dcdec600-570d-11ea-9b84-252121a907ad.png)
For this loading status, we re-use the same kind of text placeholders already used during route computations.
![Capture d’écran de 2020-02-24 13-59-08](https://user-images.githubusercontent.com/243653/75154367-da7c6c00-570d-11ea-8760-a937d072ba22.png)

To ensure consistency of these text placeholder, I introduced a new `<PlaceholderText>` component which standardizes and simplifies markup/style production. 

## Why
Improve UX feedback so the user knows something is happening.

## Screenshots
|Before|After|
|---|---|
|![Peek 24-02-2020 12-08](https://user-images.githubusercontent.com/243653/75153721-5d9cc280-570c-11ea-852e-b76e8978ecfd.gif)|![Peek 24-02-2020 12-07](https://user-images.githubusercontent.com/243653/75153728-61c8e000-570c-11ea-929d-9d244a628978.gif)|
|---|---|
|![Peek 24-02-2020 13-51](https://user-images.githubusercontent.com/243653/75153874-b704f180-570c-11ea-8cd1-53ee061039ec.gif)|![Peek 24-02-2020 13-50](https://user-images.githubusercontent.com/243653/75153883-ba987880-570c-11ea-8253-ccefe2660240.gif)|
