### PR TITLE
Disable burger menu and masq if user-agent matches regex rule

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -103,7 +103,15 @@ function App(config) {
 
   const ogMeta = new require('./middlewares/og_meta')(config);
   router.get('/*', ogMeta, (req, res) => {
-    res.render('index', { config });
+    const userAgent = req.headers['user-agent'];
+    const disableMenuRule = config.server.disableBurgerMenu.userAgentRule;
+    let appConfig = config;
+    if (disableMenuRule && userAgent && userAgent.match(disableMenuRule)) {
+      appConfig = JSON.parse(JSON.stringify(config));
+      appConfig.burgerMenu.enabled = false;
+      appConfig.masq.enabled = false;
+    }
+    res.render('index', { config: appConfig });
   });
 
   if (config.server.acceptPostedLogs) {

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -12,6 +12,8 @@ server:
       timeout: 2000 # ms
   logger:
     headersWhitelistEnabled: true
+  disableBurgerMenu:
+    userAgentRule: '' # regex, ignored if empty
   routerBaseUrl: / # path prefix expected by the express server
   # NB: `routerBaseUrl` may be different from `system.baseUrl` if a proxy is responsible for rewriting URLs
 


### PR DESCRIPTION
## Description
Add a server configuration to force `burgerMenu.enabled = false` and `masq.enabled = false` if the request matches a given user-agent rule.
