### PR TITLE
Set poi zoom level to 16.5

### DIFF
--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -57,12 +57,12 @@ export const isFromOSM = poi => poi.meta && poi.meta.source === sources.osm;
 
 // POI map util functions
 
+const DEFAULT_ZOOM = 16.5;
 const ZOOM_BY_POI_TYPES = {
-  street: 17,
-  house: 19,
-  poi: 18,
+  street: DEFAULT_ZOOM,
+  house: DEFAULT_ZOOM,
+  poi: DEFAULT_ZOOM,
 };
-const DEFAULT_ZOOM = 16;
 
 export function getBestZoom(poi) {
   return ZOOM_BY_POI_TYPES[poi.type] || DEFAULT_ZOOM;

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -192,7 +192,7 @@ test('center on select', async () => {
     return { center: window.MAP_MOCK.getCenter(), zoom: window.MAP_MOCK.getZoom() };
   });
   expect(center).toEqual({ lat: 5, lng: 30 });
-  expect(zoom).toEqual(18);
+  expect(zoom).toEqual(16.5);
 
   // @TODO: this is supposed to test that the 'bbox' parameter is used, when present,
   // to fit the map bounds to the best view. But this test is broken because of


### PR DESCRIPTION
Set zoom levels to `16.5` pois of types: `street`, `house` and `poi`.
I let the `DEFAULT_ZOOM` to 16, let me know if we should set it to 16.5 too.