### PR TITLE
Add missing poiFilters to category_markers

### DIFF
--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -9,9 +9,9 @@ export default class SceneCategory {
     this.map = map;
     this.markers = [];
 
-    listen('add_category_markers', (pois, categoryName) => {
+    listen('add_category_markers', (pois, poiFilters) => {
       this.resetMarkers();
-      this.addCategoryMarkers(pois, categoryName);
+      this.addCategoryMarkers(pois, poiFilters);
     });
     listen('remove_category_markers', () => {
       this.removeCategoryMarkers();
@@ -49,7 +49,7 @@ export default class SceneCategory {
     this.highlightPoiMarker(poi, true);
   }
 
-  addCategoryMarkers(pois, categoryName) {
+  addCategoryMarkers(pois, poiFilters) {
     this.setOsmPoisVisibility(false);
     if (pois) {
       pois.forEach(poi => {
@@ -58,9 +58,7 @@ export default class SceneCategory {
         poi.marker_id = `marker_${id}`;
         marker.onclick = function(e) {
           e.stopPropagation();
-          fire('click_category_poi', poi, {
-            category: categoryName,
-          });
+          fire('click_category_poi', poi, poiFilters);
         };
         marker.onmouseover = function(e) {
           fire('open_popup', poi, e);

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -121,7 +121,7 @@ export default class CategoryPanel extends React.Component {
       initialLoading: false,
     });
 
-    fire('add_category_markers', places, this.props.poiFilters.category);
+    fire('add_category_markers', places, this.props.poiFilters);
     fire('save_location');
   };
 


### PR DESCRIPTION
This fixes the `go back to list` button not appearing when clicking on a Poi marker on the map, when results are from a query.