### PR TITLE
[Fix] Disappearing pois

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -18,6 +18,7 @@ import { parseMapHash, getMapHash } from 'src/libs/url_utils';
 import { toUrl, getBestZoom } from 'src/libs/pois';
 import Error from 'src/adapters/error';
 import { fire, listen } from 'src/libs/customEvents';
+import { isNullOrEmpty } from 'src/libs/object';
 
 const baseUrl = nconf.get().system.baseUrl;
 
@@ -167,7 +168,9 @@ Scene.prototype.initMapBox = function() {
 
   listen('map_mark_poi', (poi, options) => {
     this.ensureMarkerIsVisible(poi, options);
-    if (!options.poiFilters || !options.poiFilters.category) {
+    // The presence of poiFilters mean we are in the context of a list of POIs
+    // where we don't need to create a new icon as it already exists
+    if (isNullOrEmpty(options.poiFilters)) {
       this.addMarker(poi, options);
     }
   });

--- a/src/libs/object.js
+++ b/src/libs/object.js
@@ -1,0 +1,1 @@
+export const isNullOrEmpty = obj => !obj || Object.keys(obj).length === 0;

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 import { parseQueryString, getCurrentUrl } from 'src/libs/url_utils';
 import { isMobileDevice, mobileDeviceMediaQuery, DeviceContext } from 'src/libs/device';
 import { fire } from 'src/libs/customEvents';
+import { isNullOrEmpty } from 'src/libs/object';
 
 const performanceEnabled = nconf.get().performance.enabled;
 const categoryEnabled = nconf.get().category.enabled;
@@ -51,7 +52,7 @@ export default class PanelManager extends React.Component {
 
     if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
       if (ActivePanel !== CategoryPanel
-        && (ActivePanel !== PoiPanel || !options.poiFilters || !options.poiFilters.category)) {
+        && (ActivePanel !== PoiPanel || isNullOrEmpty(options.poiFilters))) {
         fire('remove_category_markers');
         fire('remove_event_markers');
       }

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -50,7 +50,8 @@ export default class PanelManager extends React.Component {
     const { ActivePanel, options } = this.state;
 
     if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
-      if (ActivePanel !== PoiPanel || !options.poiFilters || !options.poiFilters.category) {
+      if (ActivePanel !== CategoryPanel
+        && (ActivePanel !== PoiPanel || !options.poiFilters || !options.poiFilters.category)) {
         fire('remove_category_markers');
         fire('remove_event_markers');
       }

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -51,8 +51,8 @@ export default class PanelManager extends React.Component {
     const { ActivePanel, options } = this.state;
 
     if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
-      if (ActivePanel !== CategoryPanel
-        && (ActivePanel !== PoiPanel || isNullOrEmpty(options.poiFilters))) {
+      // poiFilters indicate we are in a "list of POI" context, where markers should be persistent
+      if (isNullOrEmpty(options?.poiFilters)) {
         fire('remove_category_markers');
         fire('remove_event_markers');
       }


### PR DESCRIPTION
## Description
Fixes the markers disappearing when the same category or full-text query was requested from the category panel view.
The reason was the event to remove markers was thrown, but as the props of CategoryPanel didn't change, it wasn't re-render and the markers were never re-added. Now we don't remove markers at all if we detect we come from the CategoryPanel to the CategoryPanel. Markers will be refreshed anyway if the query params have changed.

Also fixes another bug, somewhat related. The markers from a full-text query behaved differently from those of a category: they were removed if clicking on a single one. Now they will act the same: the clicked marker will be emphasized, and the other markers will be kept on the map. 