### PR TITLE
[Fix] Make sure category label is always removed from search input

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -66,6 +66,7 @@ export default class CategoryPanel extends React.Component {
   }
 
   componentWillUnmount() {
+    SearchInput.setInputValue('');
     window.unListen(this.mapMoveHandler);
   }
 
@@ -141,7 +142,6 @@ export default class CategoryPanel extends React.Component {
   }
 
   close = () => {
-    SearchInput.setInputValue('');
     window.app.navigateTo('/');
   }
 


### PR DESCRIPTION
## Description
Mini bug fix: ensure we always remove the category label that is displayed in the search input field when we leave the category panel.
It was only removed when the panel was closed with the cross button, but it can be left also by clicking on the map.