### PR TITLE
Fix suggest list reappearing after fast submit

### DIFF
--- a/src/adapters/suggest.js
+++ b/src/adapters/suggest.js
@@ -21,17 +21,12 @@ export default class Suggest {
     this.searchInputDomHandler = document.querySelector(tagSelector);
     this.poi = null;
     this.suggestList = [];
-    this.pending = false;
     this.onSelect = onSelect;
 
     this.autocomplete = new Autocomplete({
       selector: tagSelector,
       minChars: 0,
       delay: 100,
-      updateData: items => {
-        this.suggestList = items;
-        this.pending = false;
-      },
       source: term => suggestResults(term, {
         withCategories,
         useFocus: SUGGEST_USE_FOCUS,
@@ -94,10 +89,6 @@ export default class Suggest {
       if (event.keyCode === 27) { // esc
         unmountReactSuggestDropdown();
       }
-
-      if (event.keyCode !== 13) { /* prevent enter key */
-        this.pending = true;
-      }
     };
   }
 
@@ -116,17 +107,8 @@ export default class Suggest {
   }
 
   async onSubmit() {
-    if (this.pending) {
-      const term = this.searchInputDomHandler.value;
-      this.preselect(term);
-    } else {
-      if (this.suggestList && this.suggestList.length > 0 &&
-          this.searchInputDomHandler.value &&
-          this.searchInputDomHandler.value.length > 0) {
-        this.onSelect(this.suggestList[0]);
-        this.searchInputDomHandler.blur();
-      }
-    }
+    const term = this.searchInputDomHandler.value;
+    this.preselect(term);
   }
 
   destroy() {

--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -30,10 +30,6 @@ export default function autoComplete(options) {
     delay: 150,
     // Takes as arguments: items, search
     renderItems: function() {},
-    // Takes as arguments: e, term, item, items
-    onSelect: function() {},
-    // Takes as arguments: e, term, items
-    onUpdate: function() {},
   };
   for (const k in options) {
     if (options.hasOwnProperty(k)) {

--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -34,8 +34,6 @@ export default function autoComplete(options) {
     onSelect: function() {},
     // Takes as arguments: e, term, items
     onUpdate: function() {},
-    // Takes as argument: items
-    updateData: function() {},
   };
   for (const k in options) {
     if (options.hasOwnProperty(k)) {
@@ -51,11 +49,6 @@ export default function autoComplete(options) {
   for (let i = 0; i < elems.length; i++) {
     that = elems[i];
     that.last_val = '';
-
-    that.sourceDom = function(data, val) {
-      o.updateData(data);
-      o.renderItems(data, val);
-    };
 
     const cancelObsolete = function() {
       clearTimeout(that.timer);

--- a/src/vendors/autocomplete.js
+++ b/src/vendors/autocomplete.js
@@ -84,7 +84,7 @@ export default function autoComplete(options) {
             that.sourcePending = o.source(val);
             that.sourcePending.then(source => {
               that.sourcePending = null;
-              if (source !== null) {
+              if (source !== null && document.activeElement === that) {
                 suggest(source);
               }
             }).catch(e => {

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -250,6 +250,21 @@ test('submit key', async () => {
   expect(center).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
 });
 
+
+test('suggestions should not reappear after fast submit', async () => {
+  responseHandler.addPreparedResponse(
+    mockAutocompleteAllTypes,
+    /autocomplete\?q=paris/,
+    { delay: 300 }
+  );
+  await page.goto(APP_URL);
+  await page.keyboard.type('paris');
+  await page.keyboard.press('Enter');
+  await page.waitFor(600);
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
+});
+
+
 test('check template', async () => {
   expect.assertions(8);
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=type/);


### PR DESCRIPTION
## Description
* Show the suggestions list only if the input field is still focused
* Remove obsolete mechanism related to pending requests in `Suggest`, and other unused options for the `Autocomplete` object

## Why
When the user used the Enter key quickly after typing a query, the suggestions list could re-appear after a result had been selected and the search input had been blurred. 

First I thought this problem was related to a pending request not being correctly aborted on submit. But I realized that some recent refactoring of the Suggest made this mechanism obsolete in such a case: the `pending` flag is never reset to `false`.  