### PR TITLE
[Suggest refacto] More data vs. rendering separation + introducing React 

### DIFF
--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -2,7 +2,6 @@
 
 import Poi from '../poi';
 import GeolocationCheck from 'src/libs/geolocation';
-export const GEOLOCALISATION_NAME = 'geolocalisation';
 
 export const navigatorGeolocationStatus = {
   PENDING: 'pending',
@@ -13,7 +12,7 @@ export const navigatorGeolocationStatus = {
 
 export default class NavigatorGeolocalisationPoi extends Poi {
   constructor() {
-    super(GEOLOCALISATION_NAME, _('Your position', 'direction'));
+    super('geolocalisation', _('Your position', 'direction'));
     this.status = navigatorGeolocationStatus.UNKNOWN;
   }
 
@@ -44,14 +43,5 @@ export default class NavigatorGeolocalisationPoi extends Poi {
   setPosition(latLng) {
     this.status = navigatorGeolocationStatus.FOUND;
     this.latLon = latLng;
-  }
-
-  render() {
-    return `
-      <div data-id="${GEOLOCALISATION_NAME}" data-val="${_('Your position', 'direction')}"
-       class="autocomplete_suggestion itinerary_suggest_your_position">
-        <div class="itinerary_suggest_your_position_icon icon-pin_geoloc"></div>
-        ${_('Your position', 'direction')}
-      </div>`;
   }
 }

--- a/src/components/SuggestItem.jsx
+++ b/src/components/SuggestItem.jsx
@@ -1,0 +1,82 @@
+/* global _ */
+import React from 'react';
+import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
+import IconManager from '../adapters/icon_manager';
+import Category from 'src/adapters/category';
+
+const ItemLabels = ({ firstLabel, secondLabel }) =>
+  <div className="autocomplete_suggestion__lines_container">
+    <div className="autocomplete_suggestion__first_line">{firstLabel}</div>
+    <div className="autocomplete_suggestion__second_line">{secondLabel}</div>
+  </div>;
+
+const GeolocationItem = () =>
+  <div
+    className="autocomplete_suggestion itinerary_suggest_your_position"
+    data-id="geolocalisation"
+    data-val={_('Your position', 'direction')}
+  >
+    <div className="itinerary_suggest_your_position_icon icon-pin_geoloc" />
+    {_('Your position', 'direction')}
+  </div>;
+
+const CategoryItem = ({ category }) => {
+  const { id, label, alternativeName, color, backgroundColor } = category;
+  const icon = category.getIcon();
+
+  return (
+    <div
+      className="autocomplete_suggestion autocomplete_suggestion--category"
+      data-id={id}
+      data-val={label}
+    >
+      <div
+        style={{ color, backgroundColor }}
+        className={`autocomplete-icon autocomplete-icon-rounded icon icon-${icon.iconClass}`}
+      />
+      <ItemLabels firstLabel={label} secondLabel={alternativeName} />
+    </div>
+  );
+};
+
+const PoiItem = ({ poi }) => {
+  const { id, name, className, subClassName, type, alternativeName } = poi;
+  const icon = IconManager.get({ className, subClassName, type });
+
+  return (
+    <div
+      className="autocomplete_suggestion"
+      data-id={id}
+      data-val={poi.getInputValue()}
+    >
+      <div
+        style={{ color: icon ? icon.color : '' }}
+        className={`autocomplete-icon icon icon-${icon.iconClass}`}
+      />
+      <ItemLabels firstLabel={name} secondLabel={alternativeName} />
+    </div>
+  );
+};
+
+const SeparatorLabel = ({ label }) =>
+  <h3 className="autocomplete_suggestion__category_title" onMouseDown="return false;">
+    {label}
+  </h3>;
+
+const SuggestItem = ({ item }) => {
+  if (item.simpleLabel) {
+    return <SeparatorLabel label={item.simpleLabel} />;
+  }
+
+  if (item instanceof NavigatorGeolocalisationPoi) {
+    return <GeolocationItem />;
+  }
+
+  if (item instanceof Category) {
+    return <CategoryItem category={item} />;
+  }
+
+  return <PoiItem poi={item} />;
+};
+
+export default SuggestItem;

--- a/src/components/SuggestItem.jsx
+++ b/src/components/SuggestItem.jsx
@@ -59,7 +59,7 @@ const PoiItem = ({ poi }) => {
 };
 
 const SeparatorLabel = ({ label }) =>
-  <h3 className="autocomplete_suggestion__category_title" onMouseDown="return false;">
+  <h3 className="autocomplete_suggestion__category_title">
     {label}
   </h3>;
 

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -18,7 +18,7 @@ class DirectionInput extends React.Component {
     this.suggest = new Suggest({
       tagSelector: `#itinerary_input_${this.props.pointType}`,
       onSelect: this.selectItem,
-      prefixes: [ NavigatorGeolocalisationPoi.getInstance() ],
+      withGeoloc: true,
       menuClass: 'direction_suggestions',
     });
   }

--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -126,6 +126,11 @@ export default function autoComplete(options) {
     addEvent(window, 'resize', that.updateSC);
     that.offsetParent.appendChild(that.sc);
 
+    // @HACK: cancel clicks on separator titles so they don't steal the focus from the input
+    live('autocomplete_suggestion__category_title', 'mousedown', function(e) {
+      e.preventDefault();
+    });
+
     live('autocomplete_suggestion', 'mouseleave', function() {
       const sel = that.sc.querySelector('.autocomplete_suggestion.selected');
       if (sel) {


### PR DESCRIPTION
*More easily reviewed one commit at a time*

## Description
Follow up to https://github.com/QwantResearch/erdapfel/pull/582
Goes one step further in the suggest refacto, by removing stuff from the current suggest component so the migration itself has to change less things.

Instead of building a big DOM string piece-by-piece for the drop-down content, focus on building the list of items to put in the suggest, trying to simplify the logic in the process, *then* render each of it.

For the render itself, replace old template string by new elementary React component and uses the `renderStaticReact` trick to render them as a DOM string, so the suggest component doesn't see the difference.
It still requires to render some attributes specific to the actual implementation (the 'id' and 'value' data attributes), but we'll soon be able to remove them and quickly make everything cleaner.
Also I didn't change the DOM or CSS to keep exactly the same behavior, but they'll be improved later. Let's advance step by step :)

## Why
Make things easier to connect to @G-Ray's ongoing work in https://github.com/QwantResearch/erdapfel/pull/583

## Screenshots
No visual or UX change.