### PR TITLE
[Clean-up] Improve code for suggestion fetching

### DIFF
--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -3,10 +3,8 @@
 import Autocomplete from '../vendors/autocomplete';
 import IconManager from '../adapters/icon_manager';
 import ExtendedString from '../libs/string';
-import BragiPoi from './poi/bragi_poi';
 import PoiStore from './poi/poi_store';
 import Category from './category';
-import CategoryService from './category_service';
 import nconf from '@qwant/nconf-getter';
 
 const geocoderConfig = nconf.get().services.geocoder;
@@ -14,12 +12,12 @@ const SUGGEST_MAX_ITEMS = geocoderConfig.maxItems;
 const SUGGEST_USE_FOCUS = geocoderConfig.useFocus;
 const SUGGEST_FOCUS_MIN_ZOOM = 11;
 
+import { suggestResults } from './suggest_sources';
+
 export default class Suggest {
   constructor({ tagSelector, onSelect, prefixes = [], withCategories = false, menuClass = '' }) {
     this.searchInputDomHandler = document.querySelector(tagSelector);
     this.poi = null;
-    this.bragiPromise = null;
-    this.historyPromise = null;
     this.suggestList = [];
     this.pending = false;
     this.onSelect = onSelect;
@@ -37,56 +35,11 @@ export default class Suggest {
         this.suggestList = items;
         this.pending = false;
       },
-      source: term => {
-        let promise;
-        if (term === '') {
-          // Prerender Favorites on focus in empty field
-          promise = PoiStore.getAll();
-        } else {
-          promise = new Promise(async (resolve, reject) => {
-            const focus = {};
-            const mapZoom = window.map && window.map.mb && window.map.mb.getZoom();
-            if (SUGGEST_USE_FOCUS && mapZoom >= SUGGEST_FOCUS_MIN_ZOOM) {
-              const center = window.map.mb.getCenter();
-              focus.lat = center.lat;
-              focus.lon = center.lng;
-              focus.zoom = mapZoom;
-            }
-            this.historyPromise = PoiStore.get(term);
-            this.bragiPromise = BragiPoi.get(term, focus);
-            this.categoryPromise = withCategories ?
-              CategoryService.getMatchingCategories(term) : null;
-
-            try {
-              const [bragiResponse, storeResponse, categoryResponse] = await Promise.all([
-                this.bragiPromise, this.historyPromise, this.categoryPromise,
-              ]);
-
-              if (!bragiResponse) {
-                return resolve(null);
-              }
-
-              this.suggestList = [];
-
-              if (categoryResponse) {
-                this.suggestList = this.suggestList.concat(categoryResponse);
-              }
-
-              this.bragiPromise = null;
-              this.suggestList = this.suggestList.concat(bragiResponse);
-              this.suggestList = this.suggestList.concat(storeResponse);
-
-              resolve(this.suggestList);
-            } catch (e) {
-              reject(e);
-            }
-          });
-        }
-        promise.abort = () => {
-          this.bragiPromise.abort();
-        };
-        return promise;
-      },
+      source: term => suggestResults(term, {
+        withCategories,
+        useFocus: SUGGEST_USE_FOCUS,
+        focusMinZoom: SUGGEST_FOCUS_MIN_ZOOM,
+      }),
 
       renderItems: (pois, query) => {
         const favorites = pois.filter(poi => poi instanceof PoiStore);
@@ -154,9 +107,6 @@ export default class Suggest {
 
   async onSubmit() {
     if (this.pending) {
-      if (this.bragiPromise) {
-        this.bragiPromise.abort();
-      }
       const term = this.searchInputDomHandler.value;
       this.preselect(term);
     } else {

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -1,0 +1,55 @@
+import PoiStore from './poi/poi_store';
+import BragiPoi from './poi/bragi_poi';
+import CategoryService from './category_service';
+
+// @TODO: Improvement: don't access directly to window.map
+function getFocus(focusMinZoom) {
+  const zoom = window.map && window.map.mb && window.map.mb.getZoom();
+  if (zoom >= focusMinZoom) {
+    const { lat, lon } = window.map.mb.getCenter();
+    return { lat, lon, zoom };
+  }
+  return {};
+}
+
+export function suggestResults(term, { withCategories, useFocus, focusMinZoom = 11 } = {}) {
+  let geocoderPromise;
+  let promise;
+  if (term === '') {
+    // Prerender Favorites on focus in empty field
+    promise = PoiStore.getAll();
+  } else {
+    promise = new Promise(async (resolve, reject) => {
+      geocoderPromise = BragiPoi.get(term, useFocus ? getFocus(focusMinZoom) : {});
+      const favoritePromise = PoiStore.get(term);
+      const categoryPromise = withCategories ? CategoryService.getMatchingCategories(term) : [];
+
+      try {
+        const [geocoderSuggestions, favorites, categories] =
+          await Promise.all([ geocoderPromise, favoritePromise, categoryPromise ]);
+
+        // For now don't display anything when there is no geocoder match
+        if (geocoderSuggestions.length === 0) {
+          return resolve([]);
+        }
+
+        const suggestList = [
+          ...categories,
+          ...geocoderSuggestions,
+          ...favorites,
+        ];
+
+        resolve(suggestList);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+  promise.abort = () => {
+    if (geocoderPromise) {
+      // will abort the underlying XHR
+      geocoderPromise.abort();
+    }
+  };
+  return promise;
+}

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -28,9 +28,10 @@ export function suggestResults(term, { withCategories, useFocus, focusMinZoom = 
         const [geocoderSuggestions, favorites, categories] =
           await Promise.all([ geocoderPromise, favoritePromise, categoryPromise ]);
 
-        // For now don't display anything when there is no geocoder match
-        if (geocoderSuggestions.length === 0) {
-          return resolve([]);
+        // This case happens when this query and the underlying XHR have been aborted.
+        // resolve(null) will cause the suggest to discard this response.
+        if (!geocoderSuggestions) {
+          return resolve(null);
         }
 
         const suggestList = [


### PR DESCRIPTION
## Description
Separate the code producing address suggestion results from the presentation layer.
Also clean-up code and comment non-explicit stuff.

## Why
Improve maintainability.
Ease migration of the suggestion widget to React.