### PR TITLE
directions: Fix incorrect error handling in first cycling request

### DIFF
--- a/src/adapters/direction_api.js
+++ b/src/adapters/direction_api.js
@@ -32,7 +32,7 @@ export default class DirectionApi {
     if (mode === modes.CYCLING) {
       // Fetch routes without ferry in priority
       const firstSearch = await DirectionApi._search(start, end, mode, { exclude: 'ferry' });
-      if (firstSearch && firstSearch.routes && firstSearch.routes.length > 0) {
+      if (firstSearch.data && firstSearch.data.routes && firstSearch.data.routes.length > 0) {
         return firstSearch;
       }
     }


### PR DESCRIPTION
## Description
In cycling mode, the first directions request uses an extra parameter to avoid ferry routes. And if no route is found, a second request is executed with default parameters (that will possibly return routes with ferries).  

The check on the first response was incorrect and the second request was always executed :(

