### PR TITLE
QMAPS-1522 display city names with postal code when restoring POI (in itinerary)

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -46,6 +46,14 @@ export default class IdunnPoi extends Poi {
     case 'address':
     case 'street':
       return this.alternativeName;
+    case 'admin':
+      if (this.address && this.address.label) {
+        const split = this.address.label.split(',');
+        if (split[0]) {
+          return split[0];
+        }
+      }
+      return this.name;
     default:
       return this.name;
     }

--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -47,13 +47,7 @@ export default class IdunnPoi extends Poi {
     case 'street':
       return this.alternativeName;
     case 'admin':
-      if (this.address && this.address.label) {
-        const split = this.address.label.split(',');
-        if (split[0]) {
-          return split[0];
-        }
-      }
-      return this.name;
+      return this.address?.label?.split(',')[0] || this.name;
     default:
       return this.name;
     }


### PR DESCRIPTION
## Description
display city names with postal code when restoring POI (in itinerary)

## Why
the postal codes disappear from the url and fields on refresh

## Screenshot
![image](https://user-images.githubusercontent.com/1225909/81189539-f9716700-8fb6-11ea-9fef-dc274cb7046f.png)

