### PR TITLE
Add cache header on logo files fetched agressively by chrome mobile

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -79,7 +79,7 @@ function App(config) {
     fallthrough: false,
     maxAge: config.statics.maxAge,
     setHeaders: (res, path, _stat) => {
-      if (path.endsWith('/favicon.png')) {
+      if (path.endsWith('/favicon.png') || path.match(/logo_\d+.png$/)) {
         /* Chrome Mobile reloads favicon on each map move */
         res.set('Cache-Control', 'public, max-age=300');
       }


### PR DESCRIPTION
## Why
We already noticed that Chrome mobile could fetch the favicon file on each map move (!). 
This phenomenon also affects the logo files that may be used as a replacement for the default favicon.

This PR sets a cache header to avoid redundant requests to these files.
