### PR TITLE
Fix Favorite button keeping previous state

### DIFF
--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -2,91 +2,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Telemetry from '../../libs/telemetry';
-import { openAndWaitForClose as openMasqFavModalAndWaitForClose }
-  from 'src/modals/MasqFavoriteModal';
-import Store from '../../adapters/store';
-import { isFromPagesJaunes } from 'src/libs/pois';
-
-const store = new Store();
-
-async function isPoiFavorite(poi) {
-  try {
-    const storePoi = await store.has(poi);
-    return !!storePoi;
-  } catch (e) {
-    return false;
-  }
-}
 
 export default class ActionButtons extends React.Component {
   static propTypes = {
     poi: PropTypes.object.isRequired,
     isDirectionActive: PropTypes.bool,
-    isMasqEnabled: PropTypes.bool,
-    isFromCategory: PropTypes.bool,
-    isFromFavorite: PropTypes.bool,
     openDirection: PropTypes.func,
     openShare: PropTypes.func,
-  }
-
-  state = {
-    showPhoneNumber: !isFromPagesJaunes(this.props.poi),
-    poiIsInFavorite: false,
-  };
-
-  componentDidMount() {
-    this.storeAddHandler = listen('poi_added_to_favs', poi => {
-      if (poi === this.props.poi) {
-        this.setState({ poiIsInFavorite: true });
-      }
-    });
-
-    this.storeRemoveHandler = listen('poi_removed_from_favs', poi => {
-      if (poi === this.props.poi) {
-        this.setState({ poiIsInFavorite: false });
-      }
-    });
-
-    this.updateFavoriteState();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.poi !== this.props.poi) {
-      this.updateFavoriteState();
-    }
-  }
-
-  updateFavoriteState() {
-    isPoiFavorite(this.props.poi).then(poiIsInFavorite => {
-      this.setState({ poiIsInFavorite });
-    });
-  }
-
-  componentWillUnmount() {
-    window.unListen(this.storeAddHandler);
-    window.unListen(this.storeRemoveHandler);
-  }
-
-  showPhone = () => {
-    if (this.props.poi && this.props.poi.meta && this.props.poi.meta.source) {
-      Telemetry.add('phone', 'poi', this.props.poi.meta.source,
-        Telemetry.buildInteractionData({
-          id: this.props.poi.id,
-          source: this.props.poi.meta.source,
-          template: 'single',
-          zone: 'detail',
-          element: 'phone',
-        })
-      );
-    }
-    this.setState({ showPhoneNumber: true });
+    isPhoneNumberVisible: PropTypes.bool,
+    showPhoneNumber: PropTypes.func,
+    isPoiInFavorite: PropTypes.bool,
+    toggleStorePoi: PropTypes.func.isRequired,
   }
 
   renderPhone() {
-    if (!this.state.showPhoneNumber) {
+    if (!this.props.isPhoneNumberVisible) {
       return <button className="poi_panel__action icon-icon_phone poi_phone_container_hidden"
-        onClick={this.showPhone}
+        onClick={this.props.showPhoneNumber}
       >
         <div>{_('SHOW NUMBER', 'poi')}</div>
       </button>;
@@ -99,23 +31,6 @@ export default class ActionButtons extends React.Component {
     </a>;
   }
 
-  toggleStorePoi = async () => {
-    if (this.props.poi.meta && this.props.poi.meta.source) {
-      Telemetry.add('favorite', 'poi', this.props.poi.meta.source);
-    }
-    if (this.state.poiIsInFavorite) {
-      store.del(this.props.poi);
-    } else {
-      if (this.props.isMasqEnabled) {
-        const isLoggedIn = await store.isLoggedIn();
-        if (!isLoggedIn) {
-          await openMasqFavModalAndWaitForClose();
-        }
-      }
-      store.add(this.props.poi);
-    }
-  }
-
   render() {
     const shouldRenderPhone = this.props.poi.blocksByType && this.props.poi.blocksByType.phone;
 
@@ -124,13 +39,13 @@ export default class ActionButtons extends React.Component {
         'poi_panel__action',
         'poi_panel__actions__icon__store',
         {
-          'icon-icon_star-filled': this.state.poiIsInFavorite,
-          'icon-icon_star': !this.state.poiIsInFavorite,
+          'icon-icon_star-filled': this.props.isPoiInFavorite,
+          'icon-icon_star': !this.props.isPoiInFavorite,
         })
       }
-      onClick={this.toggleStorePoi}
+      onClick={this.props.toggleStorePoi}
       >
-        <div>{this.state.poiIsInFavorite ? _('SAVED', 'poi') : _('FAVORITES', 'poi')}</div>
+        <div>{this.props.isPoiInFavorite ? _('SAVED', 'poi') : _('FAVORITES', 'poi')}</div>
       </button>
       <button className="poi_panel__action icon-share-2" onClick={this.props.openShare}>
         <div>{_('SHARE', 'poi')}</div>

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -48,6 +48,16 @@ export default class ActionButtons extends React.Component {
       }
     });
 
+    this.updateFavoriteState();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.poi !== this.props.poi) {
+      this.updateFavoriteState();
+    }
+  }
+
+  updateFavoriteState() {
     isPoiFavorite(this.props.poi).then(poiIsInFavorite => {
       this.setState({ poiIsInFavorite });
     });


### PR DESCRIPTION
## Description
Ensure the "save POI to favorite" button is up-to-date with the real favorite status of the POI displayed.

## Why
There is a currently a bug: when going from POI to POI (for example by clicking different places on the map), the favorite button keeps the saved/unsaved state of the first POI clicked in the series, or of the last which actually changed, ignoring the real state of the current POI.

This happens because the `ActionButtons` instance is now re-used by React, instead of being unmounted/remounted each time like it was during the migration phase.