### PR TITLE
[Fix] The dropdown can't be displayed on IE11

### DIFF
--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -66,7 +66,7 @@ export default class Suggest {
         if (!existingElem) {
           elem = document.createElement('div');
           elem.setAttribute('id', 'react-suggests-' + tagSelector);
-          this.searchInputDomHandler.parentNode.append(elem);
+          this.searchInputDomHandler.parentNode.appendChild(elem);
         }
 
         const reactElem = existingElem || elem;
@@ -98,7 +98,7 @@ export default class Suggest {
       const existingElem = document.getElementById('react-suggests-' + tagSelector);
       if (existingElem) {
         ReactDOM.unmountComponentAtNode(existingElem);
-        existingElem.remove();
+        this.searchInputDomHandler.parentNode.removeChild(existingElem);
       }
     };
 


### PR DESCRIPTION
## Description
Since its partial React refacto, the suggest dropdown creates an unknown method error on IE11, preventing it to displayed.
The cause is the methods `append` and `remove` are relatively new DOM methods and aren't supported by IE11. See MDN compatibility charts:
https://wiki.developer.mozilla.org/en-US/docs/Web/API/ParentNode/append#Browser_compatibility
https://wiki.developer.mozilla.org/en-US/docs/Web/API/ChildNode#Browser_compatibility

This PR uses an older and more widely supported alternative to do the same thing.