### PR TITLE
Use a more robust native font stack

### DIFF
--- a/src/scss/includes/font.scss
+++ b/src/scss/includes/font.scss
@@ -1,5 +1,5 @@
 
-$font_system: 'Helvetica', 'Arial', 'Noto Sans', 'Ubuntu', sans-serif;
+$font_system: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
 
 @font-face {
   font-family: 'icomoon';


### PR DESCRIPTION
## Description
Replaces the font stack by a better one, inspired by the [native font stack of Bootstrap 4](https://getbootstrap.com/docs/4.0/content/reboot/#native-font-stack).

*Note: this change has been validated by the designers and the developers currently building the Design System lib.*

## Why
- Fixes the strange Firefox bug with Helvetica on Mac and some flavors of Linux
- Will look more native on more systems, like modern Windows
