### PR TITLE
Fix search in favorites restricted to beginning of name

### DIFF
--- a/src/adapters/poi/poi_store.js
+++ b/src/adapters/poi/poi_store.js
@@ -7,10 +7,8 @@ const store = new Store();
 export default class PoiStore extends Poi {
   static async get(term) {
     try {
-      const prefixes = await store.getPrefixes(term);
-      return prefixes.map(historySuggest => {
-        return Object.assign(new PoiStore(), historySuggest);
-      });
+      const matches = await store.getMatches(term);
+      return matches.map(match => Object.assign(new PoiStore(), match));
     } catch (e) {
       Error.sendOnce('poi_store', 'get', 'error getting matching favorites', e);
       return [];

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -173,11 +173,11 @@ export default class Store {
     }
   }
 
-  async getPrefixes(prefix) {
+  async getMatches(term) {
     await this.checkInit();
     const storedItems = await this.abstractStore.getAllPois();
     return storedItems.filter(storedItem => {
-      return ExtendedString.compareIgnoreCase(storedItem.name, prefix) === 0; /* start with */
+      return ExtendedString.compareIgnoreCase(storedItem.name, term) !== -1;
     });
   }
 


### PR DESCRIPTION
## Description
When typing in the search bar, return favorites whose name include the search term, whatever the position, and not only at the beginning of the name.

## Why
Improve usefulness of search in favs, to avoid cases like "Le BHV Marais" not being returned if the user enters "BHV" without "Le". 