### PR TITLE
Fix missing icon for U-turns in itinerary roadmaps

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -533,7 +533,7 @@ input:valid:focus ~ .itinerary__field__clear {
   background-image:url(../images/direction_icons/corner-up-right.svg);
 }
 
-.itinerary_roadmap_icon_u-turn {
+.itinerary_roadmap_icon_uturn {
   background-image:url(../images/direction_icons/u-turn.svg);
 }
 


### PR DESCRIPTION
## Description
Fixes the missing icon for U-turns in itinerary roadmaps. It was just due to mismatch between the name of the maneuver in the payload ('uturn') and the name of the CSS class declaring the icon ('u-turn').

*Note: There are other problems with roadmap icons like alignment and color issues, but this will be fixed separately*

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-05-11 à 14 45 54](https://user-images.githubusercontent.com/243653/81564186-a7a25580-9397-11ea-8e18-85924c2c2b52.png)|![Capture d’écran 2020-05-11 à 14 46 19](https://user-images.githubusercontent.com/243653/81564195-ac670980-9397-11ea-8753-5f87978cc881.png)|