### PR TITLE
Fix sharable urls of POIS

### DIFF
--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -18,7 +18,7 @@ export function toAbsoluteUrl(poi) {
   const lat = poi.latLon.lat.toFixed(7);
   const lon = poi.latLon.lng.toFixed(7);
   const mapHash = `#map=${getBestZoom(poi)}/${lat}/${lon}`;
-  return `${protocol}//${host}${baseUrl}place/${toUrl(poi)}/${mapHash}`;
+  return `${protocol}//${host}${baseUrl}place/${toUrl(poi)}${mapHash}`;
 }
 
 export function fromUrl(urlParam) {


### PR DESCRIPTION
## Description
Remove a slash in URLs generated when sharing POIs, which results in the POI panel and marker not being properly restored when the URL is opened in another tab.