### PR TITLE
Fix map_control_group buttons hover on mobile

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -833,12 +833,6 @@ input:valid:focus ~ .itinerary__field__clear {
     /* Attempt to fix rare layout bug on iOS */
     transform: translate3d(0,0,0);
 
-    &:hover {
-      background: #353c52;
-      color: #fff;
-      background-size: 25px;
-    }
-
     .directions-open & {
       display: none;
     }

--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -117,6 +117,16 @@
     overflow: visible;
 
     button {
+      &:not(:disabled):hover {
+        background: #fff;
+        color: $secondary_text;
+
+        &:active {
+          background: $primary_text;
+          color: white;
+        }
+      }
+
       width: 48px;
       height: 48px;
       border-radius: 50%;


### PR DESCRIPTION
Geoloc, itinerary and rotation buttons were subject to a misbehavior of the `hover` effect on mobile: When long tapping on a button, an `hover` style remained, even after raising the finger from the screen.

This PR fixes this behavior by setting the necessary styles on a `hover + active` state. So the finger needs to press the button for this style to be effective.

We can go further using touch events, because this css only solution will "disable" the button if the finger moves on the buttons by some pixels. What do you think ?

![After](https://user-images.githubusercontent.com/2981774/79350523-dadbfb00-7f37-11ea-8294-014f1bd2eab3.gif)