### PR TITLE
[Covid-19] Hide opening hours in list for French POIs

### DIFF
--- a/src/panel/category/PoiCategoryItem.jsx
+++ b/src/panel/category/PoiCategoryItem.jsx
@@ -4,11 +4,16 @@ import ReviewScore from 'src/components/ReviewScore';
 import PhoneNumber from './PhoneNumber';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
+import nconf from '@qwant/nconf-getter';
+
+const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
 const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
   const reviews = poi.blocksByType.grades;
   const phoneBlock = poi.blocksByType.phone;
   const address = poi.address || {};
+
+  const hideOpeningHour = covid19Enabled && poi.blocksByType.covid19;
 
   return <div className="category__panel__item">
     <PoiTitleImage poi={poi} />
@@ -21,7 +26,7 @@ const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
 
     {reviews && <ReviewScore reviews={reviews} poi={poi} inList />}
 
-    <OpeningHour openingHours={poi.blocksByType.opening_hours} />
+    {!hideOpeningHour && <OpeningHour openingHours={poi.blocksByType.opening_hours} />}
 
     {phoneBlock && <PhoneNumber
       phoneBlock={phoneBlock}


### PR DESCRIPTION
## Description
Hide opening hours in the POI list like we did for POI Card, i.e. for items which have a covid19 block (in practice, all French POI).

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2020-03-31 16-53-18](https://user-images.githubusercontent.com/243653/78040748-273c0e00-7370-11ea-80ea-b8c7c5ba2a62.png)|![Capture d’écran de 2020-03-31 16-53-05](https://user-images.githubusercontent.com/243653/78040762-2b682b80-7370-11ea-8cb5-7ec1169b5e7a.png)|