### PR TITLE
[Covid-19] Include legal message in block

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -92,3 +92,4 @@ events:
 
 covid19:
   enabled: false
+  frInformationUrl: https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-derogatoire-et-justificatif-de-deplacement-professionnel

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -1,8 +1,11 @@
 import React, { Fragment } from 'react';
+import nconf from '@qwant/nconf-getter';
 import TimeTable from './TimeTable';
 import covidStrings from './covid_strings';
 import OsmSchedule from 'src/adapters/osm_schedule';
 import OpeningHour from 'src/components/OpeningHour';
+
+const covidConf = nconf.get().covid19;
 
 // @TODO: refacto OsmSchedule so it doesn't need presentational data
 const scheduleMessages = {
@@ -20,15 +23,15 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
   const additionalInfo = note &&
     <div className="covid19-note">
       <i className="icon-icon_info" />
-      {note}
+      <p>{note}</p>
     </div>;
 
   const source = contribute_url &&
     <div className="covid19-source">
       <div>Source&nbsp;:&nbsp;
-        <a href="https://caresteouvert.fr">Ça reste ouvert</a>
+        <a rel="noopener noreferrer" href="https://caresteouvert.fr">Ça reste ouvert</a>
       </div>
-      <a className="covid19-contributeLink" href={contribute_url}>
+      <a className="covid19-contributeLink" rel="noopener noreferrer" href={contribute_url}>
         {covidStrings.linkToCaResteOuvert}
       </a>
     </div>;
@@ -78,11 +81,29 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
   return content;
 };
 
+
+/* eslint-disable */
 const Covid19 = ({ block }) => {
   return <div className="poi_panel__info__section covid19">
-    <h4 className="poi_panel__sub_block__title">{covidStrings.blockTitle}</h4>
+    <h4 className="poi_panel__sub_block__title">
+      {covidStrings.blockTitle}
+    </h4>
     {getContent(block)}
+    <div className="covid19-legalWarning">
+      <i className="icon-alert-triangle" />
+      <div>
+        <p>
+          Pendant toute la période de confinement, se déplacer vers ce lieu n'est autorisé
+          qu'en possession d'une attestation de déplacement dérogatoire.
+        </p>
+        <p>
+          Plus d'informations sur{' '}
+          <a rel="noopener noreferrer" href={covidConf.frInformationUrl}>interieur.gouv.fr</a>
+        </p>
+      </div>
+    </div>
   </div>;
 };
+/* eslint-enable */
 
 export default Covid19;

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -8,7 +8,7 @@
   }
 
   &-timeTableContainer {
-    margin-top: 3px;
+    margin-top: 6px;
     position: relative;
   }
 
@@ -27,8 +27,13 @@
 
   .icon-icon_info {
     display: inline-block;
-    margin-right: 5px;
     vertical-align: middle;
+  }
+
+  .icon-icon_clock,
+  .icon-icon_info,
+  .icon-alert-triangle {
+    min-width: 24px;
   }
 
   &-status {
@@ -75,5 +80,19 @@
 
   &-note {
     margin: 12px 0 6px;
+    display: flex;
+    flex-direction: row;
+  }
+
+  &-legalWarning {
+    display: flex;
+    flex-direction: row;
+    font-size: 12px;
+    margin-top: 20px;
+
+    i {
+      color: #ff8f00;
+      font-size: 15px;
+    }
   }
 }


### PR DESCRIPTION
As a simpler alternative to #592, the legal message is rendered at the bottom of the block.

![image](https://user-images.githubusercontent.com/4726554/78118891-eabbf100-7407-11ea-80d0-12b605d81add.png)
