### PR TITLE
Recycling POI block

### DIFF
--- a/src/components/ui/Flex.jsx
+++ b/src/components/ui/Flex.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import classnames from 'classnames';
+
+const Flex = ({ children, spaceBetween, className }) =>
+  <div className={classnames('flex', { 'flex--spaceBetween': spaceBetween }, className)}>
+    {children}
+  </div>;
+
+export default Flex;

--- a/src/components/ui/Flex.jsx
+++ b/src/components/ui/Flex.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const Flex = ({ children, spaceBetween, className }) =>
-  <div className={classnames('flex', { 'flex--spaceBetween': spaceBetween }, className)}>
+const Flex = ({ children, inline, spaceBetween, alignCenter, className }) =>
+  <div className={classnames('flex', {
+    'flex--spaceBetween': spaceBetween,
+    'flex--alignCenter': alignCenter,
+    'flex--inline': inline,
+  }, className)}>
     {children}
   </div>;
 

--- a/src/components/ui/Flex.jsx
+++ b/src/components/ui/Flex.jsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
 
-const Flex = ({ children, inline, spaceBetween, alignCenter, className }) =>
-  <div className={classnames('flex', {
-    'flex--spaceBetween': spaceBetween,
-    'flex--alignCenter': alignCenter,
-    'flex--inline': inline,
-  }, className)}>
+const Flex = ({ children, inline, className,
+  justifyContent,
+  alignItems = 'center',
+}) => {
+  const style = { justifyContent, alignItems };
+  return <div
+    style={style}
+    className={classnames('flex', { 'flex--inline': inline }, className)}>
     {children}
   </div>;
+};
+
+Flex.propTypes = {
+  justifyContent: PropTypes.oneOf(['space-between']),
+  alignItems: PropTypes.oneOf(['center']),
+};
 
 export default Flex;

--- a/src/components/ui/Meter.jsx
+++ b/src/components/ui/Meter.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const valueToColor = (colors, value) => {
+  const nextIndex = colors.findIndex(({ min }) => value < min);
+  return colors[(nextIndex === -1 ? colors.length : nextIndex) - 1].color;
+};
+
+const Meter = ({ value, colors, className }) =>
+  <div className={classnames('meter', className)}>
+    <div className="meter-valueBar" style={{
+      width: `${value}%`,
+      backgroundColor: valueToColor(colors, value),
+    }} />
+  </div>;
+
+Meter.propTypes = {
+  value: PropTypes.number.isRequired,
+  colors: PropTypes.arrayOf(PropTypes.shape({
+    min: PropTypes.number.isRequired,
+    color: PropTypes.string.isRequired,
+  })).isRequired,
+  className: PropTypes.string,
+};
+
+export default Meter;

--- a/src/components/ui/Text.jsx
+++ b/src/components/ui/Text.jsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import Flex from './Flex';
 
