### PR TITLE
[Geocoding] Add a config option to enable NLU usage

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -28,6 +28,7 @@ services:
     maxItems: 7
     useFocus: true
     focusPrecision: '0.1' # lat/lon degrees
+    useNlu: false
   idunn:
     url: override_by_environment
 

--- a/src/adapters/poi/bragi_poi.js
+++ b/src/adapters/poi/bragi_poi.js
@@ -120,6 +120,9 @@ export default class BragiPoi extends Poi {
       if (geocoderConfig.useLang) {
         query.lang = window.getLang().code;
       }
+      if (geocoderConfig.useNlu) {
+        query.nlu = 'true';
+      }
       suggestsPromise = ajax.get(geocoderConfig.url, query);
       suggestsPromise.then(suggests => {
         let ranking = 0;


### PR DESCRIPTION
## Description
Simply add a configuration option to pass the `nlu=true` query parameter to geocoding requests, enabling intentions to be detected and returned in the `intentions` property of the response.