### PR TITLE
Add a meta description

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,6 +5,7 @@
     <title><%= _('Qwant Maps') %>
       <% if(config.app.versionFlag) { %> - <%= config.app.versionFlag %><% } %>
     </title>
+    <meta name="description" content="<%= _('The map that respects your privacy') %>">
     <base href="<%= config.system.baseUrl %>" target="_blank">
     <meta name='viewport' content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no'/>
     <link rel="manifest" href="./statics/manifest.json">


### PR DESCRIPTION
## Description
Assign a value to the `description` meta header, which was previously empty :roll_eyes: 
For now, re-uses the string used for the OpenGraph description field.
Can be improved later.

## Why
Let's not sink in search results for something so easy to fix…