### PR TITLE
[Covid 19] Display data from caresteouvert.fr

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -89,3 +89,6 @@ category:
 events:
   enabled: false
   maxPlaces: 40
+
+covid19:
+  enabled: false

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReviewScore from 'src/components/ReviewScore';
 import OpeningHour from 'src/components/OpeningHour';
 import poiSubClass from '../mapbox/poi_subclass';
+import nconf from '@qwant/nconf-getter';
+
+const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
 const PoiPopup = ({ poi }) => {
   const reviews = poi.blocksByType && poi.blocksByType.grades;
@@ -11,7 +14,7 @@ const PoiPopup = ({ poi }) => {
   let displayedInfo = null;
   if (reviews) {
     displayedInfo = <ReviewScore reviews={reviews} poi={poi} />;
-  } else if (openingHours) {
+  } else if (openingHours && !covid19Enabled) {
     displayedInfo = <OpeningHour poi={poi} />;
   } else if (address) {
     displayedInfo = <span className="poi_popup__address">{address}</span>;

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -27,7 +27,8 @@ export default class PoiBlockContainer extends React.Component {
     const displayCovidInfo = this.props.covid19Enabled && blocks.find(b => b.type === 'covid19');
 
     return <div className="poi_panel__info">
-      {displayCovidInfo && <CovidBlock block={covidBlock} normalHourBlock={hourBlock} />}
+      {displayCovidInfo &&
+        <CovidBlock block={covidBlock} normalHourBlock={hourBlock} poi={this.props.poi} />}
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -28,7 +28,7 @@ export default class PoiBlockContainer extends React.Component {
 
     return <div className="poi_panel__info">
       {displayCovidInfo && <CovidBlock block={covidBlock} normalHourBlock={hourBlock} />}
-      {hourBlock && <HourBlock block={hourBlock} covid19enabled={displayCovidInfo} />}
+      {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {contactBlock && <ContactBlock block={contactBlock} />}

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -5,10 +5,12 @@ import ContactBlock from './blocks/Contact';
 import ImagesBlock from './blocks/Images';
 import WebsiteBlock from './blocks/Website';
 import InformationBlock from './blocks/Information';
+import CovidBlock from './blocks/Covid19';
 
 export default class PoiBlockContainer extends React.Component {
   static propTypes = {
     poi: PropTypes.object,
+    covid19Enabled: PropTypes.bool,
   }
 
   render() {
@@ -21,8 +23,11 @@ export default class PoiBlockContainer extends React.Component {
     const websiteBlock = blocks.find(b => b.type === 'website');
     const contactBlock = blocks.find(b => b.type === 'contact');
     const imagesBlock = blocks.find(b => b.type === 'images');
+    const covidBlock = blocks.find(b => b.type === 'covid19');
+    const displayCovidInfo = this.props.covid19Enabled && blocks.find(b => b.type === 'covid19');
 
     return <div className="poi_panel__info">
+      {displayCovidInfo && <CovidBlock block={covidBlock} normalHourBlock={hourBlock} />}
       {hourBlock && <HourBlock block={hourBlock} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -28,7 +28,7 @@ export default class PoiBlockContainer extends React.Component {
 
     return <div className="poi_panel__info">
       {displayCovidInfo && <CovidBlock block={covidBlock} normalHourBlock={hourBlock} />}
-      {hourBlock && <HourBlock block={hourBlock} />}
+      {hourBlock && <HourBlock block={hourBlock} covid19enabled={displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {contactBlock && <ContactBlock block={contactBlock} />}

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -21,14 +21,16 @@ class PoiCard extends React.Component {
   }
 
   render() {
-    const { poi, closeAction, showDetails, openDirection } = this.props;
+    const { poi, closeAction, showDetails, openDirection, covid19Enabled } = this.props;
+
+    const hideOpeningHour = covid19Enabled && poi.blocks.find(b => b.type === 'covid19');
 
     return <div className="poi_card" ref={this.cardRef}>
       <div className="poi_card__description_container">
         <PoiTitleImage poi={poi} iconOnly={true} />
         <div>
           <PoiHeader poi={poi} />
-          <OpeningHour poi={poi} />
+          {!hideOpeningHour && <OpeningHour poi={poi} />}
         </div>
       </div>
       <div className="poi_card__action_container">

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -23,7 +23,8 @@ class PoiCard extends React.Component {
   render() {
     const { poi, closeAction, showDetails, openDirection, covid19Enabled } = this.props;
 
-    const hideOpeningHour = covid19Enabled && poi.blocks.find(b => b.type === 'covid19');
+    const hideOpeningHour = covid19Enabled
+      && poi.blocks && poi.blocks.find(b => b.type === 'covid19');
 
     return <div className="poi_card" ref={this.cardRef}>
       <div className="poi_card__description_container">

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -22,6 +22,8 @@ import Store from '../../adapters/store';
 import { openAndWaitForClose as openMasqFavModalAndWaitForClose }
   from 'src/modals/MasqFavoriteModal';
 
+const covid19Enabled = (nconf.get().covid19 || {}).enabled;
+
 const store = new Store();
 
 async function isPoiFavorite(poi) {
@@ -281,7 +283,7 @@ export default class PoiPanel extends React.Component {
           isPoiInFavorite={this.state.isPoiInFavorite}
           toggleStorePoi={this.toggleStorePoi}
         />
-        <PoiBlockContainer poi={poi} />
+        <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
         {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
           <h3 className="service_panel__categories_title">
             <span className="icon-icon_compass" />{_('Search around this place', 'poi')}

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -310,6 +310,7 @@ export default class PoiPanel extends React.Component {
             closeAction={this.closeAction}
             openDirection={this.isDirectionActive && this.openDirection}
             showDetails={this.showDetails}
+            covid19Enabled={covid19Enabled}
           />;
         }
         return this.renderFull(poi);

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -20,7 +20,7 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
   const additionalInfo = note &&
     <div className="covid19-note">
       <i className="icon-icon_info" />
-      <span dangerouslySetInnerHTML={{ __html: note }}/>
+      {note}
     </div>;
 
   const source = contribute_url &&

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -70,7 +70,7 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
     break;
   default:
     content = <Fragment>
-      <span>{covidStrings.statusNoData}</span>
+      <div className="covid19-status">{covidStrings.statusNoData}</div>
       {source}
     </Fragment>;
   }

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -1,56 +1,76 @@
 import React, { Fragment } from 'react';
+import TimeTable from './TimeTable';
+import covidStrings from './covid_strings';
+import OsmSchedule from 'src/adapters/osm_schedule';
+import OpeningHour from 'src/components/OpeningHour';
 
-const strings = {
-  blockTitle: 'Informations spéciales confinement',
-  linkToCaResteOuvert: 'Signaler un changement',
-  statusOpen: 'Ouvert',
-  statusMaybeOpen: 'Susceptible d\'être ouvert',
-  statusClosed: 'Fermé',
-  statusNoData: 'Pas d\'information renseignée',
-  hoursMayChange: 'Horaires susceptibles d\'être adaptés',
+// @TODO: refacto OsmSchedule so it doesn't need presentational data
+const scheduleMessages = {
+  open: {
+    msg: 'Ouvert',
+    color: '#60ad51',
+  },
+  closed: {
+    msg: 'Fermé',
+    color: '#8c0212',
+  },
 };
 
-const getContent = ({ status, contribute_url, note }) => {
+const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
   const additionalInfo = note &&
-    <div className="covid19-note" dangerouslySetInnerHTML={{ __html: note }}/>;
+    <div className="covid19-note">
+      <i className="icon-icon_info" />
+      <span dangerouslySetInnerHTML={{ __html: note }}/>
+    </div>;
 
-  const contributeLink =
+  const source =
     <a className="covid19-contributeLink" href={contribute_url}>
-      {strings.linkToCaResteOuvert}
+      {covidStrings.linkToCaResteOuvert}
     </a>;
 
-  let content = null;
+  let content;
+  let schedule;
   switch (status) {
   case 'open':
   case 'open_as_usual':
+    schedule = new OsmSchedule(opening_hours, scheduleMessages);
     content = <Fragment>
-      <span className="covid19-status covid19-status--open">{strings.statusOpen}</span>
+      <div className="covid19-status covid19-status--open">{covidStrings.statusOpen}</div>
+      {schedule && <div className="covid19-timeTableContainer">
+        <i className="icon-icon_clock" />
+        <TimeTable title={<OpeningHour poi={poi} />} schedule={schedule} />
+      </div>}
+      {<div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>}
       {additionalInfo}
-      {contributeLink}
+      {source}
     </Fragment>;
     break;
   case 'maybe_open':
     content = <Fragment>
-      <span className="covid19-status covid19-status--maybeOpen">{strings.statusMaybeOpen}</span>
-      <span className="covid19-changeWarning">{strings.hoursMayChange}</span>
+      <div className="covid19-status covid19-status--maybeOpen">
+        {covidStrings.statusMaybeOpen}
+      </div>
+      <div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>
       {additionalInfo}
-      {contributeLink}
+      {source}
     </Fragment>;
     break;
   case 'closed':
-    content = <span className="covid19-status covid19-status--closed">{strings.statusClosed}</span>;
+    content = <div className="covid19-status covid19-status--closed">
+      {covidStrings.statusClosed}
+    </div>;
     break;
   default:
-    content = <span>{strings.statusNoData}</span>;
+    content = <span>{covidStrings.statusNoData}</span>;
   }
 
   return content;
 };
 
-const Covid19 = ({ block }) => {
+const Covid19 = ({ poi, block }) => {
   return <div className="poi_panel__info__section covid19">
-    <h4 className="poi_panel__sub_block__title">{strings.blockTitle}</h4>
-    {getContent(block)}
+    <h4 className="poi_panel__sub_block__title">{covidStrings.blockTitle}</h4>
+    {getContent(poi, block)}
   </div>;
 };
 

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -33,7 +33,7 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
   switch (status) {
   case 'open':
   case 'open_as_usual':
-    schedule = new OsmSchedule(opening_hours, scheduleMessages);
+    schedule = opening_hours && new OsmSchedule(opening_hours, scheduleMessages);
     content = <Fragment>
       <div className="covid19-status covid19-status--open">{covidStrings.statusOpen}</div>
       {schedule && <div className="covid19-timeTableContainer">

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -1,0 +1,57 @@
+import React, { Fragment } from 'react';
+
+const strings = {
+  blockTitle: 'Informations spéciales confinement',
+  linkToCaResteOuvert: 'Signaler un changement',
+  statusOpen: 'Ouvert',
+  statusMaybeOpen: 'Susceptible d\'être ouvert',
+  statusClosed: 'Fermé',
+  statusNoData: 'Pas d\'information renseignée',
+  hoursMayChange: 'Horaires susceptibles d\'être adaptés',
+};
+
+const getContent = ({ status, contribute_url, note }) => {
+  const additionalInfo = note &&
+    <div className="covid19-note" dangerouslySetInnerHTML={{ __html: note }}/>;
+
+  const contributeLink =
+    <a className="covid19-contributeLink" href={contribute_url}>
+      {strings.linkToCaResteOuvert}
+    </a>;
+
+  let content = null;
+  switch (status) {
+  case 'open':
+  case 'open_as_usual':
+    content = <Fragment>
+      <span className="covid19-status covid19-status--open">{strings.statusOpen}</span>
+      {additionalInfo}
+      {contributeLink}
+    </Fragment>;
+    break;
+  case 'maybe_open':
+    content = <Fragment>
+      <span className="covid19-status covid19-status--maybeOpen">{strings.statusMaybeOpen}</span>
+      <span className="covid19-changeWarning">{strings.hoursMayChange}</span>
+      {additionalInfo}
+      {contributeLink}
+    </Fragment>;
+    break;
+  case 'closed':
+    content = <span className="covid19-status covid19-status--closed">{strings.statusClosed}</span>;
+    break;
+  default:
+    content = <span>{strings.statusNoData}</span>;
+  }
+
+  return content;
+};
+
+const Covid19 = ({ block }) => {
+  return <div className="poi_panel__info__section covid19">
+    <h4 className="poi_panel__sub_block__title">{strings.blockTitle}</h4>
+    {getContent(block)}
+  </div>;
+};
+
+export default Covid19;

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -23,10 +23,15 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
       <span dangerouslySetInnerHTML={{ __html: note }}/>
     </div>;
 
-  const source =
-    <a className="covid19-contributeLink" href={contribute_url}>
-      {covidStrings.linkToCaResteOuvert}
-    </a>;
+  const source = contribute_url &&
+    <div className="covid19-source">
+      <div>Source&nbsp;:&nbsp;
+        <a href="https://caresteouvert.fr">Ça reste ouvert</a>
+      </div>
+      <a className="covid19-contributeLink" href={contribute_url}>
+        {covidStrings.linkToCaResteOuvert}
+      </a>
+    </div>;
 
   let content;
   let schedule;
@@ -56,12 +61,18 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
     </Fragment>;
     break;
   case 'closed':
-    content = <div className="covid19-status covid19-status--closed">
-      {covidStrings.statusClosed}
-    </div>;
+    content = <Fragment>
+      <div className="covid19-status covid19-status--closed">
+        {covidStrings.statusClosed}
+      </div>
+      {source}
+    </Fragment>;
     break;
   default:
-    content = <span>{covidStrings.statusNoData}</span>;
+    content = <Fragment>
+      <span>{covidStrings.statusNoData}</span>
+      {source}
+    </Fragment>;
   }
 
   return content;

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -40,7 +40,7 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
         <i className="icon-icon_clock" />
         <TimeTable title={<OpeningHour poi={poi} />} schedule={schedule} />
       </div>}
-      {<div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>}
+      {!schedule && <div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>}
       {additionalInfo}
       {source}
     </Fragment>;

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -3,12 +3,11 @@ import React from 'react';
 import OsmSchedule from 'src/adapters/osm_schedule';
 import TimeTable from './TimeTable';
 import PropTypes from 'prop-types';
+import covidStrings from './covid_strings';
 
 function renderTitle(opening, covid19) {
   if (covid19) {
-    return <span className="poi_panel__info__hours__status__text">
-      Voir les horaires habituels
-    </span>;
+    return <span>{covidStrings.seeNormalHours}</span>;
   }
 
   let text = `${_(opening.status.msg)} `;
@@ -17,7 +16,7 @@ function renderTitle(opening, covid19) {
       _('until {nextTransitionTime}', 'hour panel',
         { nextTransitionTime: opening.nextTransition }) + ' ';
   }
-  return <span className="poi_panel__info__hours__status__text">{ text }
+  return <span>{ text }
     <div className="poi_panel__info__hour__circle" style={{ background: opening.status.color }} />
   </span>;
 }

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -26,7 +26,13 @@ function showHours(displayHours) {
   </tbody>;
 }
 
-function renderTitle(opening) {
+function renderTitle(opening, covid19) {
+  if (covid19) {
+    return <span className="poi_panel__info__hours__status__text">
+      Voir les horaires habituels
+    </span>;
+  }
+
   let text = `${_(opening.status.msg)} `;
   if (opening.nextTransition) {
     text += ' - ' +
@@ -41,6 +47,7 @@ function renderTitle(opening) {
 export default class HourBlock extends React.Component {
   static propTypes = {
     block: PropTypes.object,
+    covid19enabled: PropTypes.bool,
   }
 
   constructor(props) {
@@ -77,7 +84,7 @@ export default class HourBlock extends React.Component {
     }
     return <div>
       <div className="poi_panel__info__hours__status" onClick={this.expandCollapse}>
-        { renderTitle(opening) }
+        { renderTitle(opening, this.props.covid19enabled) }
         <i className={classnames(
           'icon-icon_chevron-down',
           'poi_panel__info__hours__status__toggle',

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -1,30 +1,8 @@
 /* global _ */
 import React from 'react';
 import OsmSchedule from 'src/adapters/osm_schedule';
-import classnames from 'classnames';
+import TimeTable from './TimeTable';
 import PropTypes from 'prop-types';
-
-function showHour(day) {
-  if (day.opening && day.opening.length > 0) {
-    return day.opening.map((openingFragment, i) =>
-      <p key={i}>{ openingFragment.beginning } - { openingFragment.end }</p>);
-  }
-  return _('Closed', 'hour block');
-}
-
-function showHours(displayHours) {
-  const dayNumber = new Date().getDay();
-
-  return <tbody>
-    {displayHours.map((day, i) =>
-      <tr key={i} className={
-        classnames({ 'poi_panel__info__hours--current': (i + 1) % 7 === dayNumber })
-      }>
-        <td className="day">{ day.dayName }</td>
-        <td className="hours">{ showHour(day) }</td>
-      </tr>)}
-  </tbody>;
-}
 
 function renderTitle(opening, covid19) {
   if (covid19) {
@@ -52,7 +30,6 @@ export default class HourBlock extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { isCollapsed: true };
 
     this.messages = {
       open: {
@@ -64,42 +41,6 @@ export default class HourBlock extends React.Component {
         color: '#8c0212',
       },
     };
-
-    this.expandCollapse = () => {
-      this.setState(state => ({
-        isCollapsed: !state.isCollapsed,
-      }));
-    };
-  }
-
-  renderStatus(opening) {
-    // TODO: use OpeningHour instead (careful! OsmSchedule initialization happens there as well!)
-    if (opening.isTwentyFourSeven) {
-      return <div className="poi_panel__info__hours__status__text poi_panel__info__hours__24_7">
-        { _('Open 24/7', 'hour block') }
-        <div className="poi_panel__info__hour__circle"
-          style={{ background: opening.status.color }}
-        />
-      </div>;
-    }
-    return <div>
-      <div className="poi_panel__info__hours__status" onClick={this.expandCollapse}>
-        { renderTitle(opening, this.props.covid19enabled) }
-        <i className={classnames(
-          'icon-icon_chevron-down',
-          'poi_panel__info__hours__status__toggle',
-          {
-            'poi_panel__info__hours__status__toggle--reversed': !this.state.isCollapsed,
-          })} />
-      </div>
-      <div className={classnames('poi_panel__info__hours', {
-        'poi_panel__info__hours--open': !this.state.isCollapsed,
-      })}>
-        <table className="poi_panel__info__hours__table">
-          { showHours(opening.displayHours) }
-        </table>
-      </div>
-    </div>;
   }
 
   render() {
@@ -112,7 +53,7 @@ export default class HourBlock extends React.Component {
       <div className="poi_panel__info__section__description">
         <div className="icon-icon_clock poi_panel__block__symbol"></div>
         <div className="poi_panel__block__content">
-          { this.renderStatus(opening) }
+          <TimeTable title={renderTitle(opening, this.props.covid19enabled)} schedule={opening} />
         </div>
       </div>
     </div>;

--- a/src/panel/poi/blocks/TimeTable.jsx
+++ b/src/panel/poi/blocks/TimeTable.jsx
@@ -1,0 +1,60 @@
+/* global _ */
+import React, { useState } from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+function showHour(day) {
+  if (day.opening && day.opening.length > 0) {
+    return day.opening.map((openingFragment, i) =>
+      <p key={i}>{ openingFragment.beginning } - { openingFragment.end }</p>);
+  }
+  return _('Closed', 'hour block');
+}
+
+function showHours(displayHours) {
+  const dayNumber = new Date().getDay();
+
+  return <tbody>
+    {displayHours.map((day, i) =>
+      <tr key={i} className={
+        classnames({ 'currentDay': (i + 1) % 7 === dayNumber })
+      }>
+        <td className="day">{ day.dayName }</td>
+        <td className="hours">{ showHour(day) }</td>
+      </tr>)}
+  </tbody>;
+}
+
+const TimeTable = ({ title, schedule }) => {
+  // TODO: use OpeningHour instead (careful! OsmSchedule initialization happens there as well!)
+  if (schedule.isTwentyFourSeven) {
+    return <div
+      className="timetable timetable-status poi_panel__info__hours__24_7">
+      { _('Open 24/7', 'hour block') }
+      <div className="poi_panel__info__hour__circle"
+        style={{ background: schedule.status.color }}
+      />
+    </div>;
+  }
+
+  const [ isCollapsed, setCollapsed ] = useState(true);
+
+  return <div className={classnames('timetable', { 'timetable--collapsed': isCollapsed })}>
+    <div className="timetable-status" onClick={() => { setCollapsed(!isCollapsed); }}>
+      <div className="timetable-status-text">{title}</div>
+      <i className="icon-icon_chevron-down" />
+    </div>
+    <div className={classnames('timetable-table')}>
+      <table>
+        { showHours(schedule.displayHours) }
+      </table>
+    </div>
+  </div>;
+};
+
+TimeTable.propTypes = {
+  title: PropTypes.node,
+  opening: PropTypes.object,
+};
+
+export default TimeTable;

--- a/src/panel/poi/blocks/covid_strings.js
+++ b/src/panel/poi/blocks/covid_strings.js
@@ -1,0 +1,11 @@
+export default {
+  blockTitle: 'Informations spéciales confinement',
+  linkToCaResteOuvert: 'Signaler un changement',
+  statusOpen: 'Lieu ouvert pendant le confinement',
+  statusMaybeOpen: 'Lieu susceptible d\'être ouvert pendant le confinement',
+  statusClosed: 'Lieu fermé pendant le confinement',
+  statusNoData: 'Pas d\'information renseignée',
+  hoursMayChange: 'Horaires susceptibles d\'être adaptés',
+  seeSpecialHours: 'Voir les horaires spéciaux',
+  seeNormalHours: 'Voir les horaires habituels',
+};

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -4,6 +4,31 @@
 
   .poi_panel__sub_block__title {
     cursor: default;
+    margin-bottom: 6px;
+  }
+
+  &-timeTableContainer {
+    margin-top: 3px;
+    position: relative;
+  }
+
+  .icon-icon_clock,
+  .icon-icon_info {
+    font-size: 16px;
+    width: 20px;
+    height: 18px;
+    color: $primary_clear;
+  }
+
+  .icon-icon_clock {
+    position: absolute;
+    top: 5px;
+  }
+
+  .icon-icon_info {
+    display: inline-block;
+    margin-right: 5px;
+    vertical-align: middle;
   }
 
   &-status {
@@ -20,6 +45,11 @@
     }
   }
 
+  .timetable {
+    margin-left: 24px;
+    margin-bottom: 3px;
+  }
+
   &-contributeLink {
     display: block;
     text-align: right;
@@ -28,5 +58,13 @@
     &:before {
       content: '» '
     }
+  }
+
+  &-changeWarning {
+    margin-bottom: 6px;
+  }
+
+  &-note {
+    margin: 12px 0 6px;
   }
 }

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -1,0 +1,32 @@
+.covid19 {
+  font-size: 15px;
+  color: $primary_text;
+
+  .poi_panel__sub_block__title {
+    cursor: default;
+  }
+
+  &-status {
+    &--open {
+      color: #60ad51;
+    }
+    
+    &--maybeOpen {
+      color: orange;
+    }
+    
+    &--closed {
+      color: #8c0212; 
+    }
+  }
+
+  &-contributeLink {
+    display: block;
+    text-align: right;
+    color: $secondary_text;
+
+    &:before {
+      content: '» '
+    }
+  }
+}

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -50,10 +50,19 @@
     margin-bottom: 3px;
   }
 
-  &-contributeLink {
-    display: block;
+  &-source {
+    font-size: 12px;
     text-align: right;
     color: $secondary_text;
+    margin-top: 6px;
+
+    a {
+      color: $secondary_text;
+    }
+  }
+
+  &-contributeLink {
+    font-weight: bold;
 
     &:before {
       content: '» '

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -609,3 +609,5 @@ $HEADER_SIZE: 40px;
     margin-bottom: 9px;
   }
 }
+
+@import "./covid";

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -456,10 +456,6 @@ $HEADER_SIZE: 40px;
     padding: 15px;
   }
 
-  .poi_panel__info__hours__status {
-    width: calc(100% - 16px);
-  }
-
   .poi_panel__sub_block__title {
     width: calc(100% - 16px);
   }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -137,80 +137,6 @@ $HEADER_SIZE: 40px;
   color: $primary_text;
 }
 
-.poi_panel__info__hours {
-  max-height: 0;
-  transition: max-height 0.3s;
-  overflow: hidden;
-}
-
-.poi_panel__info__hours__table {
-  width: calc(100% - 20px);
-  margin-top: 8px;
-  font-size: 15px;
-  color: $primary_text;
-}
-
-.poi_panel__info__hours .hours {
-  text-align: right;
-  padding: 4px 10px;
-}
-
-.poi_panel__info__hours_status {
-  cursor: pointer;
-}
-
-.poi_panel__info__hours--open {
-  max-height: 400px;
-}
-
-.poi_panel__info__hours__status {
-  cursor: pointer;
-  position: relative;
-}
-
-.poi_panel__info__section--hours {
-  .poi_panel__info__hours__status__text {
-    display: inline-block;
-    color: $primary_text;
-  }
-}
-
-.poi_panel__info__hours__status__toggle {
-  position: absolute;
-  right: 0;
-  font-size: 24px;
-  color: $secondary_text;
-  transition: transform .2s;
-}
-
-.poi_panel__info__hours__status__toggle--reversed {
-  transform: rotate(180deg);
-}
-
-.poi_panel__info__hours .day {
-  padding: 4px 5px 4px 0;
-}
-
-.poi_panel__info__hours .day:first-letter {
-  text-transform: uppercase;
-}
-
-.poi_panel__info__hours--current {
-  font-family: Asap;
-  font-weight: 700;
-}
-
-.poi_panel__hour__extend {
-  position: absolute;
-  right: 20px;
-}
-
-.hour_panel__no_data  {
-  padding-left: 64px;
-  color: $secondary_text;
-  font-size: 14px;
-}
-
 .poi_panel__info__hour__circle {
   width: 6px;
   height: 6px;
@@ -361,8 +287,11 @@ $HEADER_SIZE: 40px;
   height: 18px;
 }
 
-.poi_panel__block__symbol.icon-icon_phone, .poi_panel__block__symbol.icon-icon_clock {
+.poi_panel__block__symbol.icon-icon_phone {
   top: 20px;
+}
+.poi_panel__block__symbol.icon-icon_clock {
+  top: 24px;
 }
 
 .poi_panel__block__content {
@@ -611,3 +540,4 @@ $HEADER_SIZE: 40px;
 }
 
 @import "./covid";
+@import "./timetable";

--- a/src/scss/includes/panels/timetable.scss
+++ b/src/scss/includes/panels/timetable.scss
@@ -1,0 +1,63 @@
+
+.timetable {
+  color: $primary_text;
+  font-size: 15px;
+
+  &-table {
+    transition: max-height 0.3s;
+    overflow: hidden;
+    max-height: 400px;
+  }
+
+  table {
+    width: calc(100% - 20px);
+    margin-top: 8px;
+    font-size: 15px;
+    color: $primary_text;
+  }
+
+  .day {
+    padding: 4px 5px 4px 0;
+  
+    &:first-letter {
+      text-transform: uppercase;
+    }
+  }
+
+  .hours {
+    text-align: right;
+    padding: 4px 10px;
+  }
+  
+  .currentDay {
+    font-family: Asap;
+    font-weight: 700;
+  }
+
+  &-status {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+  }
+
+  &-status-text {
+    flex-grow: 1;
+  }
+
+  .icon-icon_chevron-down {
+    font-size: 24px;
+    color: $secondary_text;
+    transition: transform .2s;
+    transform: rotate(180deg);
+  }
+
+  &--collapsed {
+    .timetable-table {
+      max-height: 0;
+    }
+
+    .icon-icon_chevron-down {
+      transform: rotate(0deg);
+    }
+  }
+}

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -180,7 +180,7 @@ test('display details about the poi on a poi click', async () => {
     return {
       contact: document.querySelector('.poi_panel__info__contact').innerText,
       contactUrl: document.querySelector('.poi_panel__info__contact').href,
-      hours: document.querySelector('.poi_panel__info__hours__status').innerText,
+      hours: document.querySelector('.poi_panel .timetable-status').innerText,
       phone: document.querySelector('.poi_phone_container_revealed').innerText,
       website: document.querySelector('.poi_panel__info__link').innerText,
     };
@@ -299,7 +299,7 @@ describe('Poi hour i18n', () => {
       await langPage.goto(
         `${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`
       );
-      await langPage.waitForSelector('.poi_panel__info__hours__table');
+      await langPage.waitForSelector('.timetable');
       const hourData = await getHours(langPage);
       if (language.locale === 'en_US') {
         // Tuesday
@@ -345,7 +345,7 @@ async function getTitle(page) {
 
 async function getHours(page) {
   return await page.evaluate(() => {
-    return Array.from(document.querySelectorAll('.poi_panel__info__hours__table tr')).map(line => {
+    return Array.from(document.querySelectorAll('.timetable tr')).map(line => {
       return Array.from(line.querySelectorAll('td')).map(cell => {
         return cell.innerText.trim();
       });


### PR DESCRIPTION
## Description
This PR uses the new `covid19` block on french POIs, coming from the ["Ça reste ouvert" project](https://caresteouvert.fr), to display information on the lockdown in the POI panel.

It defines and uses a new feature flag `covid19.enabled`, to be able to test and remove the feature easily. 

Then we define a new `Covid19` component to manage this special block and rules. I chose to make some refacto on the way to be able to re-use the existing time table display of opening times in this block. This makes the PR grows bigger than I hoped, but make the whole thing easier at the end.

Outside from the block, several other things are adjusted:
 - we don't display the current open status in poi popups
 - if we have covid19 data, we don't display the current open status in the mobile POI Card 
 - if we have covid19 data, we don't display the current open status as header of "normal" opening hours

PJ POIs have a covid19 block of status `unkown` and no URL to contribute to Ça reste ouvert, so we just display some very neutral info.

## Screenshots
|Situation|Screenshot|
|---|---|
|open, with specified hours|![Capture d’écran de 2020-03-30 17-57-03](https://user-images.githubusercontent.com/243653/77934256-1cba3f80-72b0-11ea-8b92-7a064a478ccb.png)|
|The same in PJ|![Capture d’écran de 2020-03-30 17-58-22](https://user-images.githubusercontent.com/243653/77934310-33f92d00-72b0-11ea-9844-d9a40ec162f4.png)|
|open, with no specified hours|![Capture d’écran de 2020-03-30 17-57-14](https://user-images.githubusercontent.com/243653/77934363-45dad000-72b0-11ea-9010-8cac59928bec.png)|
|closed|![Capture d’écran de 2020-03-30 17-58-01](https://user-images.githubusercontent.com/243653/77934393-4ffcce80-72b0-11ea-947e-d7cdf4c97122.png)|
|unknown, but existing in CRO*|![Capture d’écran de 2020-03-30 17-57-48](https://user-images.githubusercontent.com/243653/77934408-5723dc80-72b0-11ea-9a9a-88eda32e599f.png)
