### PR TITLE
Fix: don't open POI when zooming with double click

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -121,6 +121,12 @@ Scene.prototype.initMapBox = function() {
     this.clickDelayHandler = null;
     this.mb.on('click', e => {
       const pois = this.mb.queryRenderedFeatures(e.point, { layers: interactiveLayers });
+      // when clicking on a POI, just trigger the action without delay,
+      // as a subsequent double click isn't a problem
+      if (pois[0]) {
+        this.clickOnMap(e.lngLat, pois[0]);
+        return;
+      }
       // cancel the previous click handler if it's still pending
       clearTimeout(this.clickDelayHandler);
       // if this is a real mouse double-click, we can simply return here
@@ -132,7 +138,7 @@ Scene.prototype.initMapBox = function() {
         if (Date.now() - this.lastDoubleTapTimeStamp < this.DOUBLE_TAP_DELAY_MS) {
           return;
         }
-        this.clickOnMap(e.lngLat, pois[0]);
+        this.clickOnMap(e.lngLat, null);
       }, this.DOUBLE_TAP_DELAY_MS);
     });
 

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -120,17 +120,17 @@ Scene.prototype.initMapBox = function() {
     // which are thrown *after* two separate click events are thrown
     this.clickDelayHandler = null;
     this.mb.on('click', e => {
+      // cancel the previous click handler if it's still pending
+      clearTimeout(this.clickDelayHandler);
+      // if this is a real mouse double-click, we can simply return here
+      if (e.originalEvent.detail >= 2) {
+        return;
+      }
       const pois = this.mb.queryRenderedFeatures(e.point, { layers: interactiveLayers });
       // when clicking on a POI, just trigger the action without delay,
       // as a subsequent double click isn't a problem
       if (pois[0]) {
         this.clickOnMap(e.lngLat, pois[0]);
-        return;
-      }
-      // cancel the previous click handler if it's still pending
-      clearTimeout(this.clickDelayHandler);
-      // if this is a real mouse double-click, we can simply return here
-      if (e.originalEvent.detail >= 2) {
         return;
       }
       this.clickDelayHandler = setTimeout(() => {

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -81,6 +81,20 @@ Scene.prototype.initMapBox = function() {
     'poi-level-public-transports-2',
   ];
 
+  // Max time between two touch to be considered a single "double click" event
+  // This is the value Mapbox-GL uses, in src/ui/handler/dblclick_zoom.js
+  this.DOUBLE_TAP_DELAY_MS = 300;
+  this.lastDoubleTapTimeStamp = 0;
+  this.lastTouchEndTimeStamp = 0;
+  this.mb.on('touchend', _e => {
+    const timeStamp = Date.now();
+    // maybe we should also check the distance between the two touch events…
+    if (timeStamp - this.lastTouchEndTimeStamp < this.DOUBLE_TAP_DELAY_MS) {
+      this.lastDoubleTapTimeStamp = timeStamp;
+    }
+    this.lastTouchEndTimeStamp = timeStamp;
+  });
+
   this.mb.on('load', () => {
     this.onHashChange();
     new SceneDirection(this.mb);
@@ -102,9 +116,24 @@ Scene.prototype.initMapBox = function() {
       this.popup.addListener(interactiveLayer);
     });
 
+    // we have to delay click event resolution to make time for possible double click events,
+    // which are thrown *after* two separate click events are thrown
+    this.clickDelayHandler = null;
     this.mb.on('click', e => {
       const pois = this.mb.queryRenderedFeatures(e.point, { layers: interactiveLayers });
-      this.clickOnMap(e.lngLat, pois[0]);
+      // cancel the previous click handler if it's still pending
+      clearTimeout(this.clickDelayHandler);
+      // if this is a real mouse double-click, we can simply return here
+      if (e.originalEvent.detail >= 2) {
+        return;
+      }
+      this.clickDelayHandler = setTimeout(() => {
+        // for touch UX we have to make sure a double tap zoom hasn't been made in the meantime
+        if (Date.now() - this.lastDoubleTapTimeStamp < this.DOUBLE_TAP_DELAY_MS) {
+          return;
+        }
+        this.clickOnMap(e.lngLat, pois[0]);
+      }, this.DOUBLE_TAP_DELAY_MS);
     });
 
     this.mb.on('moveend', () => {


### PR DESCRIPTION
## Description
Proposes a solution to fix the problem of double click/tap zooms also triggering a click on the map, which always opens the POI panel even if the user just wanted to zoom in.

## Cause
The problem is due to the way `click` and `dblclick` events are managed by the browser.
On desktop browsers (no touch), when the user double click with the mouse, **3 events are thrown**, always in this order:
 1. a first `click` event
 2. a second `click` event
 3. a `dblclick` event
The second `click` event and the `dblclick` event are the same underlying object, with a property [`detail`](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail) which indicates the number of actual clicks at the same coordinates (here `detail` will be 2).

Each click triggers our `click` listener on map, which calls the `clickOnMap` function, opening the POI panel.
Because the `doubleClickZoom` option is `true`, the `dblclick` event is listened internally by the Mapbox-GL instance which performs the zoom after.

On touch-based devices, there is no `dblclick` event, but MapBox-GL has heuristics to consider two close (in time and distance) `touchend` events as a single equivalent action (https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/handler/dblclick_zoom.js).

## Principle of the fix
**To prevent the POI action from happening when zooming with double click, we need to delay the handling of a click until we are sure no `dblclick` event or the touch equivalent will happen just after the first click.**

 1. in the `click` listener, we delay the call to `clickOnMap` with `setTimeout`.
 2. here there are two cases
    a. if it was a single click action by the user, the `clickOnMap` will be called normally after the delay has passed
    b. if the user actually double clicked/tapped, the `click` listener will be called a second time immediately, before the end of the `setTimeout`. We can then cancel the `timeOut`, which will prevent the POI panel from opening.

The most complicated part is detecting the cancellation condition on mobile, i.e. detecting two `touchend` events formed a double tap that happened within the authorized delay. For now I used a really simple rule based on timestamp only, ignoring the multitouch dimension and the distance between the positions of the touch. It seems to work fine, but I hope it won't cause bugs…

For the delay, I used the same value as MapBox to consider what is a double click/tap, i.e. 300ms.
Of course, **this has the consequence of delaying all click actions on the map by 300ms**, making it seem less responsive…
*Update: when clicking on a POI, we can safely skip the delay and trigger `clickOnMap`. Thanks @amatissart for the suggestion :)*

Maybe I overlooked some better solution but I don't think there is one, as we can't predict the user is in the middle of a double click/tap or not.
