### PR TITLE
Fix header color of mobile POI panel

### DIFF
--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -194,7 +194,6 @@ export default class PoiPanel extends React.Component {
         'poi_panel--empty-header': !isFromPagesJaunes(poi) && !isFromFavorite && !isFromCategory,
       } )}
       initialSize="maximized"
-      white
     >
       <div className="poi_panel__content">
         <div className="poi_panel__description_container" onClick={this.center}>

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -499,10 +499,6 @@ $HEADER_SIZE: 40px;
 }
 
 @media (max-width: 640px) {
-  .poi_panel .panel-header {
-    margin-bottom: 0;
-  }
-
   .poi_panel__header {
     margin-left: 0;
   }
@@ -515,13 +511,15 @@ $HEADER_SIZE: 40px;
   .poi_panel {
     .panel-header {
       height: auto;
-      background-color: #f4f6fa;
+      background-color: $surface;
       padding-bottom: 0;
       padding-left: 6px;
+      margin-bottom: 0;
     }
 
     .panel-content {
       box-shadow: rgba(0, 0, 0, 0.16) 1px 1px 6px;
+      background: white;
     }
   }
 


### PR DESCRIPTION
## Description
Fixes a bug on the maximized panel area that creates the effect of sliding under the top bar. On the poi panel, this area must be gray.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_place_osm_node_676116665@Le_Mayflower(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/75461788-8e3a6180-5983-11ea-9cea-5394a58eb788.png)|![localhost_3000_place_osm_node_3688496698@Institut_Europ%C3%A9en_des_Affaires(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/75461802-92ff1580-5983-11ea-9630-39270089e4cc.png)|


