### PR TITLE
Fix js error when user changes hash value in URL

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -139,9 +139,9 @@ export default class PanelManager extends React.Component {
     });
 
     // Default matching route
-    router.addRoute('Services', '/?', (_, options = {}) => {
+    router.addRoute('Services', '/?', (_, options) => {
       this.setState({ ActivePanel: ServicePanel, options });
-      if (options.focusSearch) {
+      if (options?.focusSearch) {
         SearchInput.select();
       }
     });


### PR DESCRIPTION
## Why
An event `popstate` is triggered when the user changes the hash value in the current URL.  
This event contains `state: null` which is not currently handled by our custom router.  
As far as I can see, this bug does not have any visible consequence for the user. The map position is correctly updated, thanks to a distinct `onhashchange` handler.


## Note
This change uses the [new optional-chaining operator `?.`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) (part of ES2020), and enabled by default in recent versions of Babel.
