### PR TITLE
Adjust COVID crisis wording

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -93,4 +93,4 @@ events:
 
 covid19:
   enabled: false
-  frInformationUrl: https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-derogatoire-et-justificatif-de-deplacement-professionnel
+  frInformationUrl:  https://www.gouvernement.fr/info-coronavirus

--- a/language/message/br_FR.po
+++ b/language/message/br_FR.po
@@ -993,16 +993,16 @@ msgstr ""
 msgid "Please comply with government travel restrictions."
 msgstr ""
 
-msgid "Open during lockdown"
+msgid "Open during the sanitary crisis"
 msgstr ""
 
-msgid "Potentially open during lockdown"
+msgid "Potentially open during the sanitary crisis"
 msgstr ""
 
-msgid "Closed during lockdown"
+msgid "Closed during the sanitary crisis"
 msgstr ""
 
-msgid "No information on opening during lockdown"
+msgid "No information on opening during the sanitary crisis"
 msgstr ""
 
 msgid "Report a change"

--- a/language/message/ca_ES.po
+++ b/language/message/ca_ES.po
@@ -985,16 +985,16 @@ msgstr ""
 msgid "Please comply with government travel restrictions."
 msgstr ""
 
-msgid "Open during lockdown"
+msgid "Open during the sanitary crisis"
 msgstr ""
 
-msgid "Potentially open during lockdown"
+msgid "Potentially open during the sanitary crisis"
 msgstr ""
 
-msgid "Closed during lockdown"
+msgid "Closed during the sanitary crisis"
 msgstr ""
 
-msgid "No information on opening during lockdown"
+msgid "No information on opening during the sanitary crisis"
 msgstr ""
 
 msgid "Report a change"

--- a/language/message/de_DE.po
+++ b/language/message/de_DE.po
@@ -993,16 +993,16 @@ msgstr ""
 msgid "Please comply with government travel restrictions."
 msgstr ""
 
-msgid "Open during lockdown"
+msgid "Open during the sanitary crisis"
 msgstr ""
 
-msgid "Potentially open during lockdown"
+msgid "Potentially open during the sanitary crisis"
 msgstr ""
 
-msgid "Closed during lockdown"
+msgid "Closed during the sanitary crisis"
 msgstr ""
 
-msgid "No information on opening during lockdown"
+msgid "No information on opening during the sanitary crisis"
 msgstr ""
 
 msgid "Report a change"

--- a/language/message/es_ES.po
+++ b/language/message/es_ES.po
@@ -987,16 +987,16 @@ msgstr ""
 msgid "Please comply with government travel restrictions."
 msgstr ""
 
-msgid "Open during lockdown"
+msgid "Open during the sanitary crisis"
 msgstr ""
 
-msgid "Potentially open during lockdown"
+msgid "Potentially open during the sanitary crisis"
 msgstr ""
 
-msgid "Closed during lockdown"
+msgid "Closed during the sanitary crisis"
 msgstr ""
 
-msgid "No information on opening during lockdown"
+msgid "No information on opening during the sanitary crisis"
 msgstr ""
 
 msgid "Report a change"

--- a/language/message/fr_FR.po
+++ b/language/message/fr_FR.po
@@ -1002,17 +1002,17 @@ msgstr ""
 "Veuillez respecter les restrictions mises en place par les autorités "
 "locales."
 
-msgid "Open during lockdown"
-msgstr "Ouvert durant le confinement"
+msgid "Open during the sanitary crisis"
+msgstr "Ouvert durant la crise sanitaire"
 
-msgid "Potentially open during lockdown"
-msgstr "Potentiellement ouvert durant le confinement"
+msgid "Potentially open during the sanitary crisis"
+msgstr "Potentiellement ouvert durant la crise sanitaire"
 
-msgid "Closed during lockdown"
-msgstr "Fermé durant le confinement"
+msgid "Closed during the sanitary crisis"
+msgstr "Fermé durant la crise sanitaire"
 
