### PR TITLE
[NLU] Add support for full-text intentions 

### DIFF
--- a/src/adapters/intention.js
+++ b/src/adapters/intention.js
@@ -4,11 +4,13 @@ import { buildQueryString } from 'src/libs/url_utils';
 export default class Intention {
   constructor({ filter, description }) {
     this.category = CategoryService.getCategoryByName(filter.category);
+    this.fullTextQuery = filter.q;
     this.bbox = filter.bbox;
     this.place = description.place;
   }
 
   toQueryString = () => buildQueryString({
+    q: this.fullTextQuery,
     type: this.category?.name,
     bbox: this.bbox?.join(','),
   });

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -47,7 +47,7 @@ export function suggestResults(term, {
           if (!intentions) { // no NLU activated
             intentionsOrCategories = CategoryService.getMatchingCategories(term);
           } else {
-            intentionsOrCategories = intentions.filter(intention => intention.category);
+            intentionsOrCategories = intentions;
           }
         }
         const keptFavorites = favorites.slice(0, maxFavorites);

--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -18,14 +18,14 @@ const GeolocationItem = () =>
   </div>;
 
 const IntentionItem = ({ intention }) => {
-  const { category, place } = intention;
+  const { category, place, fullTextQuery } = intention;
   const placeString = place
     ? `${_('Close to')} ${place.properties.geocoding.name}`
     : _('Search around this place');
 
   return <div className="autocomplete_suggestion autocomplete_suggestion--intention">
     <div className="autocomplete-icon" />
-    <ItemLabels firstLabel={category.label} secondLabel={placeString} />
+    <ItemLabels firstLabel={category?.label || fullTextQuery} secondLabel={placeString} />
   </div>;
 };
 


### PR DESCRIPTION
## Description
Allow to display geocoder intentions with "full text" queries as suggestions. Previously only intentions with category detected where possible.

## Screenshots
|Query and suggestion|Results from PJ|
|---|---|
|![Capture d’écran de 2020-05-07 16-28-00](https://user-images.githubusercontent.com/243653/81306562-e7a7c680-907f-11ea-9732-f95f5d82a054.png)|![localhost_3000_(iPhone 6_7_8 Plus)sdfsdf](https://user-images.githubusercontent.com/243653/81306725-1625a180-9080-11ea-96dd-597fb5b7d757.png)|


