### PR TITLE
[Fix] Make sure we close POI popups when the active one changes

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -22,8 +22,14 @@ PoiPopup.prototype.init = function(map) {
     this.createPJPopup(poi, e);
   });
   listen('close_popup', () => this.close());
-  listen('map_mark_poi', poi => { this.activePoiId = poi.id; });
-  listen('clean_marker', () => { this.activePoiId = null; });
+  listen('map_mark_poi', poi => {
+    this.close();
+    this.activePoiId = poi.id;
+  });
+  listen('clean_marker', () => {
+    this.close();
+    this.activePoiId = null;
+  });
 };
 
 PoiPopup.prototype.addListener = function(layer) {


### PR DESCRIPTION
## Description
When listing POIs from a query search (for example `/places/?q=decathlon`) and hovering a marker, the popup stay displayed even after we clicked on the POI (which triggers a zoom and displays the POI info in the panel).
Upon investigation it showed that the mouseout event (which closes the popup) wasn't triggered.
The root cause is that a new marker is actually created to materialize the active state, so the element changes and the mouseout event never occurs.

To avoid this, we make sure in the popup manager that when the active marker change, any active popup is closed.