### PR TITLE
Improve resizable panel responsiveness

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -22,7 +22,7 @@ export default class Panel extends React.Component {
     title: PropTypes.node,
     minimizedTitle: PropTypes.node,
     resizable: PropTypes.bool,
-    initialSize: PropTypes.string,
+    initialSize: PropTypes.oneOf(['default', 'minimized', 'maximized']),
     marginTop: PropTypes.number,
     close: PropTypes.func,
     className: PropTypes.string,
@@ -31,6 +31,7 @@ export default class Panel extends React.Component {
 
   static defaultProps = {
     marginTop: 0,
+    initialSize: 'default',
   }
 
   constructor(props) {
@@ -77,7 +78,7 @@ export default class Panel extends React.Component {
 
     this.setState(previousState => ({
       currentHeight: this.startHeight,
-      size: null,
+      size: 'default',
       previousSize: previousState.size,
       holding: true,
     }));
@@ -107,10 +108,10 @@ export default class Panel extends React.Component {
 
     const { previousSize, currentHeight } = this.state;
 
-    let size = null;
+    let size = 'default';
     if (event.timeStamp - this.interactionStarted < CLICK_RESIZE_TIMEOUT_MS) {
       // the resize handler was only clicked, provide 'smart' resize
-      size = !previousSize ? 'minimized' : null;
+      size = previousSize === 'default' ? 'minimized' : 'default';
     } else {
       // the resize handler was really dragged-n-dropped
       const maxSize = window.innerHeight - this.props.marginTop;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -282,7 +282,7 @@ export default class DirectionPanel extends React.Component {
             {!activePreviewRoute && form}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel className="directionResult_panel" resizable>
+            <Panel className="directionResult_panel" resizable marginTop={160}>
               {result}
             </Panel>}
           {activePreviewRoute &&

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -282,7 +282,7 @@ export default class DirectionPanel extends React.Component {
             {!activePreviewRoute && form}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel className="directionResult_panel" resizable marginTop={160} >
+            <Panel className="directionResult_panel" resizable>
               {result}
             </Panel>}
           {activePreviewRoute &&


### PR DESCRIPTION
## Description
Tries a new, simpler heuristic for the resizable panel responsiveness to touch gestures.
Previously, we defined 3 pixel values, corresponding to the 3 size states of the panel (`'default'`, `'minimized'` and `'maximized'`). The new size set after dragging and releasing the handle was determined by where the user released this handle, the closest pixel value giving the new size.

It had two related UX problems:
 - it required big gestures to cross the height thresholds. For example when going from `default` to `maximized`, the user had to drag the panel a long way, which was worse for big screens.
 - it wasn't responsive to quick swipe movements, which are common across many apps, appearing broken.

This PR proposes to fix that by using only the direction of the movement and a small threshold to trigger it. 

It also tries to improve code clarity with more explicit naming and simpler flow.

## Why
With the current implementation, the panel requires a lot of finger movement to be maximized, and sometimes doesn't appear to respond logically.

## Screenshots
Hard to showcase as gif, you'll have to test by yourself on a real phone :)
