### PR TITLE
Fix back to list from query

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -166,7 +166,7 @@ Scene.prototype.initMapBox = function() {
 
   listen('map_mark_poi', (poi, options) => {
     this.ensureMarkerIsVisible(poi, options);
-    if (!options.isFromCategory) {
+    if (!options.resource || !options.resource.category) {
       this.addMarker(poi, options);
     }
   });

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -166,7 +166,7 @@ Scene.prototype.initMapBox = function() {
 
   listen('map_mark_poi', (poi, options) => {
     this.ensureMarkerIsVisible(poi, options);
-    if (!options.resource || !options.resource.category) {
+    if (!options.poiFilters || !options.poiFilters.category) {
       this.addMarker(poi, options);
     }
   });

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -19,12 +19,12 @@ export default class SceneCategory {
     listen('highlight_category_marker', (poi, highlight) => {
       this.highlightPoiMarker(poi, highlight);
     });
-    listen('click_category_poi', (poi, categoryName) => {
-      this.selectPoi(poi, categoryName);
+    listen('click_category_poi', (poi, resource) => {
+      this.selectPoi(poi, resource);
     });
   }
 
-  selectPoi = (poi, categoryName) => {
+  selectPoi = (poi, resource) => {
     const previousMarker = document.querySelector('.mapboxgl-marker.active');
     if (previousMarker) {
       previousMarker.classList.remove('active');
@@ -37,14 +37,13 @@ export default class SceneCategory {
           template: 'multiple',
           zone: 'list',
           element: 'item',
-          category: categoryName,
+          category: resource.category,
         })
       );
     }
     window.app.navigateTo(`/place/${toUrl(poi)}`, {
       poi,
-      isFromCategory: true,
-      sourceCategory: categoryName,
+      resource,
       centerMap: true,
     });
     this.highlightPoiMarker(poi, true);
@@ -59,7 +58,9 @@ export default class SceneCategory {
         poi.marker_id = `marker_${id}`;
         marker.onclick = function(e) {
           e.stopPropagation();
-          fire('click_category_poi', poi, categoryName);
+          fire('click_category_poi', poi, {
+            category: categoryName,
+          });
         };
         marker.onmouseover = function(e) {
           fire('open_popup', poi, e);

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -19,12 +19,12 @@ export default class SceneCategory {
     listen('highlight_category_marker', (poi, highlight) => {
       this.highlightPoiMarker(poi, highlight);
     });
-    listen('click_category_poi', (poi, resource) => {
-      this.selectPoi(poi, resource);
+    listen('click_category_poi', (poi, poiFilters) => {
+      this.selectPoi(poi, poiFilters);
     });
   }
 
-  selectPoi = (poi, resource) => {
+  selectPoi = (poi, poiFilters) => {
     const previousMarker = document.querySelector('.mapboxgl-marker.active');
     if (previousMarker) {
       previousMarker.classList.remove('active');
@@ -37,13 +37,13 @@ export default class SceneCategory {
           template: 'multiple',
           zone: 'list',
           element: 'item',
-          category: resource.category,
+          category: poiFilters.category,
         })
       );
     }
     window.app.navigateTo(`/place/${toUrl(poi)}`, {
       poi,
-      resource,
+      poiFilters,
       centerMap: true,
     });
     this.highlightPoiMarker(poi, true);

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -57,9 +57,10 @@ export function toCssUrl(url) {
 }
 
 export function buildQueryString(queriesObject) {
-  const params = new URLSearchParams();
-  for (const name in queriesObject) {
-    params.append(name, queriesObject[name]);
+  if (Object.keys(queriesObject).length === 0) {
+    return '';
   }
-  return params.toString();
+
+  const params = new URLSearchParams(queriesObject);
+  return `?${params.toString()}`;
 }

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -55,3 +55,11 @@ export function toCssUrl(url) {
   const escapedUrl = url.replace(/'/g, "\\'");
   return `url('${escapedUrl}')`;
 }
+
+export function buildQueryString(queriesObject) {
+  const params = new URLSearchParams();
+  for (const name in queriesObject) {
+    params.append(name, queriesObject[name]);
+  }
+  return params.toString();
+}

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -49,7 +49,7 @@ export default class PanelManager extends React.Component {
     const { ActivePanel, options } = this.state;
 
     if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
-      if (ActivePanel !== PoiPanel || !options.resource || !options.resource.category) {
+      if (ActivePanel !== PoiPanel || !options.poiFilters || !options.poiFilters.category) {
         fire('remove_category_markers');
         fire('remove_event_markers');
       }
@@ -81,7 +81,7 @@ export default class PanelManager extends React.Component {
         this.setState({
           ActivePanel: CategoryPanel,
           options: {
-            resource: {
+            poiFilters: {
               category,
               query,
             },

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -49,7 +49,7 @@ export default class PanelManager extends React.Component {
     const { ActivePanel, options } = this.state;
 
     if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
-      if (ActivePanel !== PoiPanel || !options.isFromCategory) {
+      if (ActivePanel !== PoiPanel || !options.resource || !options.resource.category) {
         fire('remove_category_markers');
         fire('remove_event_markers');
       }
@@ -77,10 +77,16 @@ export default class PanelManager extends React.Component {
 
     if (categoryEnabled) {
       router.addRoute('Category', '/places/(.*)', placesParams => {
-        const { type: categoryName, q: query, ...otherOptions } = parseQueryString(placesParams);
+        const { type: category, q: query, ...otherOptions } = parseQueryString(placesParams);
         this.setState({
           ActivePanel: CategoryPanel,
-          options: { categoryName, query, ...otherOptions },
+          options: {
+            resource: {
+              category,
+              query,
+            },
+            ...otherOptions,
+          },
         });
       });
     }

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -17,9 +17,12 @@ const MAX_PLACES = Number(categoryConfig.maxPlaces);
 
 export default class CategoryPanel extends React.Component {
   static propTypes = {
-    categoryName: PropTypes.string,
-    query: PropTypes.string,
+    resource: PropTypes.object,
     bbox: PropTypes.string,
+  }
+
+  static defaultProps = {
+    resource: {},
   }
 
   state = {
@@ -29,10 +32,13 @@ export default class CategoryPanel extends React.Component {
   }
 
   componentDidMount() {
+    const { category } = this.props.resource;
+
     this.mapMoveHandler = listen('map_moveend', this.fetchData);
-    if (this.props.categoryName) {
-      Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category: this.props.categoryName });
-      const { label } = CategoryService.getCategoryByName(this.props.categoryName);
+
+    if (category) {
+      Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
+      const { label } = CategoryService.getCategoryByName(category);
       SearchInput.setInputValue(label.charAt(0).toUpperCase() + label.slice(1));
     }
 
@@ -82,6 +88,8 @@ export default class CategoryPanel extends React.Component {
   }
 
   fetchData = async () => {
+    const { category, query } = this.props.resource;
+
     const bbox = window.map.mb.getBounds();
     const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
       .map(cardinal => cardinal.toFixed(7))
@@ -90,8 +98,8 @@ export default class CategoryPanel extends React.Component {
     const { places, source } = await IdunnPoi.poiCategoryLoad(
       urlBBox,
       MAX_PLACES,
-      this.props.categoryName,
-      this.props.query
+      category,
+      query
     );
     this.setState({
       pois: places,
@@ -99,7 +107,7 @@ export default class CategoryPanel extends React.Component {
       initialLoading: false,
     });
 
-    fire('add_category_markers', places, this.props.categoryName);
+    fire('add_category_markers', places, this.props.resource.categoryName);
     fire('save_location');
   };
 
@@ -112,7 +120,7 @@ export default class CategoryPanel extends React.Component {
           template: 'multiple',
           zone: 'list',
           element: 'phone',
-          category: this.props.categoryName,
+          category: this.props.resource.categoryName,
         })
       );
     }
@@ -124,7 +132,8 @@ export default class CategoryPanel extends React.Component {
   }
 
   selectPoi = poi => {
-    fire('click_category_poi', poi, this.props.categoryName);
+    const { resource } = this.props;
+    fire('click_category_poi', poi, resource);
   }
 
   highlightPoiMarker = (poi, highlight) => {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -107,7 +107,7 @@ export default class CategoryPanel extends React.Component {
       initialLoading: false,
     });
 
-    fire('add_category_markers', places, this.props.poiFilters.categoryName);
+    fire('add_category_markers', places, this.props.poiFilters.category);
     fire('save_location');
   };
 
@@ -120,7 +120,7 @@ export default class CategoryPanel extends React.Component {
           template: 'multiple',
           zone: 'list',
           element: 'phone',
-          category: this.props.poiFilters.categoryName,
+          category: this.props.poiFilters.category,
         })
       );
     }

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -17,12 +17,12 @@ const MAX_PLACES = Number(categoryConfig.maxPlaces);
 
 export default class CategoryPanel extends React.Component {
   static propTypes = {
-    resource: PropTypes.object,
+    poiFilters: PropTypes.object,
     bbox: PropTypes.string,
   }
 
   static defaultProps = {
-    resource: {},
+    poiFilters: {},
   }
 
   state = {
@@ -32,7 +32,7 @@ export default class CategoryPanel extends React.Component {
   }
 
   componentDidMount() {
-    const { category } = this.props.resource;
+    const { category } = this.props.poiFilters;
 
     this.mapMoveHandler = listen('map_moveend', this.fetchData);
 
@@ -88,7 +88,7 @@ export default class CategoryPanel extends React.Component {
   }
 
   fetchData = async () => {
-    const { category, query } = this.props.resource;
+    const { category, query } = this.props.poiFilters;
 
     const bbox = window.map.mb.getBounds();
     const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
@@ -107,7 +107,7 @@ export default class CategoryPanel extends React.Component {
       initialLoading: false,
     });
 
-    fire('add_category_markers', places, this.props.resource.categoryName);
+    fire('add_category_markers', places, this.props.poiFilters.categoryName);
     fire('save_location');
   };
 
@@ -120,7 +120,7 @@ export default class CategoryPanel extends React.Component {
           template: 'multiple',
           zone: 'list',
           element: 'phone',
-          category: this.props.resource.categoryName,
+          category: this.props.poiFilters.categoryName,
         })
       );
     }
@@ -132,8 +132,8 @@ export default class CategoryPanel extends React.Component {
   }
 
   selectPoi = poi => {
-    const { resource } = this.props;
-    fire('click_category_poi', poi, resource);
+    const { poiFilters } = this.props;
+    fire('click_category_poi', poi, poiFilters);
   }
 
   highlightPoiMarker = (poi, highlight) => {

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -39,7 +39,7 @@ export default class PoiPanel extends React.Component {
   static propTypes = {
     poiId: PropTypes.string.isRequired,
     poi: PropTypes.object,
-    resource: PropTypes.object,
+    poiFilters: PropTypes.object,
     centerMap: PropTypes.bool,
   }
 
@@ -85,8 +85,8 @@ export default class PoiPanel extends React.Component {
   }
 
   loadPoi = async () => {
-    const { poiId, centerMap, resource } = this.props;
-    const mapOptions = { centerMap, resource };
+    const { poiId, centerMap, poiFilters } = this.props;
+    const mapOptions = { centerMap, poiFilters };
 
     // If a POI object is provided before fetching full data,
     // we can update the map immediately for UX responsiveness
@@ -178,9 +178,9 @@ export default class PoiPanel extends React.Component {
   backToList = () => {
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
-    const uri = this.props.resource.category
-      ? `/places/?type=${this.props.resource.category}`
-      : `/places/?q=${this.props.resource.query}`;
+    const uri = this.props.poiFilters.category
+      ? `/places/?type=${this.props.poiFilters.category}`
+      : `/places/?q=${this.props.poiFilters.query}`;
     window.app.navigateTo(uri);
   }
 
@@ -225,7 +225,7 @@ export default class PoiPanel extends React.Component {
 
 
   renderFull = poi => {
-    const { resource, isFromFavorite } = this.props;
+    const { poiFilters, isFromFavorite } = this.props;
 
     let backAction = null;
     if (isFromFavorite) {
@@ -234,7 +234,7 @@ export default class PoiPanel extends React.Component {
         text: _('Back to favorite'),
         className: 'poi_panel__back_to_list',
       };
-    } else if (resource && (resource.category || resource.query)) {
+    } else if (poiFilters && (poiFilters.category || poiFilters.query)) {
       backAction = {
         callback: this.backToList,
         text: _('Back to list'),
@@ -268,7 +268,7 @@ export default class PoiPanel extends React.Component {
         'poi_panel--empty-header':
           !isFromPagesJaunes(poi) &&
           !isFromFavorite &&
-          (!resource || !resource.category),
+          (!poiFilters || !poiFilters.category),
       } )}
       initialSize="maximized"
     >

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -43,6 +43,10 @@ export default class PoiPanel extends React.Component {
     centerMap: PropTypes.bool,
   }
 
+  static defaultProps = {
+    poiFilters: {},
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -178,9 +182,27 @@ export default class PoiPanel extends React.Component {
   backToList = () => {
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
-    const uri = this.props.poiFilters.category
-      ? `/places/?type=${this.props.poiFilters.category}`
-      : `/places/?q=${this.props.poiFilters.query}`;
+
+    const uri = Object
+      .keys(this.props.poiFilters)
+      .reduce((uri, filterName) => {
+        if (!this.props.poiFilters[filterName]) {
+          return uri;
+        }
+
+        uri += uri[uri.length - 1] === '/' ? '?' : '&';
+
+        // TODO use keys as query param
+        if (filterName === 'category') {
+          uri += 'type=';
+        } else if (filterName === 'query') {
+          uri += 'q=';
+        }
+
+        uri += this.props.poiFilters[filterName];
+        return uri;
+      }, '/places/');
+
     window.app.navigateTo(uri);
   }
 
@@ -234,7 +256,7 @@ export default class PoiPanel extends React.Component {
         text: _('Back to favorite'),
         className: 'poi_panel__back_to_list',
       };
-    } else if (poiFilters && (poiFilters.category || poiFilters.query)) {
+    } else if (poiFilters.category || poiFilters.query) {
       backAction = {
         callback: this.backToList,
         text: _('Back to list'),

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -14,6 +14,7 @@ import OsmContribution from 'src/components/OsmContribution';
 import CategoryList from 'src/components/CategoryList';
 import { openShareModal } from 'src/modals/ShareModal';
 import { toAbsoluteUrl, isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
+import { buildQueryString } from 'src/libs/url_utils';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import Poi from 'src/adapters/poi/poi.js';
 import SearchInput from 'src/ui_components/search_input';
@@ -181,30 +182,25 @@ export default class PoiPanel extends React.Component {
 
   backToList = () => {
     const { poiFilters } = this.props;
+    const queryObject = {};
+    const mappingParams = {
+      query: 'q',
+      category: 'type',
+    };
+
+    for (const name in poiFilters) {
+      if (!poiFilters[name]) {
+        continue;
+      }
+      const key = mappingParams[name];
+      queryObject[key || name] = poiFilters[name];
+    }
+
+    const params = buildQueryString(queryObject);
+    const uri = `/places/${params}`;
 
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
-
-    let uri = '/places/';
-
-    // Reconstruct uri
-    for (const filterName of Object.keys(poiFilters)) {
-      if (!poiFilters[filterName]) {
-        continue;
-      }
-
-      uri += uri[uri.length - 1] === '/' ? '?' : '&';
-
-      // TODO use keys as query param ?
-      if (filterName === 'category') {
-        uri += 'type=';
-      } else if (filterName === 'query') {
-        uri += 'q=';
-      }
-
-      uri += poiFilters[filterName];
-    }
-
     window.app.navigateTo(uri);
   }
 

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -39,9 +39,7 @@ export default class PoiPanel extends React.Component {
   static propTypes = {
     poiId: PropTypes.string.isRequired,
     poi: PropTypes.object,
-    isFromFavorite: PropTypes.bool,
-    isFromCategory: PropTypes.bool,
-    sourceCategory: PropTypes.string,
+    resource: PropTypes.object,
     centerMap: PropTypes.bool,
   }
 
@@ -87,8 +85,8 @@ export default class PoiPanel extends React.Component {
   }
 
   loadPoi = async () => {
-    const { poiId, centerMap, isFromCategory } = this.props;
-    const mapOptions = { centerMap, isFromCategory };
+    const { poiId, centerMap, resource } = this.props;
+    const mapOptions = { centerMap, resource };
 
     // If a POI object is provided before fetching full data,
     // we can update the map immediately for UX responsiveness
@@ -180,7 +178,10 @@ export default class PoiPanel extends React.Component {
   backToList = () => {
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
-    window.app.navigateTo(`/places/?type=${this.props.sourceCategory}`);
+    const uri = this.props.resource.category
+      ? `/places/?type=${this.props.resource.category}`
+      : `/places/?q=${this.props.resource.query}`;
+    window.app.navigateTo(uri);
   }
 
   backToSmall = () => {
@@ -224,7 +225,7 @@ export default class PoiPanel extends React.Component {
 
 
   renderFull = poi => {
-    const { isFromCategory, isFromFavorite } = this.props;
+    const { resource, isFromFavorite } = this.props;
 
     let backAction = null;
     if (isFromFavorite) {
@@ -233,7 +234,7 @@ export default class PoiPanel extends React.Component {
         text: _('Back to favorite'),
         className: 'poi_panel__back_to_list',
       };
-    } else if (isFromCategory) {
+    } else if (resource && (resource.category || resource.query)) {
       backAction = {
         callback: this.backToList,
         text: _('Back to list'),
@@ -264,7 +265,10 @@ export default class PoiPanel extends React.Component {
       title={header}
       close={this.closeAction}
       className={classnames('poi_panel', {
-        'poi_panel--empty-header': !isFromPagesJaunes(poi) && !isFromFavorite && !isFromCategory,
+        'poi_panel--empty-header':
+          !isFromPagesJaunes(poi) &&
+          !isFromFavorite &&
+          (!resource || !resource.category),
       } )}
       initialSize="maximized"
     >

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -180,28 +180,30 @@ export default class PoiPanel extends React.Component {
   }
 
   backToList = () => {
+    const { poiFilters } = this.props;
+
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
 
-    const uri = Object
-      .keys(this.props.poiFilters)
-      .reduce((uri, filterName) => {
-        if (!this.props.poiFilters[filterName]) {
-          return uri;
-        }
+    let uri = '/places/';
 
-        uri += uri[uri.length - 1] === '/' ? '?' : '&';
+    // Reconstruct uri
+    for (const filterName of Object.keys(poiFilters)) {
+      if (!poiFilters[filterName]) {
+        continue;
+      }
 
-        // TODO use keys as query param
-        if (filterName === 'category') {
-          uri += 'type=';
-        } else if (filterName === 'query') {
-          uri += 'q=';
-        }
+      uri += uri[uri.length - 1] === '/' ? '?' : '&';
 
-        uri += this.props.poiFilters[filterName];
-        return uri;
-      }, '/places/');
+      // TODO use keys as query param ?
+      if (filterName === 'category') {
+        uri += 'type=';
+      } else if (filterName === 'query') {
+        uri += 'q=';
+      }
+
+      uri += poiFilters[filterName];
+    }
 
     window.app.navigateTo(uri);
   }

--- a/tests/units/url_utils.js
+++ b/tests/units/url_utils.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-irregular-whitespace */
+import { buildQueryString } from '../../src/libs/url_utils';
+
+describe('url_utils', () => {
+  describe('buildQueryString', () => {
+    const cases = [
+      {
+        param: {},
+        expected: '',
+      },
+      {
+        param: { q: 'myquery' },
+        expected: '?q=myquery',
+      },
+      {
+        param: { q: 'myquery', type: 'restaurant' },
+        expected: '?q=myquery&type=restaurant',
+      },
+    ];
+
+    cases.map(({ param, expected }) =>
+      test(`build query string as '${expected}'`, () => {
+        expect(buildQueryString(param)).toEqual(expected);
+      })
+    );
+  });
+});


### PR DESCRIPTION
when instancing the app with a query in url, like `q=park`, a list of pois is returned.
If we select one of them, the poi is focused on the map. If we click on "go back to list", the application's panel crashes and there is no way to recover from this state without a page reload.
This is due to the way `backToList` build an url only for a category.

This PR fixes this behavior by encapsulating query/category into a `poiFilters` object. This way we can extends it as we need to add more filters, and we can build any url with appropriate filters.