### PR TITLE
Remove most all-caps strings

### DIFF
--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -22,8 +22,8 @@ const PoiPopup = ({ poi }) => {
   }
 
   return <div className="poi_popup">
-    <h1 className="poi_popup__title">{poi.name}</h1>
-    <h3 className="poi_popup__category">{poiSubClass(poi.subClassName)}</h3>
+    <h1 className="u-text--smallTitle">{poi.name}</h1>
+    <h3 className="u-firstCap u-text--subtitle">{poiSubClass(poi.subClassName)}</h3>
     <div>{displayedInfo}</div>
   </div>;
 };

--- a/src/panel/category/PoiCategoryItem.jsx
+++ b/src/panel/category/PoiCategoryItem.jsx
@@ -19,7 +19,7 @@ const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
   return <div className="category__panel__item">
     <PoiTitleImage poi={poi} />
 
-    <h3 className="category__panel__name">{poi.getInputValue()}</h3>
+    <h3 className="u-text--smallTitle">{poi.getInputValue()}</h3>
 
     {poi.subClassName && <p className="category__panel__type u-text--subtitle">
       {poiSubClass(poi.subClassName)}

--- a/src/panel/category/PoiItemListPlaceholder.jsx
+++ b/src/panel/category/PoiItemListPlaceholder.jsx
@@ -5,7 +5,7 @@ import PlaceholderText from 'src/components/ui/PlaceholderText';
 const PoiItemPlaceholder = () =>
   <div className="category__panel__item">
     <div className="poiTitleImage u-placeholder" />
-    <PlaceholderText length={25} tagName="h3" className="category__panel__name"/>
+    <PlaceholderText length={25} tagName="h3" className="u-text--smallTitle"/>
     <PlaceholderText length={15} tagName="p" className="category__panel__type u-text--subtitle" />
     <PlaceholderText length={25} tagName="p" className="category__panel__address" />
     <div className="openingHour"><PlaceholderText length={15} /></div>

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -334,7 +334,7 @@ export default class DirectionPanel extends React.Component {
           <div className="direction_panel_mobile">
             <div className="itinerary_close_mobile" onClick={this.onClose}>
               <span className="icon-chevron-left" />
-              {_('return', 'direction')}
+              <span className="u-firstCap">{_('return', 'direction')}</span>
             </div>
             {title}
             {!activePreviewRoute && form}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -301,7 +301,9 @@ export default class DirectionPanel extends React.Component {
       isLoading, isDirty, isInitializing,
       originInputText, destinationInputText,
     } = this.state;
-    const title = <h3 className="itinerary_title">{_('Directions', 'direction')}</h3>;
+    const title = <h3 className="itinerary_title u-text--smallTitle u-center">
+      {_('Directions', 'direction')}
+    </h3>;
     const form = <DirectionForm
       origin={origin}
       destination={destination}

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -62,7 +62,7 @@ export default class FavoritePoi extends React.Component {
             : 'default',
           }}
         />
-        <p className="favorite_panel__item__desc u-text--subtitle">
+        <p className="favorite_panel__item__desc u-text--subtitle u-firstCap">
           {poi.subClassName ? poiSubClass(poi.subClassName) : ''}
         </p>
       </div>

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -72,7 +72,7 @@ export default class FavoritesPanel extends React.Component {
     const header = <React.Fragment>
       {favoritePois.length === 0
         ? _('Favorite places', 'favorite panel')
-        : _('My favorites', 'favorite panel').toUpperCase()}
+        : _('My favorites', 'favorite panel')}
       {isLoggedIn && <div className="icon-masq_dark favorite_panel__masq_icon" />}
     </React.Fragment>;
 

--- a/src/panel/poi/PoiHeader.jsx
+++ b/src/panel/poi/PoiHeader.jsx
@@ -14,7 +14,7 @@ const PoiHeader = ({ poi }) => {
         <div className="poi_panel__pre_title">{ _('Close to', 'poi')}</div>
       }
       <h4 className="poi_panel__title">
-        <span className="poi_panel__title__main">
+        <span className="poi_panel__title__main u-text--smallTitle">
           {address && address.label ? address.label : title}
         </span>
       </h4>
@@ -25,12 +25,12 @@ const PoiHeader = ({ poi }) => {
 
     {subClassName !== 'latlon' && <div>
       <h4 className="poi_panel__title">
-        <span className="poi_panel__title__main">{title}</span>
+        <span className="poi_panel__title__main u-text--smallTitle">{title}</span>
         {name && localName && localName !== name &&
         <p className="poi_panel__title__alternative">{localName}</p>
         }
       </h4>
-      {subClassName && <p className="poi_panel__description u-text--subtitle">
+      {subClassName && <p className="u-firstCap u-text--subtitle">
         {poiSubClass(subClassName)}
       </p>}
       {address && address.label && <p className="poi_panel__address">{address.label}</p>}

--- a/src/panel/poi/PoiHeader.jsx
+++ b/src/panel/poi/PoiHeader.jsx
@@ -30,7 +30,7 @@ const PoiHeader = ({ poi }) => {
         <p className="poi_panel__title__alternative">{localName}</p>
         }
       </h4>
-      {subClassName && <p className="u-firstCap u-text--subtitle">
+      {subClassName && <p className="poi_panel__description u-firstCap u-text--subtitle">
         {poiSubClass(subClassName)}
       </p>}
       {address && address.label && <p className="poi_panel__address">{address.label}</p>}

--- a/src/panel/poi/blocks/TimeTable.jsx
+++ b/src/panel/poi/blocks/TimeTable.jsx
@@ -21,7 +21,7 @@ const Days = ({ days }) => {
         <tr key={i} className={
           classnames({ 'currentDay': (i + 1) % 7 === dayNumber })
         }>
-          <td className="day">{ day.dayName }</td>
+          <td className="day u-firstCap">{ day.dayName }</td>
           <td className="hours">{ showHour(day) }</td>
         </tr>)}
     </tbody>

--- a/src/panel/service/EventTypeList.jsx
+++ b/src/panel/service/EventTypeList.jsx
@@ -5,7 +5,7 @@ import Action from 'src/components/ui/MainActionButton';
 
 const EventTypeList = () =>
   <div className="service_panel__events">
-    <h3>{_('Good plans', 'service panel')}</h3>
+    <h3 className="u-text--smallTitle u-center">{_('Good plans', 'service panel')}</h3>
     {
       CategoryService.getEvents().map(item =>
         <Action

--- a/src/panel/service/ServicePanelDesktop.jsx
+++ b/src/panel/service/ServicePanelDesktop.jsx
@@ -10,7 +10,9 @@ class ServicePanelDesktop extends React.Component {
   render() {
     return <Panel
       className="service_panel"
-      title={_('Qwant Maps services', 'service panel')}
+      title={<div className="u-text--smallTitle u-center">
+        {_('Qwant Maps services', 'service panel')}
+      </div>}
       white
     >
       <CategoryList className="service_panel__categories" />

--- a/src/panel/service/ServicePanelMobile.jsx
+++ b/src/panel/service/ServicePanelMobile.jsx
@@ -18,7 +18,7 @@ class ServicePanelMobile extends React.Component {
     >
       <div className="service_panel__actions">
 
-        <h3>{_('Directions', 'service panel')}</h3>
+        <h3 className="u-text--smallTitle u-center">{_('Directions', 'service panel')}</h3>
 
         {
           nconf.get().direction.enabled &&
@@ -58,7 +58,7 @@ class ServicePanelMobile extends React.Component {
 
       <hr/>
 
-      <h3>{_('Services nearby', 'service panel')}</h3>
+      <h3 className="u-text--smallTitle u-center">{_('Services nearby', 'service panel')}</h3>
 
       <CategoryList className="service_panel__categories" />
 

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -8,7 +8,6 @@
     padding: 0 40px 0 15px;
     min-height: 40px;
     color: #5c6f84;
-    font-size: 13px;
     border-bottom: 1px solid #f4f6fa;
     display: flex;
     align-items: center;

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -102,8 +102,6 @@
 
       .panel-header {
         text-align: center;
-        font-size: 12px;
-        text-transform: uppercase;
       }
     }
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -8,11 +8,6 @@
 }
 
 .itinerary_title {
-  font-size: 14px;
-  font-weight: bold;
-  text-transform: uppercase;
-  color: #495063;
-  border: none;
   text-align: center;
   width: 100%;
 }
@@ -614,6 +609,11 @@ button.direction_shortcut {
     z-index: 3;
     font-size: 12px;
     min-height: 42px;
+
+    .itinerary_title {
+      color: $background;
+      line-height: 36px;
+    }
   }
 
   .itinerary_close_mobile {
@@ -636,11 +636,6 @@ button.direction_shortcut {
       margin: -6px 6px 0 0;
       font-size: 22px;
     }
-  }
-
-  .itinerary_title {
-    color: $background;
-    line-height: 36px;
   }
 
   .itinerary_input {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -607,7 +607,6 @@ button.direction_shortcut {
     background-size: 640px auto;
     position: fixed;
     z-index: 3;
-    font-size: 12px;
     min-height: 42px;
 
     .itinerary_title {
@@ -620,7 +619,6 @@ button.direction_shortcut {
     display: flex;
     align-items: center;
     cursor: pointer;
-    text-transform: uppercase;
     color: $background;
     line-height: 36px;
     position: absolute;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -156,7 +156,7 @@ input:valid:focus ~ .itinerary__field__clear {
     color: white;
     background-color: red;
     border-radius: 20px;
-    padding: 3px 6px;
+    padding: 1px 6px;
     margin-left: 6px;
     text-transform: uppercase;
   }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -156,6 +156,7 @@ input:valid:focus ~ .itinerary__field__clear {
   .testLabel {
     font-family: $font_system;
     font-size: 12px;
+    line-height: 16px;
     font-weight: bold;
     color: white;
     background-color: red;

--- a/src/scss/includes/osm_contribute.scss
+++ b/src/scss/includes/osm_contribute.scss
@@ -41,7 +41,6 @@
   display: inline-block;
   line-height: 22px;
   vertical-align: middle;
-  text-transform: uppercase;
 }
 
 .osm_contribute__about {

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -8,8 +8,6 @@
   &_title {
     font-weight: normal;
     color: #353c52;
-    font-size: 12px;
-    text-transform: uppercase;
     background: url('../images/pagesjaunes.svg') no-repeat left center;
     background-size: 18px;
     padding-left: 24px;

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -52,12 +52,6 @@
   }
 }
 
-.category__panel__name {
-  font-weight: bold;
-  font-size: 16px;
-  color: #353c52;
-}
-
 .category__panel__type {
   text-transform: capitalize;
 }

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -73,9 +73,7 @@
 
 .category__panel__phone {
   color: $secondary_text;
-  font-size: 12px;
   font-weight: bold;
-  text-transform: uppercase;
   margin-top: 5px;
   cursor: pointer;
 

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -12,6 +12,7 @@
     padding: 1px 6px;
     text-transform: uppercase;
     font-size: 12px;
+    line-height: 16px;
     margin-right: 12px;
     align-self: flex-start;
     flex-shrink: 0;
@@ -89,6 +90,7 @@
     display: flex;
     align-items: center;
     font-size: 12px;
+    line-height: 16px;
     background-color: $surface;
     border-radius: 3px;
     padding: 9px 6px;

--- a/src/scss/includes/panels/favorite_panel.scss
+++ b/src/scss/includes/panels/favorite_panel.scss
@@ -60,10 +60,6 @@ $MASQ_BANNER_HEIGHT: 93px;
   font-weight: bold;
 }
 
-.favorite_panel__item__desc:first-letter {
-  text-transform: uppercase;
-}
-
 .favorite_panel__masq_footer {
   height: $MASQ_BANNER_HEIGHT;
   border-radius: 0 0 3px 3px;

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -107,15 +107,14 @@ $HEADER_SIZE: 40px;
   margin: 0;
 }
 
-.poi_panel__info__link, .poi_panel__info__contact {
-  font-size: 13px;
+.poi_panel__info__link,
+.poi_panel__info__contact {
   color: $secondary_text;
-  text-transform: uppercase;
-}
 
-.poi_panel__info__link:HOVER, .poi_panel__info__contact:HOVER {
-  text-decoration: none;
-  color: $primary_text;
+  &:hover {
+    text-decoration: none;
+    color: $primary_text;
+  }
 }
 
 .poi_panel__info__hour__circle {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -42,7 +42,6 @@ $HEADER_SIZE: 40px;
 
 .poi_panel__back_text {
   padding-left: 5px;
-  text-transform: uppercase;
 }
 
 .poi_panel__back.icon-arrow-left {
@@ -390,9 +389,7 @@ $HEADER_SIZE: 40px;
 }
 
 .poi_panel__header {
-  font-size: 12px;
   color: $secondary_text;
-  text-transform: uppercase;
   display: flex;
   margin-left: -6px;
 }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -327,10 +327,9 @@ $HEADER_SIZE: 40px;
 }
 
 .poi_panel__info__wiki__link {
-  font-size: 13px;
+  font-size: 12px;
   color: $secondary_text;
   position: relative;
-  text-transform: uppercase;
 
   .icon-chevrons-right {
     position: absolute;

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -68,12 +68,6 @@ $HEADER_SIZE: 40px;
   color: $secondary_text;
 }
 
-.poi_panel__title {
-  font-weight: bold;
-  color: $primary_text;
-  font-size: 16px;
-}
-
 .poi_panel__title__alternative {
   color: $secondary_text;
   font-weight: lighter;
@@ -93,10 +87,6 @@ $HEADER_SIZE: 40px;
   height: 1px;
   margin-top: 8px;
   background: $separator_color;
-}
-
-.poi_panel__description:first-letter {
-  text-transform: uppercase;
 }
 
 .poi_panel__address {

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -52,27 +52,21 @@
     h3 {
       margin-bottom: 6px;
     }
-
-    .panel-content {
-      height: calc(100% - 40px);
-    }
   }
 
-  .panel.service_panel .panel-resizeHandle {
-    min-height: 40px;
+  .service_panel:not(.minimized) {
+    .panel-resizeHandle {
+      height: 30px;
+      min-height: auto;
+    }
+
+    .panel-content {
+      height: calc(100% - 30px);
+    }
   }
 
   .service_panel .panel-header {
     padding: 10px 16px 5px;
-  }
-
-  .panel.service_panel.minimized {
-    height: 40px;
-  }
-
-  .panel.service_panel.minimized .panel-header {
-    padding-top: 7px;
-    font-weight: normal;
   }
 
   .service_panel__events,

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -11,26 +11,15 @@
   }
 
   h3 {
-    text-align: center;
-    font-size: 12px;
-    font-weight: bold;
-    text-transform: uppercase;
-    line-height: 16px;
-    margin: 0 0 7px;
-    color: #495063;
+    margin-bottom: 18px;
   }
 }
 
 .service_panel .panel-header {
-  padding: 25px 16px 15px;
-  color: #495063;
-  text-align: center;
-  font-size: 12px;
+  padding: 18px 0;
   border: none;
-  text-transform: uppercase;
   display: block;
   min-height: 50px;
-  font-weight: bold;
 }
 
 .service_panel__categories,
@@ -60,6 +49,10 @@
       margin-bottom: 16px;
     }
 
+    h3 {
+      margin-bottom: 6px;
+    }
+
     .panel-content {
       height: calc(100% - 40px);
     }
@@ -71,7 +64,6 @@
 
   .service_panel .panel-header {
     padding: 10px 16px 5px;
-    font-weight: bold;
   }
 
   .panel.service_panel.minimized {

--- a/src/scss/includes/panels/timetable.scss
+++ b/src/scss/includes/panels/timetable.scss
@@ -13,10 +13,6 @@
 
   .day {
     padding: 4px 5px 4px 0;
-  
-    &:first-letter {
-      text-transform: uppercase;
-    }
   }
 
   .hours {

--- a/src/scss/includes/popup.scss
+++ b/src/scss/includes/popup.scss
@@ -18,21 +18,5 @@
   border-radius: 4px;
   background: $background;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  padding: 20px;
+  padding: 16px;
 }
-
-.poi_popup__title {
-  margin-bottom: -4px;
-  font-size: 16px;
-}
-
-.poi_popup__category {
-  font-weight: normal;
-  font-size: 12px;
-  color: $secondary_text;
-}
-
-.poi_popup__category:first-letter {
-  text-transform: uppercase;
-}
-

--- a/src/scss/includes/reset.scss
+++ b/src/scss/includes/reset.scss
@@ -10,7 +10,7 @@
 body {
   font-family: $font_system;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 18px;
   color: $primary_text;
   overflow: hidden;
 }

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -6,6 +6,10 @@
   text-align: center;
 }
 
+.u-firstCap::first-letter {
+  text-transform: uppercase;
+}
+
 @keyframes placeholderPulse {
   from { opacity: 0.6; }
   to { opacity: 1; }
@@ -31,10 +35,19 @@
   font-size: 12px;
   line-height: 16px;
   color: $secondary_text;
+  font-weight: normal;
 }
 
 .u-text--subtitle {
   font-size: 14px;
   line-height: 18px;
   color: $secondary_text;
+  font-weight: normal;
+}
+
+.u-text--smallTitle {
+  font-size: 16px;
+  line-height: 20px;
+  color: $primary_text;
+  font-weight: bold;
 }

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -188,9 +188,9 @@ test('display details about the poi on a poi click', async () => {
   });
   expect(hours.trim()).toMatch('Fermé');
   expect(phone).toMatch('01 40 49 48 14');
-  expect(website).toMatch('WWW.MUSEE-ORSAY.FR');
+  expect(website).toMatch('www.musee-orsay.fr');
   expect(contactUrl).toMatch('mailto:admin@orsay.fr');
-  expect(contact).toMatch('ADMIN@ORSAY.FR');
+  expect(contact).toMatch('admin@orsay.fr');
 
   const wiki_block = await page.waitForSelector('.poi_panel__info__wiki');
   expect(wiki_block).not.toBeFalsy();


### PR DESCRIPTION
## Description
Remove most uppercase styling of strings and labels accross the app, while bringing again more consistency.
The only thing remaining in all-caps are basically the buttons. Which can be adjusted later.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran - 2020-05-05 à 09 34 29](https://user-images.githubusercontent.com/243653/81044811-4d942280-8eb5-11ea-9c18-9af8eb80b76c.png)|![Capture d’écran - 2020-05-05 à 09 34 32](https://user-images.githubusercontent.com/243653/81044825-5258d680-8eb5-11ea-9ab5-e7d292ac4519.png)|
|![Capture d’écran - 2020-05-05 à 09 34 53](https://user-images.githubusercontent.com/243653/81044853-5dac0200-8eb5-11ea-97b6-a1f0ea057501.png)|![Capture d’écran - 2020-05-05 à 09 34 49](https://user-images.githubusercontent.com/243653/81044868-61d81f80-8eb5-11ea-8c84-ebe1a833ce96.png)|
|![Capture d’écran - 2020-05-05 à 09 48 44](https://user-images.githubusercontent.com/243653/81045183-fa6e9f80-8eb5-11ea-934e-b3a4494c051d.png)|![Capture d’écran - 2020-05-05 à 09 35 03](https://user-images.githubusercontent.com/243653/81045189-fe9abd00-8eb5-11ea-8edd-75a7ccfe77df.png)|
|![Capture d’écran - 2020-05-05 à 09 36 08](https://user-images.githubusercontent.com/243653/81045200-04909e00-8eb6-11ea-96f6-d3f86944ba3a.png)|![Capture d’écran - 2020-05-05 à 09 36 10](https://user-images.githubusercontent.com/243653/81045205-08bcbb80-8eb6-11ea-969a-858ca6036cc5.png)|
|![Capture d’écran - 2020-05-05 à 09 52 23](https://user-images.githubusercontent.com/243653/81045348-4cafc080-8eb6-11ea-88cc-840d2bb31abc.png)|![Capture d’écran - 2020-05-05 à 09 53 24](https://user-images.githubusercontent.com/243653/81045359-51747480-8eb6-11ea-8663-49dbde75abf4.png)|