### PR TITLE
Enable POI anywhere on Android with long-touch

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -142,6 +142,12 @@ Scene.prototype.initMapBox = function() {
       }, this.DOUBLE_TAP_DELAY_MS);
     });
 
+    if (isMobileDevice()) {
+      this.mb.on('contextmenu', e => {
+        this.clickOnMap(e.lngLat, null, { longTouch: true });
+      });
+    }
+
     this.mb.on('moveend', () => {
       const { lng, lat } = this.mb.getCenter();
       const zoom = this.mb.getZoom();
@@ -187,22 +193,18 @@ Scene.prototype.getCurrentPaddings = () => getMapPaddings({
   isDirectionsActive: !!document.querySelector('.directions-open'),
 });
 
-Scene.prototype.clickOnMap = function(lngLat, clickedFeature) {
-
-  // Ignore clicks anywhere on mobile if direction panel is not open
-  if (isMobileDevice() && !clickedFeature && !document.querySelector('.directions-open')) {
-    window.app.navigateTo('/');
-    return;
-  }
-
+Scene.prototype.clickOnMap = function(lngLat, clickedFeature, { longTouch = false } = {}) {
   // Instantiate the place clicked as a PoI
   const poi = clickedFeature ? new MapPoi(clickedFeature) : new LatLonPoi(lngLat);
 
-  // If Direction panel is open, tell it to fill its fields with this PoI, on PC and mobile
-  // Else, open PoI panel
   if (document.querySelector('.directions-open')) {
+    // If Direction panel is open, tell it to fill its fields with this PoI
     fire('set_direction_point', poi);
+  } else if (isMobileDevice() && !clickedFeature && !longTouch) {
+    // On mobile, simple clicks anywhere close the currently open panel
+    window.app.navigateTo('/');
   } else {
+    // Default case: open the POI panel
     window.app.navigateTo(`/place/${toUrl(poi)}`, { poi });
   }
 };


### PR DESCRIPTION
## Description
Allow Android users to use a "long touch" action to display info on an arbitrary map location (aka. "POI anywhere").
Doesn't change the action associated with a short touch (closing the currently opened panel).

For now it works on Android browsers only, as they map natively long touch interactions with the `contextmenu` event, which is easy to listen to.
iOS browsers don't do that and would probably require some hacks using `touchstart` and `touchend` events to detect long touch actions. As I don't have access to an iPhone device for extended testing, I prefer postponing that for these devices. Progressive enhancement FTW :)
I just used somebody's else iPhone to ensure this `contextmenu` handler doesn't introduce bugs.
