### PR TITLE
Qmaps 1354 - show addresses in destination panel fields in case of latlon pois

### DIFF
--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -71,7 +71,9 @@ export default class SceneDirection {
       'itinerary_marker_origin', { draggable: true }
     )
       .addTo(this.map)
-      .on('dragend', event => this.refreshDirection('origin', event.target.getLngLat()));
+      .on('dragend', event => {
+        this.refreshDirection('origin', event.target.getLngLat());
+      });
     this.routeMarkers.push(originMarker);
   }
 
@@ -81,7 +83,9 @@ export default class SceneDirection {
       'itinerary_marker_destination', { draggable: true, anchor: 'bottom' }
     )
       .addTo(this.map)
-      .on('dragend', event => this.refreshDirection('destination', event.target.getLngLat()));
+      .on('dragend', event => {
+        this.refreshDirection('destination', event.target.getLngLat());
+      });
     this.routeMarkers.push(destinationMarker);
   }
 
@@ -160,6 +164,7 @@ export default class SceneDirection {
   refreshDirection(type, lngLat) {
     const newPoint = new LatLonPoi(lngLat);
     fire('change_direction_point', type, '', newPoint);
+    fire('get_addresses');
   }
 
   reset() {

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -159,7 +159,7 @@ export default class SceneDirection {
 
   refreshDirection(type, lngLat) {
     const newPoint = new LatLonPoi(lngLat);
-    fire('change_direction_point', type, newPoint);
+    fire('change_direction_point', type, '', newPoint);
   }
 
   reset() {

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -56,12 +56,10 @@ export default class SceneDirection {
 
     listen('set_origin', poi => {
       this.setOrigin(poi);
-      fire('fit_map', poi, false);
     });
 
     listen('set_destination', poi => {
       this.setDestination(poi);
-      fire('fit_map', poi, false);
     });
   }
 

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -164,7 +164,6 @@ export default class SceneDirection {
   refreshDirection(type, lngLat) {
     const newPoint = new LatLonPoi(lngLat);
     fire('change_direction_point', type, '', newPoint);
-    fire('get_addresses');
   }
 
   reset() {

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -39,8 +39,8 @@ export default class DirectionForm extends React.Component {
     }
   }
 
-  onChangePoint = (which, textInput, point) => {
-    this.props.onChangeDirectionPoint(which, point);
+  onChangePoint = (which, value, point) => {
+    this.props.onChangeDirectionPoint(which, value, point);
   }
 
   onReverse = () => {

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -11,8 +11,6 @@ export default class DirectionForm extends React.Component {
     destination: PropTypes.object,
     onChangeDirectionPoint: PropTypes.func.isRequired,
     onReversePoints: PropTypes.func.isRequired,
-    onEmptyOrigin: PropTypes.func.isRequired,
-    onEmptyDestination: PropTypes.func.isRequired,
     vehicles: PropTypes.array.isRequired,
     onSelectVehicle: PropTypes.func.isRequired,
     activeVehicle: PropTypes.string.isRequired,

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -11,6 +11,8 @@ export default class DirectionForm extends React.Component {
     destination: PropTypes.object,
     onChangeDirectionPoint: PropTypes.func.isRequired,
     onReversePoints: PropTypes.func.isRequired,
+    onEmptyOrigin: PropTypes.func.isRequired,
+    onEmptyDestination: PropTypes.func.isRequired,
     vehicles: PropTypes.array.isRequired,
     onSelectVehicle: PropTypes.func.isRequired,
     activeVehicle: PropTypes.string.isRequired,

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -15,11 +15,8 @@ export default class DirectionForm extends React.Component {
     onSelectVehicle: PropTypes.func.isRequired,
     activeVehicle: PropTypes.string.isRequired,
     isInitializing: PropTypes.bool,
-  }
-
-  state = {
-    originInputText: '',
-    destinationInputText: '',
+    originInputText: PropTypes.string,
+    destinationInputText: PropTypes.string,
   }
 
   constructor(props) {
@@ -28,20 +25,11 @@ export default class DirectionForm extends React.Component {
     this.destinationRef = React.createRef();
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const { origin, destination } = props;
-    return {
-      originInputText: origin ? origin.getInputValue() : state.originInputText,
-      destinationInputText: destination ? destination.getInputValue() : state.destinationInputText,
-    };
-  }
-
   componentDidUpdate(prevProps) {
     if (isMobileDevice() || this.props.isInitializing) {
       return;
     }
-    const { originInputText, destinationInputText } = this.state;
-    const { origin, destination } = this.props;
+    const { origin, destination, originInputText, destinationInputText } = this.props;
     if (!originInputText && (prevProps.destination !== destination || prevProps.isInitializing)) {
       this.originRef.current.focus();
     } else if (!destinationInputText && prevProps.origin !== origin) {
@@ -50,25 +38,21 @@ export default class DirectionForm extends React.Component {
   }
 
   onChangePoint = (which, textInput, point) => {
-    if (which === 'origin') {
-      this.setState({ originInputText: textInput });
-    } else {
-      this.setState({ destinationInputText: textInput });
-    }
     this.props.onChangeDirectionPoint(which, point);
   }
 
   onReverse = () => {
-    this.setState(prevState => ({
-      originInputText: prevState.destinationInputText,
-      destinationInputText: prevState.originInputText,
-    }));
     this.props.onReversePoints();
   }
 
   render() {
-    const { originInputText, destinationInputText } = this.state;
-    const { vehicles, activeVehicle, onSelectVehicle } = this.props;
+    const {
+      vehicles,
+      activeVehicle,
+      onSelectVehicle,
+      originInputText,
+      destinationInputText,
+    } = this.props;
 
     return <div className="itinerary_form">
       <div className="itinerary_fields">

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -30,8 +30,8 @@ class DirectionInput extends React.Component {
   }
 
   onChange = event => {
-    const input = event.target.value;
-    this.props.onChangePoint(input, null);
+    const value = event.target.value;
+    this.props.onChangePoint(value, null);
   }
 
   onKeyPress = event => {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -117,12 +117,18 @@ export default class DirectionPanel extends React.Component {
       if (origin) {
         window.execOnMapLoaded(() => {
           fire('set_origin', origin);
+          if (!destination) {
+            fire('fit_map', origin);
+          }
         });
         this.setTextInput('origin', origin);
       }
       if (destination) {
         window.execOnMapLoaded(() => {
           fire('set_destination', destination);
+          if (!origin) {
+            fire('fit_map', destination);
+          }
         });
         this.setTextInput('destination', destination);
       }

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -133,8 +133,15 @@ export default class DirectionPanel extends React.Component {
   computeRoutes = async () => {
     const { origin, destination, vehicle } = this.state;
     if (origin && destination) {
-      this.setState({ isDirty: false, isLoading: true, error: 0, routes: [] });
+      this.setState({
+        isDirty: false,
+        isLoading: true,
+        error: 0,
+        routes: [],
+      });
       const currentQueryId = ++this.lastQueryId;
+      fire('set_origin', origin);
+      fire('set_destination', destination);
       const directionResponse = await DirectionApi.search(
         origin,
         destination,
@@ -238,6 +245,8 @@ export default class DirectionPanel extends React.Component {
     this.setState(previousState => ({
       origin: previousState.destination,
       destination: previousState.origin,
+      originInputText: this.state.destinationInputText,
+      destinationInputText: this.state.originInputText,
       isDirty: true,
     }), this.update);
   }

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -131,10 +131,10 @@ export default class DirectionPanel extends React.Component {
       persistentPointState.destination = destination;
 
       // Show the raw POI name/latlon while waiting for computeRoutes to complete
-      this.setState({
+      /*this.setState({
         originInputText: ' ',
         destinationInputText: ' ',
-      });
+      });*/
 
       // Set markers
       if (origin) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -97,12 +97,10 @@ export default class DirectionPanel extends React.Component {
       persistentPointState.destination = destination;
 
       // Show the raw POI name/latlon while waiting for computeRoutes to complete
-      if (origin) {
-        this.setState({ originInputText: origin.name });
-      }
-      if (destination) {
-        this.setState({ destinationInputText: destination.name });
-      }
+      this.setState({
+        originInputText: origin ? origin.name : '',
+        destinationInputText: destination ? destination.name : '',
+      });
 
       // Set markers
       if (origin) {
@@ -251,16 +249,8 @@ export default class DirectionPanel extends React.Component {
     }), this.update);
   }
 
-  emptyOrigin = () => {
-    this.setState({ originInputText: '' });
-  }
-
-  emptyDestination = () => {
-    this.setState({ destinationInputText: '' });
-  }
-
   changeDirectionPoint = (which, value, point) => {
-    persistentPointState[which] = value;
+    persistentPointState[which] = point;
     this.setState({
       [which]: point,
       isDirty: true,

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -259,8 +259,8 @@ export default class DirectionPanel extends React.Component {
     this.setState(previousState => ({
       origin: previousState.destination,
       destination: previousState.origin,
-      originInputText: this.state.destinationInputText,
-      destinationInputText: this.state.originInputText,
+      originInputText: previousState.destinationInputText,
+      destinationInputText: previousState.originInputText,
       isDirty: true,
     }), this.update);
   }

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -126,10 +126,12 @@ export default class DirectionPanel extends React.Component {
       persistentPointState.destination = destination;
 
       // Show the raw POI name/latlon while waiting for computeRoutes to complete
-      this.setState({
-        originInputText: ' ',
-        destinationInputText: ' ',
-      });
+      if (origin || destination) {
+        this.setState({
+          originInputText: ' ',
+          destinationInputText: ' ',
+        });
+      }
 
       // Set markers
       if (origin) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -250,12 +250,12 @@ export default class DirectionPanel extends React.Component {
     this.setState({ destinationInputText: '' });
   }
 
-  changeDirectionPoint = (which, value) => {
+  changeDirectionPoint = (which, value, point) => {
     persistentPointState[which] = value;
     this.setState({
-      [which]: value,
+      [which]: point,
       isDirty: true,
-      [which + 'InputText']: value && value.name ? value.name : '',
+      [which + 'InputText']: value || '',
     }, this.update);
   }
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -253,6 +253,12 @@ export default class DirectionPanel extends React.Component {
     const form = <DirectionForm
       origin={origin}
       destination={destination}
+      originInputText = {origin && origin.getInputValue ? origin.getInputValue() : ''}
+      destinationInputText = {
+        destination && destination.getInputValue
+          ? destination.getInputValue()
+          : ''
+      }
       onChangeDirectionPoint={this.changeDirectionPoint}
       onReversePoints={this.reversePoints}
       vehicles={this.vehicles}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -88,7 +88,7 @@ export default class DirectionPanel extends React.Component {
       if (poi.type === 'latlon') {
         this.getAddress(which, poi);
       } else {
-        this.setState({ [which + 'InputText']: poi.name || '' });
+        this.setState({ [which + 'InputText']: poi.getInputValue() || '' });
       }
     } else {
       this.setState({ [which + 'InputText']: '' });
@@ -112,14 +112,6 @@ export default class DirectionPanel extends React.Component {
     Promise.all(poiRestorePromises).then(([ origin, destination ]) => {
       persistentPointState.origin = origin;
       persistentPointState.destination = destination;
-
-      // Show the raw POI name/latlon while waiting for computeRoutes to complete
-      /*if (origin || destination) {
-        this.setState({
-          originInputText: origin && origin.name ? origin.name : '',
-          destinationInputText: destination && destination.name ? destination.name : '',
-        });
-      }*/
 
       // Set markers
       if (origin) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -12,7 +12,7 @@ import Error from 'src/adapters/error';
 import Poi from 'src/adapters/poi/poi.js';
 import { getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
-import IdunnPoi from "src/adapters/poi/idunn_poi";
+import IdunnPoi from 'src/adapters/poi/idunn_poi';
 
 // this outside state is used to restore origin/destination when returning to the panel after closing
 const persistentPointState = {
@@ -175,7 +175,7 @@ export default class DirectionPanel extends React.Component {
     if (origin) {
       if (origin.type === 'latlon') {
         poiInfo = await IdunnPoi.poiApiLoad(origin);
-        this.setState({ originInputText: poiInfo.alternativeName || poiInfo.name});
+        this.setState({ originInputText: poiInfo.alternativeName || poiInfo.name });
       } else {
         this.setState({ originInputText: origin.name });
       }
@@ -184,7 +184,7 @@ export default class DirectionPanel extends React.Component {
     if (destination) {
       if (destination.type === 'latlon') {
         poiInfo = await IdunnPoi.poiApiLoad(destination);
-        this.setState({ destinationInputText: poiInfo.alternativeName || poiInfo.name});
+        this.setState({ destinationInputText: poiInfo.alternativeName || poiInfo.name });
       } else {
         this.setState({ destinationInputText: destination.name });
       }

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -100,13 +100,13 @@ export default class DirectionPanel extends React.Component {
       this.setState({
         originInputText: origin
           ? origin.type === 'latlon'
-            ? origin.alternativeName || origin.name
-            : origin.name
+            ? origin.alternativeName || origin.getInputValue()
+            : origin.getInputValue()
           : this.state.originInputText,
         destinationInputText: destination
           ? destination.type === 'latlon'
-            ? destination.alternativeName || destination.name
-            : destination.name
+            ? destination.alternativeName || destination.getInputValue()
+            : destination.getInputValue()
           : this.state.destinationInputText,
       });
     });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -253,7 +253,9 @@ export default class DirectionPanel extends React.Component {
     }, this.update);
 
     // Retrieve addresses
-    this.setTextInput(which, persistentPointState[which]);
+    if (point && point.type === 'latlon') {
+      this.setTextInput(which, persistentPointState[which]);
+    }
   }
 
   setDirectionPoint = poi => {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -84,10 +84,14 @@ export default class DirectionPanel extends React.Component {
   }
 
   setTextInput(which, poi) {
-    if (poi.type === 'latlon') {
-      this.getAddress(which, poi);
+    if (poi) {
+      if (poi.type === 'latlon') {
+        this.getAddress(which, poi);
+      } else {
+        this.setState({ [which + 'InputText']: poi.name || '' });
+      }
     } else {
-      this.setState({ [which + 'InputText']: poi.name || '' });
+      this.setState({ [which + 'InputText']: '' });
     }
   }
 
@@ -110,12 +114,12 @@ export default class DirectionPanel extends React.Component {
       persistentPointState.destination = destination;
 
       // Show the raw POI name/latlon while waiting for computeRoutes to complete
-      if (origin || destination) {
+      /*if (origin || destination) {
         this.setState({
-          originInputText: ' ',
-          destinationInputText: ' ',
+          originInputText: origin && origin.name ? origin.name : '',
+          destinationInputText: destination && destination.name ? destination.name : '',
         });
-      }
+      }*/
 
       // Set markers
       if (origin) {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -84,7 +84,7 @@ input:valid:focus + .itinerary__field__clear {
   position: relative;
   width: 100%;
   height: 40px;
-  padding: 0 36px 0 44px;
+  padding: 0 60px 0 44px;
   border: none;
   font-size: 16px;
   color: $primary_text;

--- a/tests/__data__/latlonpoi.json
+++ b/tests/__data__/latlonpoi.json
@@ -1,0 +1,74 @@
+{
+  "type": "latlon",
+  "id": "latlon:43.70324:7.25997",
+  "name": "43.70324 : 7.25997",
+  "local_name": "43.70324 : 7.25997",
+  "class_name": "latlon",
+  "subclass_name": "latlon",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      7.25997,
+      43.70324
+    ],
+    "center": [
+      7.25997,
+      43.70324
+    ]
+  },
+  "address": {
+    "id": "addr:7.259928;43.703297:16",
+    "name": "16 Avenue Thiers",
+    "housenumber": "16",
+    "postcode": "06000",
+    "label": "16 Avenue Thiers (Nice)",
+    "admin": null,
+    "street": {
+      "id": "street:",
+      "name": "Avenue Thiers",
+      "label": "Avenue Thiers (Nice)",
+      "postcodes": [
+        "06000"
+      ]
+    },
+    "admins": [
+      {
+        "id": "admin:osm:relation:170100",
+        "label": "Nice (06000-06300), Alpes-Maritimes, Provence-Alpes-Côte d'Azur, France",
+        "name": "Nice",
+        "class_name": "city",
+        "postcodes": [
+          "06000",
+          "06100",
+          "06200",
+          "06300"
+        ]
+      },
+      {
+        "id": "admin:osm:relation:7385",
+        "label": "Alpes-Maritimes, Provence-Alpes-Côte d'Azur, France",
+        "name": "Alpes-Maritimes",
+        "class_name": "state_district",
+        "postcodes": []
+      },
+      {
+        "id": "admin:osm:relation:8654",
+        "label": "Provence-Alpes-Côte d'Azur, France",
+        "name": "Provence-Alpes-Côte d'Azur",
+        "class_name": "state",
+        "postcodes": []
+      },
+      {
+        "id": "admin:osm:relation:2202162",
+        "label": "France",
+        "name": "France",
+        "class_name": "country",
+        "postcodes": []
+      }
+    ]
+  },
+  "blocks": [],
+  "meta": {
+    "source": null
+  }
+}

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -92,7 +92,7 @@ test('destination', async () => {
   const directionStartInput = await page.evaluate(() =>
     document.getElementById('itinerary_input_origin').value
   );
-  expect(directionStartInput).toEqual(' ');
+  expect(directionStartInput).toEqual('');
 
   const directionEndInput = await page.evaluate(() =>
     document.getElementById('itinerary_input_destination').value

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -26,7 +26,7 @@ test('check "My position" label', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
 
   // wait for autocomplete library starting-up
-  //await page.waitForSelector('.itinerary_suggest_your_position');
+  await page.waitForSelector('.itinerary_suggest_your_position');
 
   await page.focus('#itinerary_input_origin');
 

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -26,7 +26,7 @@ test('check "My position" label', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
 
   // wait for autocomplete library starting-up
-  await page.waitForSelector('.itinerary_suggest_your_position');
+  //await page.waitForSelector('.itinerary_suggest_your_position');
 
   await page.focus('#itinerary_input_origin');
 

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -92,7 +92,7 @@ test('destination', async () => {
   const directionStartInput = await page.evaluate(() =>
     document.getElementById('itinerary_input_origin').value
   );
-  expect(directionStartInput).toEqual('');
+  expect(directionStartInput).toEqual(' ');
 
   const directionEndInput = await page.evaluate(() =>
     document.getElementById('itinerary_input_destination').value

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -122,9 +122,10 @@ test('origin & destination', async () => {
 
 test('origin & latlon destination & mode', async () => {
   responseHandler.addPreparedResponse(mockPoi1, new RegExp(`places/${mockPoi1.id}`));
+  responseHandler.addPreparedResponse(mockLatlonPoi, new RegExp(`places/${mockLatlonPoi.id}`));
 
   expect.assertions(3);
-  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=latlon:43.70324:7.25997&mode=walking`);
+  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=${mockLatlonPoi.id}&mode=walking`);
   await page.waitForSelector('#itinerary_input_origin');
 
   const directionStartInput = await page.evaluate(() =>

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -6,6 +6,7 @@ const mockAutocomplete = require('../../__data__/autocomplete.json');
 const mockMapBox = require('../../__data__/mapbox.json');
 const mockPoi1 = require('../../__data__/poi.json');
 const mockPoi2 = require('../../__data__/poi2.json');
+const mockLatlonPoi = require('../../__data__/latlonpoi.json');
 
 let browser;
 let page;
@@ -119,11 +120,11 @@ test('origin & destination', async () => {
   expect(directionEndInput).toEqual(mockPoi2.name);
 });
 
-test('origin & destination & mode', async () => {
+test('origin & latlon destination & mode', async () => {
   responseHandler.addPreparedResponse(mockPoi1, new RegExp(`places/${mockPoi1.id}`));
 
   expect.assertions(3);
-  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=latlon:47.4:7.5974115&mode=walking`);
+  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=latlon:43.70324:7.25997&mode=walking`);
   await page.waitForSelector('#itinerary_input_origin');
 
   const directionStartInput = await page.evaluate(() =>
@@ -134,7 +135,7 @@ test('origin & destination & mode', async () => {
   const directionEndInput = await page.evaluate(() =>
     document.getElementById('itinerary_input_destination').value
   );
-  expect(directionEndInput).toEqual('47.40000 : 7.59741');
+  expect(directionEndInput).toEqual(mockLatlonPoi.address.label);
 
   const activeLabel = await page.evaluate(() => {
     return Array.from(document.querySelector('.itinerary_vehicle_button--active').classList).join(',');


### PR DESCRIPTION
## Description
Complete destination fields with latlon POI's addresses when it's possible
- when clicking on the map
- when restoring pois on page reload

## Why
It's more readable than GPS coordinates

## Screenshots
![chelou2](https://user-images.githubusercontent.com/1225909/76740177-c0aed180-676d-11ea-9cd4-af70d934f0ff.gif)

