### PR TITLE
QMAPS-1485 itinerary: display the same text as the start input's content in the roadmap's start step

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -303,8 +303,8 @@ export default class DirectionPanel extends React.Component {
       vehicle={vehicle}
       error={error}
       routes={routes}
-      origin={origin && origin.getInputValue()}
-      destination={destination && destination.getInputValue()}
+      origin={originInputText}
+      destination={destinationInputText}
       openMobilePreview={this.openMobilePreview}
     />;
 


### PR DESCRIPTION
## Description
display the same text as the start input's content in the roadmap's start step
this avoids having Start: [GPS coordinates] when the start is a PoI anywhere (the one you have when clicking on the map)

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/81576628-c6f5ae80-93a8-11ea-8baa-f96ae9f65d36.png)
