### PR TITLE
Loading indicator improvements

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -156,7 +156,7 @@ export default class CategoryPanel extends React.Component {
 
     return <Panel
       resizable
-      title={<CategoryPanelHeader dataSource={dataSource} />}
+      title={<CategoryPanelHeader dataSource={dataSource} loading={initialLoading} />}
       minimizedTitle={_('Show results', 'categories')}
       close={this.close}
       className="category__panel"

--- a/src/panel/category/CategoryPanelHeader.jsx
+++ b/src/panel/category/CategoryPanelHeader.jsx
@@ -1,8 +1,16 @@
 /* global _ */
 import React from 'react';
 import { sources } from 'config/constants.yml';
+import PlaceholderText from 'src/components/ui/PlaceholderText';
 
-const CategoryPanelHeader = ({ dataSource }) => {
+const CategoryPanelHeader = ({ loading, dataSource }) => {
+  if (loading) {
+    return <div className="category__panel__pj">
+      <PlaceholderText length={10} />
+      <PlaceholderText length={7} />
+    </div>;
+  }
+
   if (dataSource === sources.pagesjaunes) {
     return <div className="category__panel__pj">
       <div className="category__panel__pj_title">

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -2,11 +2,17 @@
   font-weight: bold;
 }
 
+@keyframes placeholderPulse {
+  from { opacity: 0.6; }
+  to { opacity: 1; }
+}
+
 .u-placeholder {
   user-select: none;
   color: transparent;
   background-color: #e0e1e6;
   border-radius: 3px;
+  animation: placeholderPulse 0.8s ease-in-out alternate infinite;
 
   &--text {
     margin: 0 0 7px;

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -15,7 +15,7 @@
   animation: placeholderPulse 0.8s ease-in-out alternate infinite;
 
   &--text {
-    margin: 0 0 7px;
+    margin: 4px 0 3px;
     height: 13px;
     display: inline-block;
   }


### PR DESCRIPTION
## Description
Tweak the loading placeholders so they appear to "pulse", better indicating the app is working and not stuck.
Also add text placeholders in the category panel header.

## Why
Tweaks proposed by the designer.

## Screenshots
![Peek 27-02-2020 15-57](https://user-images.githubusercontent.com/243653/75456329-ac4f9400-597a-11ea-9a3a-35a66448062c.gif)