### PR TITLE
[Maintenance] Mapbox-GL 1.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6700,9 +6700,9 @@
       }
     },
     "gl-matrix": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.1.0.tgz",
-      "integrity": "sha512-526NA+3EA+ztAQi0IZpSWiM0fyQXIp7IbRvfJ4wS/TjjQD0uv0fVybXwwqqSOlq33UckivI0yMDlVtboWm3k7A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.2.1.tgz",
+      "integrity": "sha512-YYVO8jUSf6+SakL4AJmx9Jc7zAZhkJQ+WhdtX3VQe5PJdCOX6/ybY4x1vk+h94ePnjRn6uml68+QxTAJneUpvA==",
       "dev": true
     },
     "glob": {
@@ -9578,9 +9578,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.6.1.tgz",
-      "integrity": "sha512-qUvu8c/WX0woSLj8M64eK8351th4RI2+grGJ0ZlFb5ELEJNTb4SqMX/4uxRkb5d1euh2U72+AML1QOZjQnUPUw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.8.1.tgz",
+      "integrity": "sha512-Q6c8XAFxHxMPnZIfiRsExk5dNN+dCgvbRNHPfX7hHV5LDcX5Ptc1MEVpOJEDyojuriZssAeWMTJob0hir9mpUw==",
       "dev": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.4.0",
@@ -9593,7 +9593,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.2",
-        "earcut": "^2.2.0",
+        "earcut": "^2.2.2",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.0.0",
         "grid-index": "^1.1.0",
@@ -9629,9 +9629,9 @@
           }
         },
         "earcut": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
-          "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
+          "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==",
           "dev": true
         },
         "pbf": {
@@ -9649,15 +9649,6 @@
           "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
           "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
           "dev": true
-        },
-        "resolve-protobuf-schema": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-          "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1"
-          }
         },
         "tinyqueue": {
           "version": "2.0.3",
@@ -12351,6 +12342,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
+    },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dev": true,
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jest": "^24.1.0",
     "jest-extended": "^0.11.2",
     "json-loader": "0.5.7",
-    "mapbox-gl": "^1.6.1",
+    "mapbox-gl": "^1.8.1",
     "mapbox-gl-js-mock": "https://github.com/QwantResearch/mapbox-gl-js-mock.git#7eaee7b",
     "masq-lib": "git+https://github.com/QwantResearch/masq-lib.git#v0.14.3",
     "node-sass": "^4.13.1",

--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -43,6 +43,7 @@ export default class ExtendedControl {
         enableHighAccuracy: true,
       },
       trackUserLocation: true,
+      showAccuracyCircle: false,
     }, this.bottomButtonGroup);
 
     this.topButtonGroup.appendChild(this._compass);


### PR DESCRIPTION
## Description
Update Mapbox-GL to 1.8.1.
Also disable the display of GPS accuracy as a disk which has been introduced as default in version 1.8.

## Why
Keeping up-to-date with Mapbox-GL.