### PR TITLE
Wrap longitude values when creating LatLonPoi from a point of the map

### DIFF
--- a/src/adapters/poi/latlon_poi.js
+++ b/src/adapters/poi/latlon_poi.js
@@ -1,13 +1,19 @@
 import Poi from './poi';
 
 export default class LatLonPoi extends Poi {
-  constructor(latLon, label) {
-    const id = `latlon:${latLon.lat.toFixed(5)}:${latLon.lng.toFixed(5)}`;
+  constructor(lnglat, label) {
+    if (typeof lnglat.wrap === 'function') {
+      // mapbox-gl LngLat provides a wrap() method to wrap longitude values.
+      // These values are out of bounds for points on world copies
+      // (i.e. when multiple worlds are visible at lower zooms).
+      lnglat = lnglat.wrap();
+    }
+    const id = `latlon:${lnglat.lat.toFixed(5)}:${lnglat.lng.toFixed(5)}`;
 
     if (!label) {
-      label = `${latLon.lat.toFixed(5)} : ${latLon.lng.toFixed(5)}`;
+      label = `${lnglat.lat.toFixed(5)} : ${lnglat.lng.toFixed(5)}`;
     }
-    super(id, label, null, null, latLon);
+    super(id, label, null, null, lnglat);
     this.type = 'latlon';
   }
 }


### PR DESCRIPTION
## Description
This PR prevents using invalid longitude values for LatLonPoi, after a click on the map occurs on a world copy created by mapbox-gl at lower zooms.
