### PR TITLE
Qmaps 1308: add origin/destination pins on the map while completing itinerary fields

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -119,8 +119,8 @@ Scene.prototype.initMapBox = function() {
     fire('map_loaded');
   });
 
-  listen('fit_map', item => {
-    this.fitMap(item, this.getCurrentPaddings());
+  listen('fit_map', (item, zoom) => {
+    this.fitMap(item, this.getCurrentPaddings(), zoom);
   });
 
   listen('map_mark_poi', (poi, options) => {
@@ -225,7 +225,7 @@ Scene.prototype.fitBbox = function(bbox, padding = { left: 0, top: 0, right: 0, 
 };
 
 
-Scene.prototype.fitMap = function(item, padding) {
+Scene.prototype.fitMap = function(item, padding, zoom = true) {
   // BBox
   if (item._ne && item._sw) {
     this.fitBbox(item, padding);
@@ -235,7 +235,7 @@ Scene.prototype.fitMap = function(item, padding) {
     } else { // poi center
       const flyOptions = {
         center: item.latLon,
-        zoom: getBestZoom(item),
+        zoom: zoom ? getBestZoom(item) : this.mb.getZoom(),
         screenSpeed: 1.5,
         animate: false,
       };

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -120,7 +120,7 @@ Scene.prototype.initMapBox = function() {
   });
 
   listen('fit_map', (item, zoom) => {
-    this.fitMap(item, this.getCurrentPaddings(), zoom);
+    this.fitMap(item, { padding: this.getCurrentPaddings(), zoom });
   });
 
   listen('map_mark_poi', (poi, options) => {
@@ -224,26 +224,29 @@ Scene.prototype.fitBbox = function(bbox, padding = { left: 0, top: 0, right: 0, 
   this.mb.fitBounds(bbox, { padding, animate });
 };
 
-
-Scene.prototype.fitMap = function(item, padding, zoom = true) {
+// Move the map to focus on an item
+// Options:
+// - padding: {left, right, top, bottom} (optional)
+// - zoom: true/false (optional)
+Scene.prototype.fitMap = function(item, options = {}) {
   // BBox
   if (item._ne && item._sw) {
-    this.fitBbox(item, padding);
+    this.fitBbox(item, options.padding);
   } else { // PoI
     if (item.bbox) { // poi Bbox
-      this.fitBbox(item.bbox, padding);
+      this.fitBbox(item.bbox, options.padding);
     } else { // poi center
       const flyOptions = {
         center: item.latLon,
-        zoom: zoom ? getBestZoom(item) : this.mb.getZoom(),
+        zoom: options.zoom ? getBestZoom(item) : this.mb.getZoom(),
         screenSpeed: 1.5,
         animate: false,
       };
 
-      if (padding) {
+      if (options.padding) {
         flyOptions.offset = [
-          (padding.left - padding.right) / 2,
-          (padding.top - padding.bottom) / 2,
+          (options.padding.left - options.padding.right) / 2,
+          (options.padding.top - options.padding.bottom) / 2,
         ];
       }
 

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -120,7 +120,7 @@ Scene.prototype.initMapBox = function() {
   });
 
   listen('fit_map', (item, zoom) => {
-    this.fitMap(item, { padding: this.getCurrentPaddings(), zoom });
+    this.fitMap(item, this.getCurrentPaddings(), zoom);
   });
 
   listen('map_mark_poi', (poi, options) => {
@@ -228,25 +228,26 @@ Scene.prototype.fitBbox = function(bbox, padding = { left: 0, top: 0, right: 0, 
 // Options:
 // - padding: {left, right, top, bottom} (optional)
 // - zoom: true/false (optional)
-Scene.prototype.fitMap = function(item, options = {}) {
+Scene.prototype.fitMap = function(item, padding, allowZoom = true) {
+
   // BBox
   if (item._ne && item._sw) {
-    this.fitBbox(item, options.padding);
+    this.fitBbox(item, padding);
   } else { // PoI
     if (item.bbox) { // poi Bbox
-      this.fitBbox(item.bbox, options.padding);
+      this.fitBbox(item.bbox, padding);
     } else { // poi center
       const flyOptions = {
         center: item.latLon,
-        zoom: options.zoom ? getBestZoom(item) : this.mb.getZoom(),
+        zoom: allowZoom ? getBestZoom(item) : this.mb.getZoom(),
         screenSpeed: 1.5,
         animate: false,
       };
 
-      if (options.padding) {
+      if (padding) {
         flyOptions.offset = [
-          (options.padding.left - options.padding.right) / 2,
-          (options.padding.top - options.padding.bottom) / 2,
+          (padding.left - padding.right) / 2,
+          (padding.top - padding.bottom) / 2,
         ];
       }
 

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -53,6 +53,32 @@ export default class SceneDirection {
     listen('unhighlight_step', step => {
       this.unhighlightStep(step);
     });
+
+    listen('set_origin', pos => {
+      this.setOrigin(pos);
+    });
+
+    listen('set_destination', pos => {
+      this.setDestination(pos);
+    });
+  }
+
+  setOrigin = pos => {
+    const originMarker = createMarker(pos, 'itinerary_marker_origin', { draggable: true })
+      .addTo(this.map)
+      .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
+    this.routeMarkers.push(originMarker);
+  }
+
+  setDestination = pos => {
+    const destinationMarker = createMarker(pos,
+      'itinerary_marker_destination', {
+        draggable: true,
+        anchor: 'bottom',
+      })
+      .addTo(this.map)
+      .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
+    this.routeMarkers.push(destinationMarker);
   }
 
   addMarkerSteps(route) {
@@ -112,20 +138,8 @@ export default class SceneDirection {
 
     const { origin, destination } = originDestinationCoords(mainRoute);
 
-    const originMarker = createMarker(origin, 'itinerary_marker_origin', { draggable: true })
-      .addTo(this.map)
-      .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
-
-    const destinationMarker = createMarker(destination,
-      'itinerary_marker_destination', {
-        draggable: true,
-        anchor: 'bottom',
-      })
-      .addTo(this.map)
-      .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
-
-    this.routeMarkers.push(originMarker);
-    this.routeMarkers.push(destinationMarker);
+    this.setOrigin(origin);
+    this.setDestination(destination);
   }
 
   displayRoute() {

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -54,33 +54,35 @@ export default class SceneDirection {
       this.unhighlightStep(step);
     });
 
-    listen('set_origin', pos => {
-      this.setOrigin(pos);
+    listen('set_origin', poi => {
+      this.setOrigin(poi);
     });
 
-    listen('set_destination', pos => {
-      this.setDestination(pos);
+    listen('set_destination', poi => {
+      this.setDestination(poi);
     });
   }
 
-  setOrigin = pos => {
-    const originMarker = createMarker(pos, 'itinerary_marker_origin', { draggable: true })
+  setOrigin = poi => {
+    const originMarker = createMarker(
+      poi.latLon,
+      'itinerary_marker_origin', { draggable: true }
+    )
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
     this.routeMarkers.push(originMarker);
-    window.map.mb.flyTo({ center: pos });
+    fire('fit_map', poi);
   }
 
-  setDestination = pos => {
-    const destinationMarker = createMarker(pos,
-      'itinerary_marker_destination', {
-        draggable: true,
-        anchor: 'bottom',
-      })
+  setDestination = poi => {
+    const destinationMarker = createMarker(
+      poi.latLon,
+      'itinerary_marker_destination', { draggable: true, anchor: 'bottom' }
+    )
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
     this.routeMarkers.push(destinationMarker);
-    window.map.mb.flyTo({ center: pos });
+    fire('fit_map', poi);
   }
 
   addMarkerSteps(route) {
@@ -137,11 +139,11 @@ export default class SceneDirection {
     this.routeMarkers = [];
 
     this.addMarkerSteps(mainRoute);
-
     const { origin, destination } = originDestinationCoords(mainRoute);
 
-    this.setOrigin(origin);
-    this.setDestination(destination);
+    this.setOrigin({ latLon: { lng: origin[0], lat: origin[1] } });
+
+    this.setDestination({ latLon: { lng: destination[0], lat: destination[1] } });
   }
 
   displayRoute() {

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -54,16 +54,16 @@ export default class SceneDirection {
       this.unhighlightStep(step);
     });
 
-    listen('set_origin', (pos) => {
+    listen('set_origin', pos => {
       this.setOrigin(pos);
     });
 
-    listen('set_destination', (pos) => {
+    listen('set_destination', pos => {
       this.setDestination(pos);
     });
   }
 
-  setOrigin = (pos) => {
+  setOrigin = pos => {
     const originMarker = createMarker(pos, 'itinerary_marker_origin', { draggable: true })
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
@@ -71,7 +71,7 @@ export default class SceneDirection {
     window.map.mb.flyTo({ center: pos });
   }
 
-  setDestination = (pos) => {
+  setDestination = pos => {
     const destinationMarker = createMarker(pos,
       'itinerary_marker_destination', {
         draggable: true,

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -56,10 +56,12 @@ export default class SceneDirection {
 
     listen('set_origin', poi => {
       this.setOrigin(poi);
+      fire('fit_map', poi, false);
     });
 
     listen('set_destination', poi => {
       this.setDestination(poi);
+      fire('fit_map', poi, false);
     });
   }
 
@@ -71,7 +73,6 @@ export default class SceneDirection {
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
     this.routeMarkers.push(originMarker);
-    fire('fit_map', poi, false);
   }
 
   setDestination = poi => {
@@ -82,7 +83,6 @@ export default class SceneDirection {
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
     this.routeMarkers.push(destinationMarker);
-    fire('fit_map', poi, false);
   }
 
   addMarkerSteps(route) {

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -54,23 +54,24 @@ export default class SceneDirection {
       this.unhighlightStep(step);
     });
 
-    listen('set_origin', pos => {
+    listen('set_origin', (pos) => {
       this.setOrigin(pos);
     });
 
-    listen('set_destination', pos => {
+    listen('set_destination', (pos) => {
       this.setDestination(pos);
     });
   }
 
-  setOrigin = pos => {
+  setOrigin = (pos) => {
     const originMarker = createMarker(pos, 'itinerary_marker_origin', { draggable: true })
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
     this.routeMarkers.push(originMarker);
+    window.map.mb.flyTo({ center: pos });
   }
 
-  setDestination = pos => {
+  setDestination = (pos) => {
     const destinationMarker = createMarker(pos,
       'itinerary_marker_destination', {
         draggable: true,
@@ -79,6 +80,7 @@ export default class SceneDirection {
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
     this.routeMarkers.push(destinationMarker);
+    window.map.mb.flyTo({ center: pos });
   }
 
   addMarkerSteps(route) {

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -71,7 +71,7 @@ export default class SceneDirection {
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
     this.routeMarkers.push(originMarker);
-    fire('fit_map', poi);
+    fire('fit_map', poi, false);
   }
 
   setDestination = poi => {
@@ -82,7 +82,7 @@ export default class SceneDirection {
       .addTo(this.map)
       .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
     this.routeMarkers.push(destinationMarker);
-    fire('fit_map', poi);
+    fire('fit_map', poi, false);
   }
 
   addMarkerSteps(route) {

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -40,6 +40,10 @@ class DirectionInput extends React.Component {
     }
   }
 
+  onFocus = () => {
+    fire('set_focused_field', this.props.pointType);
+  }
+
   selectItem = async selectedPoi => {
     if (selectedPoi instanceof NavigatorGeolocalisationPoi) {
       this.suggest.setIdle(true);
@@ -89,6 +93,7 @@ class DirectionInput extends React.Component {
         value={this.props.value}
         onChange={this.onChange}
         onKeyPress={this.onKeyPress}
+        onFocus={this.onFocus}
       />
       <div className="icon-x itinerary__field__clear" onMouseDown={this.clear} />
       <div className="itinerary_field_return">

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -40,10 +40,6 @@ class DirectionInput extends React.Component {
     }
   }
 
-  onFocus = () => {
-    fire('set_focused_field', this.props.pointType);
-  }
-
   selectItem = async selectedPoi => {
     if (selectedPoi instanceof NavigatorGeolocalisationPoi) {
       this.suggest.setIdle(true);
@@ -93,7 +89,6 @@ class DirectionInput extends React.Component {
         value={this.props.value}
         onChange={this.onChange}
         onKeyPress={this.onKeyPress}
-        onFocus={this.onFocus}
       />
       <div className="icon-x itinerary__field__clear" onMouseDown={this.clear} />
       <div className="itinerary_field_return">

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -60,6 +60,7 @@ export default class DirectionPanel extends React.Component {
       routes: [],
       activePreviewRoute: null,
       isInitializing: true,
+      focusedField: null
     };
 
     this.restorePoints(props);
@@ -69,6 +70,11 @@ export default class DirectionPanel extends React.Component {
     document.body.classList.add('directions-open');
     this.dragPointHandler = listen('change_direction_point', this.changeDirectionPoint);
     this.setPointHandler = listen('set_direction_point', this.setDirectionPoint);
+    listen('set_focused_field', this.setFocusedField );
+  }
+
+  setFocusedField = field => {
+    this.focusedField = field;
   }
 
   componentWillUnmount() {
@@ -215,9 +221,12 @@ export default class DirectionPanel extends React.Component {
       return;
     }
 
-    // If origin field is empty, set it
-    // or, if destination field is empty, set it
-    if (persistentPointState.origin === null) {
+    // If destination field is empty and focused, set it
+    // else, if origin field is empty (focused or not), set it
+    // else, if destination field is empty (focused or not), set it
+    if (persistentPointState.destination === null && this.focusedField === 'destination') {
+      persistentPointState.destination = poi;
+    } else if (persistentPointState.origin === null) {
       persistentPointState.origin = poi;
     } else if (persistentPointState.destination === null) {
       persistentPointState.destination = poi;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -90,6 +90,16 @@ export default class DirectionPanel extends React.Component {
     Promise.all(poiRestorePromises).then(([ origin, destination ]) => {
       persistentPointState.origin = origin;
       persistentPointState.destination = destination;
+      if (origin) {
+        window.execOnMapLoaded(() => {
+          fire('set_origin', origin.latLon);
+        });
+      }
+      if (destination) {
+        window.execOnMapLoaded(() => {
+          fire('set_destination', destination.latLon);
+        });
+      }
       this.setState({
         origin,
         destination,

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -134,6 +134,11 @@ export default class DirectionPanel extends React.Component {
       // When both fields are not filled yet or not filled anymore
       this.setState({ isLoading: false, isDirty: false, error: 0, routes: [] });
       fire('clean_routes');
+      if (origin) {
+        fire('set_origin', origin.latLon);
+      } else if (destination) {
+        fire('set_destination', destination.latLon);
+      }
     }
   }
 
@@ -209,7 +214,7 @@ export default class DirectionPanel extends React.Component {
     }
 
     // Update state
-    // If both fields are now set, call update() to perform a search and redraw the UI
+    // (Call update() that will perform a search and redraw the UI if both fields are set)
     this.setState({
       origin: persistentPointState.origin,
       destination: persistentPointState.destination,

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -60,7 +60,7 @@ export default class DirectionPanel extends React.Component {
       routes: [],
       activePreviewRoute: null,
       isInitializing: true,
-      focusedField: null
+      focusedField: null,
     };
 
     this.restorePoints(props);

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -60,7 +60,6 @@ export default class DirectionPanel extends React.Component {
       routes: [],
       activePreviewRoute: null,
       isInitializing: true,
-      focusedField: null,
     };
 
     this.restorePoints(props);
@@ -70,11 +69,6 @@ export default class DirectionPanel extends React.Component {
     document.body.classList.add('directions-open');
     this.dragPointHandler = listen('change_direction_point', this.changeDirectionPoint);
     this.setPointHandler = listen('set_direction_point', this.setDirectionPoint);
-    listen('set_focused_field', this.setFocusedField );
-  }
-
-  setFocusedField = field => {
-    this.focusedField = field;
   }
 
   componentWillUnmount() {
@@ -98,12 +92,12 @@ export default class DirectionPanel extends React.Component {
       persistentPointState.destination = destination;
       if (origin) {
         window.execOnMapLoaded(() => {
-          fire('set_origin', origin.latLon);
+          fire('set_origin', origin);
         });
       }
       if (destination) {
         window.execOnMapLoaded(() => {
-          fire('set_destination', destination.latLon);
+          fire('set_destination', destination);
         });
       }
       this.setState({
@@ -151,9 +145,9 @@ export default class DirectionPanel extends React.Component {
       this.setState({ isLoading: false, isDirty: false, error: 0, routes: [] });
       fire('clean_routes');
       if (origin) {
-        fire('set_origin', origin.latLon);
+        fire('set_origin', origin);
       } else if (destination) {
-        fire('set_destination', destination.latLon);
+        fire('set_destination', destination);
       }
     }
   }
@@ -221,12 +215,9 @@ export default class DirectionPanel extends React.Component {
       return;
     }
 
-    // If destination field is empty and focused, set it
-    // else, if origin field is empty (focused or not), set it
-    // else, if destination field is empty (focused or not), set it
-    if (persistentPointState.destination === null && this.focusedField === 'destination') {
-      persistentPointState.destination = poi;
-    } else if (persistentPointState.origin === null) {
+    // If origin field is empty, set it
+    // else, if destination field is empty, set it
+    if (persistentPointState.origin === null) {
       persistentPointState.origin = poi;
     } else if (persistentPointState.destination === null) {
       persistentPointState.destination = poi;


### PR DESCRIPTION
## Description
- Add start/end pin on field input or map click
- Center the map on the marker
- The destination pin can be set first if the destination field is focused
- The pin also appears when one field is set and the page is refreshed

## Why
We didn't have a visual clue on the map representing the field that was already filled

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/75266636-ec840a80-57f2-11ea-8d81-a7091f3e6a4f.png)
![image](https://user-images.githubusercontent.com/1225909/75266683-fefe4400-57f2-11ea-8b38-efb9eec7c701.png)


