### PR TITLE
QMAPS-1469 don't list category POIs hidden by the Maps UI

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -11,7 +11,7 @@ import SearchInput from 'src/ui_components/search_input';
 import nconf from '@qwant/nconf-getter';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import CategoryService from 'src/adapters/category_service';
-import { getMapPaddings } from 'src/panel/layouts';
+import { getVisibleBbox } from 'src/panel/layouts';
 import { isMobileDevice } from '../../libs/device';
 
 const categoryConfig = nconf.get().category;
@@ -105,22 +105,7 @@ export default class CategoryPanel extends React.Component {
 
   fetchData = async () => {
     const { category, query } = this.props.poiFilters;
-    const bbox = window.map.mb.getBounds();
-
-    // On desktop, fetch PoIs on a bbox that doesn't include the list panel's width and the header's height
-    if (!isMobileDevice()) {
-      let ne = bbox.getNorthEast();
-      let sw = bbox.getSouthWest();
-      const ne_canvas = window.map.mb.project(ne);
-      const sw_canvas = window.map.mb.project(sw);
-      const paddings = getMapPaddings({});
-      sw_canvas.x += paddings.left;
-      ne_canvas.y += paddings.top;
-      ne = window.map.mb.unproject(ne_canvas);
-      sw = window.map.mb.unproject(sw_canvas);
-      bbox.setNorthEast(ne);
-      bbox.setSouthWest(sw);
-    }
+    const bbox = getVisibleBbox();
 
     const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
       .map(cardinal => cardinal.toFixed(7))

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -12,7 +12,6 @@ import nconf from '@qwant/nconf-getter';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import CategoryService from 'src/adapters/category_service';
 import { getVisibleBbox } from 'src/panel/layouts';
-import { isMobileDevice } from '../../libs/device';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -11,6 +11,8 @@ import SearchInput from 'src/ui_components/search_input';
 import nconf from '@qwant/nconf-getter';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import CategoryService from 'src/adapters/category_service';
+import { getMapPaddings } from 'src/panel/layouts';
+import { isMobileDevice } from '../../libs/device';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);
@@ -103,8 +105,23 @@ export default class CategoryPanel extends React.Component {
 
   fetchData = async () => {
     const { category, query } = this.props.poiFilters;
-
     const bbox = window.map.mb.getBounds();
+
+    // On desktop, fetch PoIs on a bbox that doesn't include the list panel's width and the header's height
+    if (!isMobileDevice()) {
+      let ne = bbox.getNorthEast();
+      let sw = bbox.getSouthWest();
+      const ne_canvas = window.map.mb.project(ne);
+      const sw_canvas = window.map.mb.project(sw);
+      const paddings = getMapPaddings({});
+      sw_canvas.x += paddings.left;
+      ne_canvas.y += paddings.top;
+      ne = window.map.mb.unproject(ne_canvas);
+      sw = window.map.mb.unproject(sw_canvas);
+      bbox.setNorthEast(ne);
+      bbox.setSouthWest(sw);
+    }
+
     const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
       .map(cardinal => cardinal.toFixed(7))
       .join(',');

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -104,7 +104,7 @@ export default class CategoryPanel extends React.Component {
 
   fetchData = async () => {
     const { category, query } = this.props.poiFilters;
-    const bbox = getVisibleBbox();
+    const bbox = getVisibleBbox(window.map.mb);
 
     const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
       .map(cardinal => cardinal.toFixed(7))

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -26,25 +26,25 @@ export function getMapPaddings({ isMobile, isDirectionsActive }) {
   return MOBILE_CARD;
 }
 
-export function getVisibleBbox() {
+export function getVisibleBbox(mb) {
 
-  const bbox = window.map.mb.getBounds();
+  const bbox = mb.getBounds();
   let ne = bbox.getNorthEast();
   let sw = bbox.getSouthWest();
-  const ne_canvas = window.map.mb.project(ne);
-  const sw_canvas = window.map.mb.project(sw);
+  const ne_canvas = mb.project(ne);
+  const sw_canvas = mb.project(sw);
 
   if (isMobileDevice()) {
     // On mobile, compute a bbox that excludes the header's height
     ne_canvas.y += 65;
   } else {
     // On desktop, compute a bbox that excludes the left panel's width and the header's height
-    sw_canvas.x += DESKTOP_PANEL_WIDTH;
+    sw_canvas.x += DESKTOP_PANEL_WIDTH + ADDITIONAL_PADDING / 2;
     ne_canvas.y += DESKTOP_TOP_BAR_HEIGHT;
   }
 
-  ne = window.map.mb.unproject(ne_canvas);
-  sw = window.map.mb.unproject(sw_canvas);
+  ne = mb.unproject(ne_canvas);
+  sw = mb.unproject(sw_canvas);
   bbox.setNorthEast(ne);
   bbox.setSouthWest(sw);
   return bbox;

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -35,9 +35,8 @@ export function getVisibleBbox() {
   const sw_canvas = window.map.mb.project(sw);
 
   if (isMobileDevice()) {
-    // On mobile, compute a bbox that excludes the resizable panel height and the header's height
+    // On mobile, compute a bbox that excludes the header's height
     ne_canvas.y += 65;
-    sw_canvas.y -= window.innerHeight / 2;
   } else {
     // On desktop, compute a bbox that excludes the left panel's width and the header's height
     sw_canvas.x += DESKTOP_PANEL_WIDTH;

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -1,3 +1,4 @@
+import { isMobileDevice } from '../libs/device';
 
 const DESKTOP_PANEL_WIDTH = 400;
 const DESKTOP_TOP_BAR_HEIGHT = 100;
@@ -23,6 +24,31 @@ export function getMapPaddings({ isMobile, isDirectionsActive }) {
     return { ...MOBILE_FULL_SCREEN_PANEL, bottom: bottomPadding };
   }
   return MOBILE_CARD;
+}
+
+export function getVisibleBbox() {
+
+  const bbox = window.map.mb.getBounds();
+  let ne = bbox.getNorthEast();
+  let sw = bbox.getSouthWest();
+  const ne_canvas = window.map.mb.project(ne);
+  const sw_canvas = window.map.mb.project(sw);
+
+  if (isMobileDevice()) {
+    // On mobile, compute a bbox that excludes the resizable panel height and the header's height
+    ne_canvas.y += 65;
+    sw_canvas.y -= window.innerHeight / 2;
+  } else {
+    // On desktop, compute a bbox that excludes the left panel's width and the header's height
+    sw_canvas.x += DESKTOP_PANEL_WIDTH;
+    ne_canvas.y += DESKTOP_TOP_BAR_HEIGHT;
+  }
+
+  ne = window.map.mb.unproject(ne_canvas);
+  sw = window.map.mb.unproject(sw_canvas);
+  bbox.setNorthEast(ne);
+  bbox.setSouthWest(sw);
+  return bbox;
 }
 
 export function getMapCenterOffset({ isMobile }) {


### PR DESCRIPTION
## Description
Fetch POIs in a bbox that excludes the left panel and top header on desktop

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/80508299-2b137e00-8978-11ea-85d5-5c248e9eceb4.png)
