### PR TITLE
Routes: ignore obsolete pending query results

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -49,6 +49,8 @@ export default class DirectionPanel extends React.Component {
     const activeVehicle = this.vehicles.indexOf(props.mode) !== -1
       ? props.mode : modes.DRIVING;
 
+    this.lastQueryId = 0;
+
     this.state = {
       vehicle: activeVehicle,
       origin: persistentPointState.origin || null,
@@ -109,11 +111,16 @@ export default class DirectionPanel extends React.Component {
     const { origin, destination, vehicle } = this.state;
     if (origin && destination) {
       this.setState({ isDirty: false, isLoading: true, error: 0, routes: [] });
+      const currentQueryId = ++this.lastQueryId;
       const directionResponse = await DirectionApi.search(
         origin,
         destination,
         vehicle,
       );
+      // A more recent query was done in the meantime, ignore this result silently
+      if (currentQueryId !== this.lastQueryId) {
+        return;
+      }
       if (directionResponse && directionResponse.error === 0) {
         // Valid, non-empty response
         const routes = directionResponse.data.routes.map((route, i) => ({


### PR DESCRIPTION
## Description
Simple fix to avoid displaying route results from a previous query.

Typically happens when computing a route takes a long time (example: bicycle accross the whole France), and the user switches to another vehicle or change origin or destination points before the result arrives. If the second query takes less time, it may be displayed first, but then be replaced by the result from the first query, resulting in inconsistent display.

![Peek 05-03-2020 15-52](https://user-images.githubusercontent.com/243653/75993241-76ba2600-5ef9-11ea-9123-6f210fcf5294.gif)

The fix consist of keeping track locally and globally of the latest query time, and comparing these two values after receiving the results. If they are different, it means we received old results, that can be safely ignored.
For now we don't abort the XHR request like some other API calls in Erdapfel do, we just fix the big UX bug.
