### PR TITLE
QMAPS-1318 move geolocation button during mobile preview

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -180,6 +180,10 @@ Scene.prototype.initMapBox = function() {
   listen('move_mobile_bottom_ui', bottom => {
     this.moveMobileBottomUI(bottom);
   });
+
+  listen('move_mobile_geolocation_button', bottom => {
+    this.moveMobileGeolocationButton(bottom);
+  });
 };
 
 Scene.prototype.getCurrentPaddings = () => getMapPaddings({
@@ -384,6 +388,12 @@ Scene.prototype.moveMobileBottomUI = function(bottom = 0) {
     uiControls.forEach(uiControl => {
       this.translateUIControl(uiControl, bottom);
     });
+  }
+};
+
+Scene.prototype.moveMobileGeolocationButton = function(bottom = 0) {
+  if (isMobileDevice() || bottom === 0) {
+    this.translateUIControl('.mapboxgl-ctrl-geolocate', bottom);
   }
 };
 

--- a/src/panel/direction/MobileRoadMapPreview.jsx
+++ b/src/panel/direction/MobileRoadMapPreview.jsx
@@ -13,6 +13,7 @@ export default class MobileRoadMapPreview extends React.Component {
 
   componentDidMount() {
     this.zoomToCurrentStep();
+    fire('move_mobile_geolocation_button', 65);
   }
 
   zoomToCurrentStep = () => {


### PR DESCRIPTION
## Description
move geolocation button 65px up during mobile preview

## Why
they were hidden by the < / > buttons

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/76227809-235d1600-6220-11ea-8988-6614ebb27190.png)

