### PR TITLE
Fix geocoder query: getFocus did not retrieve the map center correctly

### DIFF
--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -6,7 +6,7 @@ import CategoryService from './category_service';
 function getFocus(focusMinZoom) {
   const zoom = window.map && window.map.mb && window.map.mb.getZoom();
   if (zoom >= focusMinZoom) {
-    const { lat, lon } = window.map.mb.getCenter();
+    const { lat, lng: lon } = window.map.mb.getCenter();
     return { lat, lon, zoom };
   }
   return {};

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -66,6 +66,26 @@ test('search has lang in query', async () => {
   expect(autocompleteItems).toHaveLength(SUGGEST_MAX_ITEMS);
 });
 
+test('search with focus on current map position', async () => {
+  const page = await browser.newPage();
+  await page.setDefaultTimeout(2000);
+  const responseHandler = await ResponseHandler.init(page);
+  const autocompleteHelper = new AutocompleteHelper(page);
+
+  const query = 'townhall';
+  responseHandler.addPreparedResponse(
+    mockAutocomplete, /autocomplete\?q=townhall(.*)&lat=45(.*)&lon=5/
+  );
+
+  await page.goto(APP_URL);
+  await page.evaluate(() => {
+    window.map.mb.flyTo({ center: { lat: 45, lng: 5 }, zoom: 15, animate: false });
+  });
+  await autocompleteHelper.typeAndWait(query);
+  const autocompleteItems = await autocompleteHelper.getSuggestList();
+  expect(autocompleteItems).toHaveLength(SUGGEST_MAX_ITEMS);
+});
+
 test('keyboard navigation', async () => {
   const TypedSearch = 'Hello';
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);


### PR DESCRIPTION
## Description
This PR fixes a regression introduced by #582 about the focus position used in the geocoder request.

## Why
The map center was not retrieved correctly, as [`getCenter()`](https://docs.mapbox.com/mapbox-gl-js/api/#map#getcenter) returns an object with {lat, lng} properties, where we expected {lat, lon}.  
As a consequence, the focus position was not used at all.


