### PR TITLE
Fix benchmark URL overload

### DIFF
--- a/bench/performances.js
+++ b/bench/performances.js
@@ -113,15 +113,11 @@ async function wait(time) {
 async function serverStart() {
   const App = require(path.join(__dirname, '../bin/app'));
   const configBuilder = require('@qwant/nconf-builder');
-
-  configBuilder.set('store:name', 'local_store');
-
-  configBuilder.set('mapStyle:poiMapUrl', `["http://localhost:${PORT}/fake_pbf/{z}/{x}/{y}.pbf"]`);
-  configBuilder.set('mapStyle:baseMapUrl', `["http://localhost:${PORT}/fake_pbf/{z}/{x}/{y}.pbf"]`);
-  configBuilder.set('performance:enabled', true);
-
-
-  const config = configBuilder.get();
+  const config = configBuilder.get_without_check();
+  config.mapStyle.baseMapUrl = `["http://localhost:${PORT}/fake_pbf/{z}/{x}/{y}.pbf"]`;
+  config.mapStyle.poiMapUrl = `["http://localhost:${PORT}/fake_pbf/{z}/{x}/{y}.pbf"]`;
+  config.performance.enabled = true;
+  config.store.name = 'local_store';
   const appServer = new App(config);
 
   console.log(`Start test on PORT : ${PORT}`);

--- a/local_modules/nconf_builder/index.js
+++ b/local_modules/nconf_builder/index.js
@@ -54,10 +54,6 @@ class ConfigChecker {
     return confToCheck;
   }
 
-  set(key, value) {
-    this.conf.set(key, value);
-  }
-
   get_without_check() {
     return this.conf.get();
   }


### PR DESCRIPTION
The `set` method works but only if it has been overwrote once. In here, if you have an environment variable, the bench `set` call won't work.