### PR TITLE
[Covid-19] Fix display of 24/7 opening hours in Covid mode

### DIFF
--- a/src/adapters/osm_schedule.js
+++ b/src/adapters/osm_schedule.js
@@ -1,4 +1,8 @@
-function OsmSchedule(scheduleResponse, messages) {
+
+function OsmSchedule(scheduleResponse) {
+  if (!scheduleResponse) {
+    return null;
+  }
   this.isTwentyFourSeven = scheduleResponse.is_24_7;
   this.days = scheduleResponse.days;
   this.displayHours = translateSchedule(this.days);
@@ -6,20 +10,7 @@ function OsmSchedule(scheduleResponse, messages) {
     scheduleResponse.seconds_before_next_transition,
     scheduleResponse.next_transition_datetime,
   );
-  this.status = scheduleStatus(scheduleResponse, messages);
-}
-
-function scheduleStatus(scheduleResponse, timeMessages) {
-  if (!scheduleResponse) {
-    return { msg: '', color: '#fff' };
-  }
-  if (scheduleResponse.status === 'closed') {
-    return { msg: timeMessages.closed.msg, color: timeMessages.closed.color };
-  } else if (scheduleResponse.status === 'open') {
-    return { msg: timeMessages.open.msg, color: timeMessages.open.color };
-  }
-
-  return { msg: '', color: '#fff' };
+  this.status = scheduleResponse.status;
 }
 
 function getIntlLocales() {

--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -1,45 +1,44 @@
 /* global _ */
 import React from 'react';
-import OsmSchedule from 'src/adapters/osm_schedule';
 
-let memoizedMessages = null;
-const getMessages = () => {
-  memoizedMessages = memoizedMessages ||
-    {
-      open: {
-        msg: _('Open'),
-        color: '#60ad51',
-      },
-      closed: {
-        msg: _('Closed'),
-        color: '#8c0212',
-      },
+const getStatusMessage = status => {
+  if (status === 'open') {
+    return {
+      label: _('Open'),
+      color: '#60ad51',
     };
-  return memoizedMessages;
+  }
+  if (status === 'closed') {
+    return {
+      label: _('Closed'),
+      color: '#8c0212',
+    };
+  }
+  return { label: '', color: '#fff' };
 };
 
-const OpeningHour = ({ openingHours }) => {
-  if (!openingHours) {
+const OpeningHour = ({ schedule }) => {
+  if (!schedule) {
     return null;
   }
 
-  const schedule = new OsmSchedule(openingHours, getMessages());
   const { isTwentyFourSeven, status, nextTransition } = schedule;
+  const { label, color } = getStatusMessage(status);
   if (isTwentyFourSeven) {
     return <div className="openingHour poi_panel__info__hours__24_7">
       {_('Open 24/7', 'hour block')}
       {' '}
-      <div className="openingHour-circle" style={{ background: status.color }} />
+      <div className="openingHour-circle" style={{ background: color }} />
     </div>;
   }
 
   return <div className="openingHour">
-    {_(status.msg)}
+    {label}
     {nextTransition &&
       ` - ${_('until {nextTransitionTime}', 'hour panel', { nextTransitionTime: nextTransition })}`
     }
     {' '}
-    <div className="openingHour-circle" style={{ background: status.color }} />
+    <div className="openingHour-circle" style={{ background: color }} />
   </div>;
 };
 

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReviewScore from 'src/components/ReviewScore';
 import OpeningHour from 'src/components/OpeningHour';
+import OsmSchedule from 'src/adapters/osm_schedule';
 import poiSubClass from '../mapbox/poi_subclass';
 import nconf from '@qwant/nconf-getter';
 
@@ -15,7 +16,7 @@ const PoiPopup = ({ poi }) => {
   if (reviews) {
     displayedInfo = <ReviewScore reviews={reviews} poi={poi} />;
   } else if (openingHours && !covid19Enabled) {
-    displayedInfo = <OpeningHour openingHours={openingHours} />;
+    displayedInfo = <OpeningHour schedule={new OsmSchedule(openingHours)} />;
   } else if (address) {
     displayedInfo = <span className="poi_popup__address">{address}</span>;
   }

--- a/src/panel/category/PoiCategoryItem.jsx
+++ b/src/panel/category/PoiCategoryItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import OpeningHour from 'src/components/OpeningHour';
+import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PhoneNumber from './PhoneNumber';
 import poiSubClass from 'src/mapbox/poi_subclass';
@@ -26,7 +27,7 @@ const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
 
     {reviews && <ReviewScore reviews={reviews} poi={poi} inList />}
 
-    {!hideOpeningHour && <OpeningHour openingHours={poi.blocksByType.opening_hours} />}
+    {!hideOpeningHour && <OpeningHour schedule={new OsmSchedule(poi.blocksByType.opening_hours)} />}
 
     {phoneBlock && <PhoneNumber
       phoneBlock={phoneBlock}

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -27,8 +27,7 @@ export default class PoiBlockContainer extends React.Component {
     const displayCovidInfo = this.props.covid19Enabled && blocks.find(b => b.type === 'covid19');
 
     return <div className="poi_panel__info">
-      {displayCovidInfo &&
-        <CovidBlock block={covidBlock} />}
+      {displayCovidInfo && <CovidBlock block={covidBlock} />}
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PoiHeader from './PoiHeader';
 import PoiTitleImage from './PoiTitleImage';
 import OpeningHour from 'src/components/OpeningHour';
+import OsmSchedule from 'src/adapters/osm_schedule';
 import Button from 'src/components/ui/Button';
 
 class PoiCard extends React.Component {
@@ -33,7 +34,7 @@ class PoiCard extends React.Component {
         <PoiTitleImage poi={poi} iconOnly={true} />
         <div>
           <PoiHeader poi={poi} />
-          {!hideOpeningHour && <OpeningHour openingHours={openingHours} />}
+          {!hideOpeningHour && <OpeningHour schedule={new OsmSchedule(openingHours)} />}
         </div>
       </div>
       <div className="poi_card__action_container">

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -7,18 +7,6 @@ import OpeningHour from 'src/components/OpeningHour';
 
 const covidConf = nconf.get().covid19;
 
-// @TODO: refacto OsmSchedule so it doesn't need presentational data
-const scheduleMessages = {
-  open: {
-    msg: 'Ouvert',
-    color: '#60ad51',
-  },
-  closed: {
-    msg: 'Fermé',
-    color: '#8c0212',
-  },
-};
-
 const getContent = ({ status, opening_hours, note, contribute_url }) => {
   const additionalInfo = note &&
     <div className="covid19-note">
@@ -41,12 +29,12 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
   switch (status) {
   case 'open':
   case 'open_as_usual':
-    schedule = opening_hours && new OsmSchedule(opening_hours, scheduleMessages);
+    schedule = opening_hours && new OsmSchedule(opening_hours);
     content = <Fragment>
       <div className="covid19-status covid19-status--open">{covidStrings.statusOpen}</div>
       {schedule && <div className="covid19-timeTableContainer">
         <i className="icon-icon_clock" />
-        <TimeTable title={<OpeningHour openingHours={opening_hours} />} schedule={schedule} />
+        <TimeTable title={<OpeningHour schedule={schedule} />} schedule={schedule} />
       </div>}
       {!schedule && <div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>}
       {additionalInfo}
@@ -80,7 +68,6 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
 
   return content;
 };
-
 
 /* eslint-disable */
 const Covid19 = ({ block }) => {

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -3,7 +3,6 @@ import nconf from '@qwant/nconf-getter';
 import TimeTable from './TimeTable';
 import covidStrings from './covid_strings';
 import OsmSchedule from 'src/adapters/osm_schedule';
-import OpeningHour from 'src/components/OpeningHour';
 
 const covidConf = nconf.get().covid19;
 
@@ -34,7 +33,7 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
       <div className="covid19-status covid19-status--open">{covidStrings.statusOpen}</div>
       {schedule && <div className="covid19-timeTableContainer">
         <i className="icon-icon_clock" />
-        <TimeTable title={<OpeningHour schedule={schedule} />} schedule={schedule} />
+        <TimeTable schedule={schedule} />
       </div>}
       {!schedule && <div className="covid19-changeWarning">{covidStrings.hoursMayChange}</div>}
       {additionalInfo}

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -27,23 +27,8 @@ export default class HourBlock extends React.Component {
     covid19enabled: PropTypes.bool,
   }
 
-  constructor(props) {
-    super(props);
-
-    this.messages = {
-      open: {
-        msg: _('Open'),
-        color: '#60ad51',
-      },
-      closed: {
-        msg: _('Closed'),
-        color: '#8c0212',
-      },
-    };
-  }
-
   render() {
-    const opening = new OsmSchedule(this.props.block, this.messages);
+    const opening = new OsmSchedule(this.props.block);
     if (!opening.days) {
       return null;
     }

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -3,7 +3,6 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import TimeTable from './TimeTable';
 import PropTypes from 'prop-types';
 import covidStrings from './covid_strings';
-import OpeningHour from 'src/components/OpeningHour';
 
 export default class HourBlock extends React.Component {
   static propTypes = {
@@ -17,15 +16,14 @@ export default class HourBlock extends React.Component {
       return null;
     }
 
-    const timeTableTitle = this.props.covid19enabled
-      ? <span>{covidStrings.seeNormalHours}</span>
-      : <OpeningHour schedule={schedule} />;
-
     return <div className="poi_panel__info__section poi_panel__info__section--hours">
       <div className="poi_panel__info__section__description">
         <div className="icon-icon_clock poi_panel__block__symbol"></div>
         <div className="poi_panel__block__content">
-          <TimeTable schedule={schedule} title={timeTableTitle} />
+          <TimeTable
+            schedule={schedule}
+            title={this.props.covid19enabled && covidStrings.seeNormalHours}
+          />
         </div>
       </div>
     </div>;

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -1,25 +1,9 @@
-/* global _ */
 import React from 'react';
 import OsmSchedule from 'src/adapters/osm_schedule';
 import TimeTable from './TimeTable';
 import PropTypes from 'prop-types';
 import covidStrings from './covid_strings';
-
-function renderTitle(opening, covid19) {
-  if (covid19) {
-    return <span>{covidStrings.seeNormalHours}</span>;
-  }
-
-  let text = `${_(opening.status.msg)} `;
-  if (opening.nextTransition) {
-    text += ' - ' +
-      _('until {nextTransitionTime}', 'hour panel',
-        { nextTransitionTime: opening.nextTransition }) + ' ';
-  }
-  return <span>{ text }
-    <div className="poi_panel__info__hour__circle" style={{ background: opening.status.color }} />
-  </span>;
-}
+import OpeningHour from 'src/components/OpeningHour';
 
 export default class HourBlock extends React.Component {
   static propTypes = {
@@ -28,16 +12,20 @@ export default class HourBlock extends React.Component {
   }
 
   render() {
-    const opening = new OsmSchedule(this.props.block);
-    if (!opening.days) {
+    const schedule = new OsmSchedule(this.props.block);
+    if (!schedule.days) {
       return null;
     }
+
+    const timeTableTitle = this.props.covid19enabled
+      ? <span>{covidStrings.seeNormalHours}</span>
+      : <OpeningHour schedule={schedule} />;
 
     return <div className="poi_panel__info__section poi_panel__info__section--hours">
       <div className="poi_panel__info__section__description">
         <div className="icon-icon_clock poi_panel__block__symbol"></div>
         <div className="poi_panel__block__content">
-          <TimeTable title={renderTitle(opening, this.props.covid19enabled)} schedule={opening} />
+          <TimeTable schedule={schedule} title={timeTableTitle} />
         </div>
       </div>
     </div>;

--- a/src/panel/poi/blocks/TimeTable.jsx
+++ b/src/panel/poi/blocks/TimeTable.jsx
@@ -12,12 +12,12 @@ function showHour(day) {
   return _('Closed', 'hour block');
 }
 
-function showHours(displayHours) {
+const Days = ({ days }) => {
   const dayNumber = new Date().getDay();
 
   return <table>
     <tbody>
-      {displayHours.map((day, i) =>
+      {days.map((day, i) =>
         <tr key={i} className={
           classnames({ 'currentDay': (i + 1) % 7 === dayNumber })
         }>
@@ -26,21 +26,41 @@ function showHours(displayHours) {
         </tr>)}
     </tbody>
   </table>;
-}
+};
 
 const TimeTable = ({ title, schedule }) => {
   const [ isCollapsed, setCollapsed ] = useState(true);
 
-  return <div className={classnames('timetable', { 'timetable--collapsed': isCollapsed })}>
-    <div className="timetable-status" onClick={() => { setCollapsed(!isCollapsed); }}>
-      <div className="timetable-status-text">{title}</div>
-      <i className="icon-icon_chevron-down" />
+  let header;
+  let content;
+  if (title) {
+    header = title;
+    content = schedule.isTwentyFourSeven
+      ? <OpeningHour schedule={schedule} />
+      : <Days days={schedule.displayHours} />;
+  } else {
+    header = <OpeningHour schedule={schedule} />;
+    if (!schedule.isTwentyFourSeven) {
+      content = <Days days={schedule.displayHours} />;
+    }
+  }
+
+  const collapsable = !!content;
+  return <div className={classnames('timetable', {
+    'timetable--collapsable': collapsable,
+    'timetable--collapsed': isCollapsed,
+  })}>
+    <div className="timetable-status" onClick={() => {
+      if (collapsable) {
+        setCollapsed(!isCollapsed);
+      }
+    }}>
+      <div className="timetable-status-text">{header}</div>
+      {collapsable && <i className="icon-icon_chevron-down" />}
     </div>
-    <div className={classnames('timetable-table')}>
-      {schedule.isTwentyFourSeven
-        ? <OpeningHour schedule={schedule} />
-        : showHours(schedule.displayHours)}
-    </div>
+    {collapsable && <div className={classnames('timetable-table')}>
+      {content}
+    </div>}
   </div>;
 };
 

--- a/src/panel/poi/blocks/TimeTable.jsx
+++ b/src/panel/poi/blocks/TimeTable.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import OpeningHour from 'src/components/OpeningHour';
 
 function showHour(day) {
   if (day.opening && day.opening.length > 0) {
@@ -14,29 +15,20 @@ function showHour(day) {
 function showHours(displayHours) {
   const dayNumber = new Date().getDay();
 
-  return <tbody>
-    {displayHours.map((day, i) =>
-      <tr key={i} className={
-        classnames({ 'currentDay': (i + 1) % 7 === dayNumber })
-      }>
-        <td className="day">{ day.dayName }</td>
-        <td className="hours">{ showHour(day) }</td>
-      </tr>)}
-  </tbody>;
+  return <table>
+    <tbody>
+      {displayHours.map((day, i) =>
+        <tr key={i} className={
+          classnames({ 'currentDay': (i + 1) % 7 === dayNumber })
+        }>
+          <td className="day">{ day.dayName }</td>
+          <td className="hours">{ showHour(day) }</td>
+        </tr>)}
+    </tbody>
+  </table>;
 }
 
 const TimeTable = ({ title, schedule }) => {
-  // TODO: use OpeningHour instead (careful! OsmSchedule initialization happens there as well!)
-  if (schedule.isTwentyFourSeven) {
-    return <div
-      className="timetable timetable-status poi_panel__info__hours__24_7">
-      { _('Open 24/7', 'hour block') }
-      <div className="poi_panel__info__hour__circle"
-        style={{ background: schedule.status.color }}
-      />
-    </div>;
-  }
-
   const [ isCollapsed, setCollapsed ] = useState(true);
 
   return <div className={classnames('timetable', { 'timetable--collapsed': isCollapsed })}>
@@ -45,9 +37,9 @@ const TimeTable = ({ title, schedule }) => {
       <i className="icon-icon_chevron-down" />
     </div>
     <div className={classnames('timetable-table')}>
-      <table>
-        { showHours(schedule.displayHours) }
-      </table>
+      {schedule.isTwentyFourSeven
+        ? <OpeningHour schedule={schedule} />
+        : showHours(schedule.displayHours)}
     </div>
   </div>;
 };

--- a/src/scss/includes/panels/timetable.scss
+++ b/src/scss/includes/panels/timetable.scss
@@ -35,13 +35,19 @@
   }
 
   &-status {
-    cursor: pointer;
     display: flex;
     align-items: center;
   }
 
   &-status-text {
     flex-grow: 1;
+    line-height: 24px;
+  }
+
+  &--collapsable {
+    .timetable-status {
+      cursor: pointer;
+    }
   }
 
   .icon-icon_chevron-down {

--- a/src/scss/includes/panels/timetable.scss
+++ b/src/scss/includes/panels/timetable.scss
@@ -44,6 +44,10 @@
     line-height: 24px;
   }
 
+  .openingHour {
+    font-size: 15px;
+  }
+
   &--collapsable {
     .timetable-status {
       cursor: pointer;


### PR DESCRIPTION
## Description
Don't show 24/7 normal opening status when Covid flag is enabled.
Unfortunalety required *a lot* of refacto on components managing hours to be able to manage every case…
The best option from the very start would have been to manage all collapsible POI info blocks in a generic component, but that would touch too many unrelated parts.
Let's keep that for a future cleaning.

## Why
24/7 are managed as a special case with collapse/expand action.

## Screenshots
|Before|After (expanded)|
|---|---|
|![Capture d’écran de 2020-03-31 16-25-14](https://user-images.githubusercontent.com/243653/78037762-3faa2980-736c-11ea-9112-1227645e1a47.png)|![Capture d’écran de 2020-03-31 16-24-25](https://user-images.githubusercontent.com/243653/78037864-610b1580-736c-11ea-8183-4ba5f23d82d7.png)|
