### PR TITLE
Tweak the look of public transport roadmap bullets

### DIFF
--- a/src/panel/direction/TransportLineLeg.jsx
+++ b/src/panel/direction/TransportLineLeg.jsx
@@ -27,9 +27,14 @@ const TransportLineLeg = ({ leg }) => {
       <span className={`icon-icon_chevron-${detailsOpen ? 'up' : 'down'}`} />
     </div>
     {detailsOpen && <div className="itinerary_roadmap_substeps">
-      <div>{from.name}</div>
-      {stops.map((stop, index) => <div key={index}>{stop.name}</div>)}
-      <div>{to.name}</div>
+      {[from, ...stops, to].map((stop, index) =>
+        <div className="itinerary_roadmap_substep" key={index}>
+          <div
+            className="itinerary_roadmap_substep_bullet"
+            style={{ borderColor: info.lineColor ? `#${info.lineColor}` : 'black' }}
+          />
+          {stop.name}
+        </div>)}
     </div>}
   </RoadMapItem>;
 };

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -427,26 +427,25 @@ input:valid:focus + .itinerary__field__clear {
   }
 }
 
-.itinerary_roadmap_item--transportLine .itinerary_roadmap_substeps > div {
-  position: relative;
-  padding-top: 6px;
-
-  &:before {
-    background: white;
-    content: '';
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
-    border-radius: 50%;
-    width: 5px;
-    height: 5px;
-    position: absolute;
-    top: 12px;
-    left: -32px;
-  }
-}
-
-.itinerary_roadmap_item--walk .itinerary_roadmap_substep {
+.itinerary_roadmap_substep {
   display: flex;
-  padding-top: 6px;
+  padding: 3px 0;
+  position: relative;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &_bullet {
+    background: white;
+    border-radius: 50%;
+    border: 3px solid;
+    width: 13px;
+    height: 13px;
+    position: absolute;
+    top: 6px;
+    left: -36px;
+  }
 
   .itinerary_roadmap_icon {
     margin: 0 6px 0 0;
@@ -476,6 +475,11 @@ input:valid:focus + .itinerary__field__clear {
   &--walk {
     background: url(../images/direction_icons/walking_bullet_roadmap.png) repeat space;
     background-size: 7px 10px;
+  }
+
+  &--transportLine {
+    height: calc(100% - 36px);
+    top: 42px;
   }
 }
 

--- a/src/scss/includes/routes.scss
+++ b/src/scss/includes/routes.scss
@@ -1,6 +1,5 @@
 .routePtLine {
   padding: 3px 4px 2px;
-  margin: 0 2px;
   border: 1px solid transparent;
   border-radius: 3px;
   font-weight: bold;
@@ -26,7 +25,7 @@
 
     &:not(:last-child):after {
       content: '›';
-      padding: 0 3px;
+      padding: 0 5px;
       font-size: 28px;
       color: silver;
     }


### PR DESCRIPTION
## Description
Change the look of public transport roadmap sections to match the designs more closely.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 87036_2 32593 destination=latlon_48 83429_2 36375 mode=publicTransport pt=true (1)](https://user-images.githubusercontent.com/243653/75563151-2569ec80-5a4a-11ea-9c17-e952f6cd0ce4.png)|![localhost_3000_routes__origin=latlon_48 87036_2 32593 destination=latlon_48 83429_2 36375 mode=publicTransport pt=true (3)](https://user-images.githubusercontent.com/243653/75563163-29960a00-5a4a-11ea-8bec-6e07e9286a7f.png)|