-const Text = ({ children, level, inline, icon, className }) => {
-  const TagName = inline ? 'span' : 'div';
-  return <TagName className={classnames({ [`u-text--${level}`]: level }, className)}>
+const Text = ({ children, level, inline, icon, className, ...rest }) => {
+  let TagName;
+  const props = { ...rest };
+  if (icon) {
+    TagName = Flex;
+    props.inline = inline;
+    props.alignCenter = true;
+  } else {
+    TagName = inline ? 'span' : 'div';
+  }
+  return <TagName
+    className={classnames({ [`u-text--${level}`]: level }, className)}
+    {...props}
+  >
     {icon && <i className={`u-mr-4 icon-${icon}`} />}
     {children}
   </TagName>;

--- a/src/components/ui/Text.jsx
+++ b/src/components/ui/Text.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+const Text = ({ children, level, inline, icon, className }) => {
+  const TagName = inline ? 'span' : 'div';
+  return <TagName className={classnames({ [`u-text--${level}`]: level }, className)}>
+    {icon && <i className={`u-mr-4 icon-${icon}`} />}
+    {children}
+  </TagName>;
+};
+
+Text.propTypes = {
+  level: PropTypes.oneOf(['caption', 'smallTitle', 'subtitle']),
+  icon: PropTypes.string,
+  children: PropTypes.node,
+  inline: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default Text;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -1,0 +1,26 @@
+import Button from './Button';
+import ContextMenu from './ContextMenu';
+import Flex from './Flex';
+import { ItemList, Item } from './ItemList';
+import MainActionButton from './MainActionButton';
+import Meter from './Meter';
+import Modal from './Modal';
+import Panel from './Panel';
+import PlaceholderText from './PlaceholderText';
+import Suggest from './Suggest';
+import Text from './Text';
+
+export {
+  Button,
+  ContextMenu,
+  Flex,
+  ItemList,
+  Item,
+  MainActionButton,
+  Meter,
+  Modal,
+  Panel,
+  PlaceholderText,
+  Suggest,
+  Text,
+};

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -7,6 +7,7 @@ import WebsiteBlock from './blocks/Website';
 import InformationBlock from './blocks/Information';
 import CovidBlock from './blocks/Covid19';
 import PhoneBlock from './blocks/Phone';
+import RecyclingBlock from './blocks/Recycling';
 
 export default class PoiBlockContainer extends React.Component {
   static propTypes = {
@@ -25,6 +26,7 @@ export default class PoiBlockContainer extends React.Component {
     const websiteBlock = blocks.find(b => b.type === 'website');
     const contactBlock = blocks.find(b => b.type === 'contact');
     const imagesBlock = blocks.find(b => b.type === 'images');
+    const recyclingBlock = blocks.find(b => b.type === 'recycling');
     const covidBlock = blocks.find(b => b.type === 'covid19');
     const displayCovidInfo = this.props.covid19Enabled && blocks.find(b => b.type === 'covid19');
 
@@ -35,6 +37,7 @@ export default class PoiBlockContainer extends React.Component {
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {phoneBlock && <PhoneBlock block={phoneBlock} />}
+      {recyclingBlock && <RecyclingBlock block={recyclingBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {contactBlock && <ContactBlock block={contactBlock} />}
       {imagesBlock && <ImagesBlock block={imagesBlock} poi={this.props.poi} />}

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -10,7 +10,7 @@ const RED = '#ff3b4a';
 const containerTypes = type => {
   return {
     glass: _('Glass'),
-    paper: _('Paper, carton'),
+    recyclable: _('Recyclable'),
   }[type] || _('Unknown');
 };
 

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -20,10 +20,9 @@ const Container = ({ type, filling_level, updated_at }) =>
       {_(
         'Updated {datetime}',
         'recycling', {
-          datetime: Intl.DateTimeFormat(window.getLang(), {
+          datetime: Intl.DateTimeFormat(window.getLang().locale.replace('_', '-'), {
             year: 'numeric', month: 'numeric', day: 'numeric',
-            hour: 'numeric', minute: 'numeric', second: 'numeric',
-            hour12: false,
+            hour: 'numeric', minute: 'numeric',
           }).format(new Date(updated_at)),
         }
       )}

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -9,9 +9,9 @@ const RED = '#ff3b4a';
 
 const containerTypes = type => {
   return {
-    glass: _('Glass'),
-    recyclable: _('Recyclable'),
-  }[type] || _('Unknown');
+    glass: _('Glass', 'recycling'),
+    recyclable: _('Recyclable', 'recycling'),
+  }[type] || _('Unknown', 'recycling');
 };
 
 const Container = ({ type, filling_level, updated_at }) =>

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -1,0 +1,57 @@
+/* globals _ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Flex, Text, Meter } from 'src/components/ui';
+
+const GREEN = '#87c966';
+const YELLOW = '#ffda12';
+const RED = '#ff3b4a';
+
+const containerTypes = type => {
+  return {
+    glass: _('Glass'),
+    paper: _('Paper, carton'),
+  }[type] || _('Unknown');
+};
+
+const Container = ({ type, filling_level, updated_at }) =>
+  <div className="recycling-container">
+    <Text level="caption" icon="icon_clock" className="u-mb-8">
+      {_(
+        'Updated {datetime}',
+        'recycling', {
+          datetime: Intl.DateTimeFormat(window.getLang(), {
+            year: 'numeric', month: 'numeric', day: 'numeric',
+            hour: 'numeric', minute: 'numeric', second: 'numeric',
+            hour12: false,
+          }).format(new Date(updated_at)),
+        }
+      )}
+    </Text>
+    <Flex spaceBetween>
+      <Text level="smallTitle">{containerTypes(type)}</Text>
+      <Text>{filling_level} %</Text>
+    </Flex>
+    <Meter value={filling_level} colors={[
+      { min: 0, color: GREEN },
+      { min: 50, color: YELLOW },
+      { min: 75, color: RED },
+    ]} />
+  </div>;
+
+const RecyclingBlock = ({ block }) => {
+  const containers = block?.containers;
+  if (containers.length === 0) {
+    return null;
+  }
+
+  return <div className="poi_panel__info__section recycling">
+    {containers.map((container, index) => <Container key={index} {...container} />)}
+  </div>;
+};
+
+RecyclingBlock.propTypes = {
+  block: PropTypes.object.isRequired,
+};
+
+export default RecyclingBlock;

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -27,7 +27,7 @@ const Container = ({ type, filling_level, updated_at }) =>
         }
       )}
     </Text>
-    <Flex spaceBetween>
+    <Flex justifyContent="space-between">
       <Text level="smallTitle">{containerTypes(type)}</Text>
       <Text>{filling_level} %</Text>
     </Flex>

--- a/src/scss/includes/components/flex.scss
+++ b/src/scss/includes/components/flex.scss
@@ -3,5 +3,13 @@
 
   &--spaceBetween {
     justify-content: space-between;
-  } 
+  }
+
+  &--alignCenter {
+    align-items: center;
+  }
+
+  &--inline {
+    display: inline-flex;
+  }
 }

--- a/src/scss/includes/components/flex.scss
+++ b/src/scss/includes/components/flex.scss
@@ -1,0 +1,7 @@
+.flex {
+  display: flex;
+
+  &--spaceBetween {
+    justify-content: space-between;
+  } 
+}

--- a/src/scss/includes/components/flex.scss
+++ b/src/scss/includes/components/flex.scss
@@ -1,14 +1,6 @@
 .flex {
   display: flex;
 
-  &--spaceBetween {
-    justify-content: space-between;
-  }
-
-  &--alignCenter {
-    align-items: center;
-  }
-
   &--inline {
     display: inline-flex;
   }

--- a/src/scss/includes/components/meter.scss
+++ b/src/scss/includes/components/meter.scss
@@ -1,0 +1,16 @@
+.meter {
+  width: 100%;
+  height: 4px;
+  margin: 7px 0;
+  background-color: $surface;
+  border-radius: 2px;
+  overflow: hidden;
+  position: relative;
+
+  .meter-valueBar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+  }
+}

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -508,3 +508,4 @@ $HEADER_SIZE: 40px;
 
 @import "./covid";
 @import "./timetable";
+@import "./recycling";

--- a/src/scss/includes/panels/recycling.scss
+++ b/src/scss/includes/panels/recycling.scss
@@ -1,0 +1,9 @@
+.recycling {
+  &-container {
+    padding: 1em 0;
+
+    & + & {
+      border-top: 1px solid $separator_color;
+    }
+  }
+}

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -4,3 +4,4 @@
 @import "./components/button";
 @import "./components/mainActionButton";
 @import "./components/meter";
+@import "./components/flex";

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -3,3 +3,4 @@
 @import "./components/contextMenu";
 @import "./components/button";
 @import "./components/mainActionButton";
+@import "./components/meter";

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -51,3 +51,7 @@
   color: $primary_text;
   font-weight: bold;
 }
+
+.u-mr-4 {
+  margin-right: 4px;
+}

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -55,3 +55,7 @@
 .u-mr-4 {
   margin-right: 4px;
 }
+
+.u-mb-8 {
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Description
Implement a "Recycling" POI block, to display details about recycling containers.

**Note**
This PR is quite big for such content as I used it as an excuse to introduce things that I think were currently missing and can ease development for all parts of the app in the future:
 - I introduced a generic `<Flex>` component. It's very basic for now, to be completed when needed and/or replaced by a similar component from the Qwant Design System if we find a way to use it one day… The goal is to promote the use of the `flex` layout in a standard way, instead of floats or absolute positionings that are still used in many parts of the app with a lot of unnecessary CSS and many inconsistencies. 
 - I introduced a generic `<Text>` component, to standardize the typographic classes beyond just CSS and do common patterns in a consistent way (like displaying an icon before the text). As for `<Flex>`, it's meant to be re-used anywhere possible, adapted to our needs and replaced by a Design System component when the time is right.
 - I developed the `<Meter>` component as a shared one, so it can be re-used easily in other parts if needed. BTW, it's a choice not to use the native `meter` HTML element, as it's a real hell to style properly and would introduce broken designs on older browsers.
 - I introduced a way to export individual generic components from a centralized file, so they can be imported more easily. Once again, the idea is to encourage their use. So, instead of:
```js
import Flex from 'src/components/ui/Flex';
import Text from 'src/components/ui/Text';
import Meter from 'src/components/ui/Meter';
```
It's now possible to do:
```js
import { Flex, Text, Meter } from 'src/components/ui';
```
  
## Screenshots
![localhost_3000_place_osm_node_721429822@](https://user-images.githubusercontent.com/243653/82305272-b901e800-99bd-11ea-9ab7-9c8f0abc9753.png)
