### PR TITLE
covid19 fix: Opening hours title does not use hours from the new block

### DIFF
--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -18,13 +18,12 @@ const getMessages = () => {
   return memoizedMessages;
 };
 
-const OpeningHour = ({ poi }) => {
-  const openingBlock = poi.blocksByType && poi.blocksByType.opening_hours;
-  if (!openingBlock) {
+const OpeningHour = ({ openingHours }) => {
+  if (!openingHours) {
     return null;
   }
 
-  const schedule = new OsmSchedule(openingBlock, getMessages());
+  const schedule = new OsmSchedule(openingHours, getMessages());
   const { isTwentyFourSeven, status, nextTransition } = schedule;
   if (isTwentyFourSeven) {
     return <div className="openingHour poi_panel__info__hours__24_7">

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -15,7 +15,7 @@ const PoiPopup = ({ poi }) => {
   if (reviews) {
     displayedInfo = <ReviewScore reviews={reviews} poi={poi} />;
   } else if (openingHours && !covid19Enabled) {
-    displayedInfo = <OpeningHour poi={poi} />;
+    displayedInfo = <OpeningHour openingHours={openingHours} />;
   } else if (address) {
     displayedInfo = <span className="poi_popup__address">{address}</span>;
   }

--- a/src/panel/category/PoiCategoryItem.jsx
+++ b/src/panel/category/PoiCategoryItem.jsx
@@ -21,7 +21,7 @@ const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
 
     {reviews && <ReviewScore reviews={reviews} poi={poi} inList />}
 
-    <OpeningHour poi={poi} />
+    <OpeningHour openingHours={poi.blocksByType.opening_hours} />
 
     {phoneBlock && <PhoneNumber
       phoneBlock={phoneBlock}

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -28,7 +28,7 @@ export default class PoiBlockContainer extends React.Component {
 
     return <div className="poi_panel__info">
       {displayCovidInfo &&
-        <CovidBlock block={covidBlock} normalHourBlock={hourBlock} poi={this.props.poi} />}
+        <CovidBlock block={covidBlock} />}
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -26,12 +26,14 @@ class PoiCard extends React.Component {
     const hideOpeningHour = covid19Enabled
       && poi.blocks && poi.blocks.find(b => b.type === 'covid19');
 
+    const openingHours = poi.blocksByType && poi.blocksByType.opening_hours;
+
     return <div className="poi_card" ref={this.cardRef}>
       <div className="poi_card__description_container">
         <PoiTitleImage poi={poi} iconOnly={true} />
         <div>
           <PoiHeader poi={poi} />
-          {!hideOpeningHour && <OpeningHour poi={poi} />}
+          {!hideOpeningHour && <OpeningHour openingHours={openingHours} />}
         </div>
       </div>
       <div className="poi_card__action_container">

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -43,7 +43,7 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
       <div className="covid19-status covid19-status--open">{covidStrings.statusOpen}</div>
       {schedule && <div className="covid19-timeTableContainer">
         <i className="icon-icon_clock" />
-        <TimeTable title={<OpeningHour poi={poi} />} schedule={schedule} />
+        <TimeTable title={<OpeningHour openingHours={opening_hours} />} schedule={schedule} />
       </div>}
       {!schedule && <div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>}
       {additionalInfo}

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -16,7 +16,7 @@ const scheduleMessages = {
   },
 };
 
-const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
+const getContent = ({ status, opening_hours, note, contribute_url }) => {
   const additionalInfo = note &&
     <div className="covid19-note">
       <i className="icon-icon_info" />
@@ -78,10 +78,10 @@ const getContent = (poi, { status, opening_hours, note, contribute_url }) => {
   return content;
 };
 
-const Covid19 = ({ poi, block }) => {
+const Covid19 = ({ block }) => {
   return <div className="poi_panel__info__section covid19">
     <h4 className="poi_panel__sub_block__title">{covidStrings.blockTitle}</h4>
-    {getContent(poi, block)}
+    {getContent(block)}
   </div>;
 };
 


### PR DESCRIPTION
## Description
The opening hours title could be wrong, because it used the default opening hours, instead of those that appear in the new block.