-msgid "No information on opening during lockdown"
-msgstr "Pas d'information sur l'ouverture durant le confinement"
+msgid "No information on opening during the sanitary crisis"
+msgstr "Pas d'information sur l'ouverture durant la crise sanitaire"
 
 msgid "Report a change"
 msgstr "Signaler un changement"

--- a/language/message/it_IT.po
+++ b/language/message/it_IT.po
@@ -991,16 +991,16 @@ msgstr ""
 msgid "Please comply with government travel restrictions."
 msgstr ""
 
-msgid "Open during lockdown"
+msgid "Open during the sanitary crisis"
 msgstr ""
 
-msgid "Potentially open during lockdown"
+msgid "Potentially open during the sanitary crisis"
 msgstr ""
 
-msgid "Closed during lockdown"
+msgid "Closed during the sanitary crisis"
 msgstr ""
 
-msgid "No information on opening during lockdown"
+msgid "No information on opening during the sanitary crisis"
 msgstr ""
 
 msgid "Report a change"

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -71,30 +71,17 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
 };
 
 /* eslint-disable */
-const LocalizedWarning = ({ countryCode }) => {
-  const warnings = {
-    'FR': (
-      <div>
-        <p>
-          {_('During the entire period of lockdown, moving to this location is only permitted with a derogatory certificate.', 'covid19')}
-        </p>
-        <p>
-          {_('More information at', 'covid19')}
-          {' '}<a rel="noopener noreferrer" href={covidConf.frInformationUrl}>interieur.gouv.fr</a>
-        </p>
-      </div>
-    ),
-    'default': (
-      <div>
-        <p>
-          {_('Please comply with government travel restrictions.', 'covid19')}
-        </p>
-      </div>
-    )
-  };
-
-  return warnings[countryCode] || warnings['default']
-}
+const LocalizedWarning = ({ countryCode }) => (
+  <div>
+    <p>
+      {_('Please comply with government travel restrictions.', 'covid19')}
+    </p>
+    {countryCode === 'FR' && <p>
+      {_('More information at', 'covid19')}
+      {' '}<a rel="noopener noreferrer" href={covidConf.frInformationUrl}>gouvernement.fr/info-coronavirus</a>
+    </p>}
+  </div>
+)
 
 const LegalWarning = ({ countryCode }) => (
   <div className="covid19-legalWarning">
@@ -105,11 +92,11 @@ const LegalWarning = ({ countryCode }) => (
 
 const Status = ({ status }) => {
   const statusMessages = {
-    open: _('Open during lockdown', 'covid19'),
-    open_as_usual: _('Open during lockdown', 'covid19'),
-    maybe_open: _('Potentially open during lockdown', 'covid19'),
-    closed: _('Closed during lockdown', 'covid19'),
-    unknown: _('No information on opening during lockdown', 'covid19'),
+    open: _('Open during the sanitary crisis', 'covid19'),
+    open_as_usual: _('Open during the sanitary crisis', 'covid19'),
+    maybe_open: _('Potentially open during the sanitary crisis', 'covid19'),
+    closed: _('Closed during the sanitary crisis', 'covid19'),
+    unknown: _('No information on opening during the sanitary crisis', 'covid19'),
   };
 
   return (

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -46,8 +46,7 @@
   }
 
   .icon-icon_clock,
-  .icon-icon_info,
-  .icon-alert-triangle {
+  .icon-icon_info {
     min-width: 24px;
   }
 
@@ -103,7 +102,7 @@
     i {
       color: red;
       font-size: 15px;
-      margin: 0 6px;
+      margin: 0 9px 0 3px;
     }
 
     a {


### PR DESCRIPTION
## Description
Adjust the wording of the COVID-19 POI block to be less specific and better match the current situation.

## Why
Lockdown has ended in many countries, especially France.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-05-15 à 10 55 29](https://user-images.githubusercontent.com/243653/82031825-b1c79b00-969a-11ea-9092-cc9af8503d9c.png)|![Capture d’écran 2020-05-15 à 10 54 30](https://user-images.githubusercontent.com/243653/82031839-b8561280-969a-11ea-8626-e12f60dbafb8.png)|
