### PR TITLE
Update PoiPanel actions design

### DIFF
--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -7,7 +7,6 @@ import Button from 'src/components/ui/Button';
 export default class ActionButtons extends React.Component {
   static propTypes = {
     poi: PropTypes.object.isRequired,
-    isMobile: PropTypes.bool.isRequired,
     isDirectionActive: PropTypes.bool,
     openDirection: PropTypes.func,
     openShare: PropTypes.func,
@@ -17,16 +16,14 @@ export default class ActionButtons extends React.Component {
   }
 
   renderPhone() {
-    const { onClickPhoneNumber, poi, isMobile } = this.props;
+    const { onClickPhoneNumber, poi } = this.props;
     return <Button
       className="poi_panel__action__button poi_panel__action__phone"
       onClick={onClickPhoneNumber}
       icon="icon_phone"
       href={poi.blocksByType.phone.url}
       rel="noopener noreferrer external"
-    >
-      {!isMobile && poi.blocksByType.phone.local_format}
-    </Button>;
+    />;
   }
 
   render() {

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -1,7 +1,8 @@
 /* globals _ */
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+
+import Button from 'src/components/ui/Button';
 
 export default class ActionButtons extends React.Component {
   static propTypes = {
@@ -16,47 +17,45 @@ export default class ActionButtons extends React.Component {
   }
 
   renderPhone() {
-    if (!this.props.isPhoneNumberVisible) {
-      return <button className="poi_panel__action icon-icon_phone poi_phone_container_hidden"
-        onClick={this.props.showPhoneNumber}
-      >
-        <div>{_('Show number', 'poi')}</div>
-      </button>;
-    }
-    return <a className="poi_panel__action icon-icon_phone poi_phone_container_revealed"
+    const { isPhoneNumberVisible, showPhoneNumber, poi } = this.props;
+    return <Button
+      className="poi_panel__action__button poi_panel__action__phone"
+      onClick={showPhoneNumber}
+      icon="icon_phone"
+      href={isPhoneNumberVisible ? poi.blocksByType.phone.url : null}
       rel="noopener noreferrer external"
-      href={this.props.poi.blocksByType.phone.url}
     >
-      <div>{this.props.poi.blocksByType.phone.local_format}</div>
-    </a>;
+      {isPhoneNumberVisible && poi.blocksByType.phone.local_format}
+    </Button>;
   }
 
   render() {
     const shouldRenderPhone = this.props.poi.blocksByType && this.props.poi.blocksByType.phone;
 
     return <div className="poi_panel__actions">
-      <button className={classnames(
-        'poi_panel__action',
-        'poi_panel__actions__icon__store',
-        {
-          'icon-icon_star-filled': this.props.isPoiInFavorite,
-          'icon-icon_star': !this.props.isPoiInFavorite,
-        })
-      }
-      onClick={this.props.toggleStorePoi}
-      >
-        <div>{this.props.isPoiInFavorite ? _('Saved', 'poi') : _('Favorites', 'poi')}</div>
-      </button>
-      <button className="poi_panel__action icon-share-2" onClick={this.props.openShare}>
-        <div>{_('Share', 'poi')}</div>
-      </button>
       {this.props.isDirectionActive &&
-        <button className="poi_panel__action icon-corner-up-right"
-          onClick={this.props.openDirection}>
-          <div>{_('Directions', 'poi')}</div>
-        </button>
+        <Button
+          className="button--noBorder poi_panel__action__direction"
+          variant="invert"
+          onClick={this.props.openDirection}
+        >
+          { _('Directions', 'poi panel') }
+        </Button>
       }
+
       {shouldRenderPhone && this.renderPhone()}
+
+      <Button
+        className="poi_panel__action__button poi_panel__action__favorite"
+        onClick={this.props.toggleStorePoi}
+        icon={this.props.isPoiInFavorite ? 'icon_star-filled' : 'star'}
+      />
+
+      <Button
+        className="poi_panel__action__button poi_panel__action__share"
+        onClick={this.props.openShare}
+        icon="share-2"
+      />
     </div>;
   }
 }

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -7,25 +7,25 @@ import Button from 'src/components/ui/Button';
 export default class ActionButtons extends React.Component {
   static propTypes = {
     poi: PropTypes.object.isRequired,
+    isMobile: PropTypes.bool.isRequired,
     isDirectionActive: PropTypes.bool,
     openDirection: PropTypes.func,
     openShare: PropTypes.func,
-    isPhoneNumberVisible: PropTypes.bool,
-    showPhoneNumber: PropTypes.func,
+    onClickPhoneNumber: PropTypes.func,
     isPoiInFavorite: PropTypes.bool,
     toggleStorePoi: PropTypes.func.isRequired,
   }
 
   renderPhone() {
-    const { isPhoneNumberVisible, showPhoneNumber, poi } = this.props;
+    const { onClickPhoneNumber, poi, isMobile } = this.props;
     return <Button
       className="poi_panel__action__button poi_panel__action__phone"
-      onClick={showPhoneNumber}
+      onClick={onClickPhoneNumber}
       icon="icon_phone"
-      href={isPhoneNumberVisible ? poi.blocksByType.phone.url : null}
+      href={poi.blocksByType.phone.url}
       rel="noopener noreferrer external"
     >
-      {isPhoneNumberVisible && poi.blocksByType.phone.local_format}
+      {!isMobile && poi.blocksByType.phone.local_format}
     </Button>;
   }
 

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -6,6 +6,7 @@ import ImagesBlock from './blocks/Images';
 import WebsiteBlock from './blocks/Website';
 import InformationBlock from './blocks/Information';
 import CovidBlock from './blocks/Covid19';
+import PhoneBlock from './blocks/Phone';
 
 export default class PoiBlockContainer extends React.Component {
   static propTypes = {
@@ -21,6 +22,7 @@ export default class PoiBlockContainer extends React.Component {
     const hourBlock = blocks.find(b => b.type === 'opening_hours');
     const informationBlock = blocks.find(b => b.type === 'information');
     const websiteBlock = blocks.find(b => b.type === 'website');
+    const phoneBlock = blocks.find(b => b.type === 'phone');
     const contactBlock = blocks.find(b => b.type === 'contact');
     const imagesBlock = blocks.find(b => b.type === 'images');
     const covidBlock = blocks.find(b => b.type === 'covid19');
@@ -33,6 +35,7 @@ export default class PoiBlockContainer extends React.Component {
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
+      {phoneBlock && <PhoneBlock block={phoneBlock} />}
       {contactBlock && <ContactBlock block={contactBlock} />}
       {imagesBlock && <ImagesBlock block={imagesBlock} poi={this.props.poi} />}
     </div>;

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -21,8 +21,8 @@ export default class PoiBlockContainer extends React.Component {
     const blocks = this.props.poi.blocks;
     const hourBlock = blocks.find(b => b.type === 'opening_hours');
     const informationBlock = blocks.find(b => b.type === 'information');
-    const websiteBlock = blocks.find(b => b.type === 'website');
     const phoneBlock = blocks.find(b => b.type === 'phone');
+    const websiteBlock = blocks.find(b => b.type === 'website');
     const contactBlock = blocks.find(b => b.type === 'contact');
     const imagesBlock = blocks.find(b => b.type === 'images');
     const covidBlock = blocks.find(b => b.type === 'covid19');
@@ -34,8 +34,8 @@ export default class PoiBlockContainer extends React.Component {
       }
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
-      {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {phoneBlock && <PhoneBlock block={phoneBlock} />}
+      {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {contactBlock && <ContactBlock block={contactBlock} />}
       {imagesBlock && <ImagesBlock block={imagesBlock} poi={this.props.poi} />}
     </div>;

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -44,17 +44,16 @@ class PoiCard extends React.Component {
         </div>
         { !!openDirection &&
           <Button
-            className="poi_card__action__direction"
+            className="button--noBorder poi_card__action__direction"
             variant="invert"
             onClick={openDirection}
-            icon="corner-up-right"
           >
             { _('Directions', 'poi panel') }
           </Button>
         }
         <Button
           className="poi_card__action__see-more"
-          onClick={showDetails} icon="chevrons-right"
+          onClick={showDetails}
         >
           { _('See more', 'poi panel') }
         </Button>

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -244,7 +244,7 @@ export default class PoiPanel extends React.Component {
   }
 
 
-  renderFull = (poi, isMobile) => {
+  renderFull = poi => {
     const { poiFilters, isFromFavorite } = this.props;
 
     let backAction = null;
@@ -299,7 +299,6 @@ export default class PoiPanel extends React.Component {
         </div>
         <ActionButtons
           poi={poi}
-          isMobile={isMobile}
           isDirectionActive={this.isDirectionActive}
           openDirection={this.openDirection}
           openShare={this.openShare}
@@ -337,7 +336,7 @@ export default class PoiPanel extends React.Component {
             covid19Enabled={covid19Enabled}
           />;
         }
-        return this.renderFull(poi, isMobile);
+        return this.renderFull(poi);
       }}
     </DeviceContext.Consumer>;
   }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -55,7 +55,6 @@ export default class PoiPanel extends React.Component {
       showDetails: false,
       fullPoi: null,
       isPoiInFavorite: false,
-      isPhoneNumberVisible: false,
     };
     this.isDirectionActive = nconf.get().direction.enabled;
     this.isMasqEnabled = nconf.get().masq.enabled;
@@ -123,7 +122,6 @@ export default class PoiPanel extends React.Component {
     } else {
       this.setState({
         fullPoi: poi,
-        isPhoneNumberVisible: !isFromPagesJaunes(poi),
       });
       isPoiFavorite(poi).then(isPoiInFavorite => {
         this.setState({ isPoiInFavorite });
@@ -211,7 +209,7 @@ export default class PoiPanel extends React.Component {
     this.setState({ showDetails: false });
   }
 
-  showPhoneNumber = () => {
+  onClickPhoneNumber = () => {
     const poi = this.getBestPoi();
     const source = poi.meta && poi.meta.source;
     if (source) {
@@ -225,7 +223,6 @@ export default class PoiPanel extends React.Component {
         })
       );
     }
-    this.setState({ isPhoneNumberVisible: true });
   }
 
   toggleStorePoi = async () => {
@@ -247,7 +244,7 @@ export default class PoiPanel extends React.Component {
   }
 
 
-  renderFull = poi => {
+  renderFull = (poi, isMobile) => {
     const { poiFilters, isFromFavorite } = this.props;
 
     let backAction = null;
@@ -302,11 +299,11 @@ export default class PoiPanel extends React.Component {
         </div>
         <ActionButtons
           poi={poi}
+          isMobile={isMobile}
           isDirectionActive={this.isDirectionActive}
           openDirection={this.openDirection}
           openShare={this.openShare}
-          isPhoneNumberVisible={this.state.isPhoneNumberVisible}
-          showPhoneNumber={this.showPhoneNumber}
+          onClickPhoneNumber={this.onClickPhoneNumber}
           isPoiInFavorite={this.state.isPoiInFavorite}
           toggleStorePoi={this.toggleStorePoi}
         />
@@ -340,7 +337,7 @@ export default class PoiPanel extends React.Component {
             covid19Enabled={covid19Enabled}
           />;
         }
-        return this.renderFull(poi);
+        return this.renderFull(poi, isMobile);
       }}
     </DeviceContext.Consumer>;
   }

--- a/src/panel/poi/blocks/Phone.jsx
+++ b/src/panel/poi/blocks/Phone.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class PhoneBlock extends React.Component {
+  static propTypes = {
+    block: PropTypes.object,
+  }
+
+  render() {
+    const { block } = this.props;
+
+    return <div className="poi_panel__info__section poi_panel__info__section--phone">
+      <div className="poi_panel__info__section__description">
+        <div className="icon-icon_phone poi_panel__block__symbol"></div>
+        <div className="poi_panel__block__content">
+          {block.local_format}
+        </div>
+      </div>
+    </div>;
+  }
+}

--- a/src/panel/poi/blocks/Phone.jsx
+++ b/src/panel/poi/blocks/Phone.jsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default class PhoneBlock extends React.Component {
-  static propTypes = {
-    block: PropTypes.object,
-  }
-
-  render() {
-    const { block } = this.props;
-
-    return <div className="poi_panel__info__section poi_panel__info__section--phone">
-      <div className="poi_panel__info__section__description">
-        <div className="icon-icon_phone poi_panel__block__symbol"></div>
-        <div className="poi_panel__block__content">
-          {block.local_format}
-        </div>
+const PhoneBlock = ({ block }) =>
+  <div className="poi_panel__info__section poi_panel__info__section--phone">
+    <div className="poi_panel__info__section__description">
+      <div className="icon-icon_phone poi_panel__block__symbol"></div>
+      <div className="poi_panel__block__content">
+        {block.local_format}
       </div>
-    </div>;
-  }
-}
+    </div>
+  </div>
+;
+
+PhoneBlock.propTypes = {
+  block: PropTypes.object,
+};
+
+export default PhoneBlock;

--- a/src/panel/poi/blocks/Phone.jsx
+++ b/src/panel/poi/blocks/Phone.jsx
@@ -6,7 +6,7 @@ const PhoneBlock = ({ block }) =>
     <div className="poi_panel__info__section__description">
       <div className="icon-icon_phone poi_panel__block__symbol"></div>
       <div className="poi_panel__block__content">
-        {block.local_format}
+        <a href={block.url}>{block.local_format}</a>
       </div>
     </div>
   </div>

--- a/src/scss/includes/component.scss
+++ b/src/scss/includes/component.scss
@@ -10,6 +10,9 @@ $secondary_text : #5c6f84;
 $secondary_text_clear: #697496;
 $secondary_variant_text : #018475; /* link */
 
+/* actions */
+$action-blue-base: #1a6aff;
+
 /* background */
 $background : #ffffff;
 $background_hover : #F4F6FA;

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -41,6 +41,11 @@
   &-icon + &-content {
     margin-left: 6px;
   }
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
 }
 
 a.button {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -280,6 +280,10 @@ $HEADER_SIZE: 40px;
   margin-top: 18px;
   margin-bottom: 20px;
   padding-left: $BLOCK_PADDING;
+
+  a {
+    color: #5c6f84;
+  }
 }
 
 .poi_panel__service_information__container {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -508,13 +508,16 @@ $HEADER_SIZE: 40px;
     width: 120px;
   }
 
-  &__action__direction {
+  .poi_card__action__direction {
     margin-bottom: 9px;
-    text-transform: uppercase;
+    font-size: 14px;
+    background-color: $action-blue-base;
   }
 
-  &__action__see-more {
-    text-transform: uppercase;
+  .poi_card__action__see-more {
+    font-size: 14px;
+    color: $action-blue-base;
+    border-color: $action-blue-base;
   }
 }
 

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -131,6 +131,21 @@ $HEADER_SIZE: 40px;
 .poi_panel__actions {
   display: flex;
   margin-bottom: 12px;
+
+  :not(:last-child) {
+    margin-right: 8px;
+  }
+
+  .poi_panel__action__direction {
+    font-size: 14px;
+    background-color: $action-blue-base;
+    flex-grow: 1;
+  }
+
+  .poi_panel__action__button {
+    border-color: $action-blue-base;
+    color: $action-blue-base;
+  }
 }
 
 .poi_panel__action {

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -182,7 +182,7 @@ test('display details about the poi on a poi click', async () => {
       contact: document.querySelector('.poi_panel__info__contact').innerText,
       contactUrl: document.querySelector('.poi_panel__info__contact').href,
       hours: document.querySelector('.poi_panel .timetable-status').innerText,
-      phone: document.querySelector('.poi_panel__action__phone').innerText,
+      phone: document.querySelector('.poi_panel__info__section--phone').innerText,
       website: document.querySelector('.poi_panel__info__link').innerText,
     };
   });

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -54,7 +54,7 @@ test('load a poi from url', async () => {
 test('load a poi from url and click on directions', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poi_panel__title');
-  await page.click('.poi_panel__actions button.icon-corner-up-right'); // Click on directions button
+  await page.click('.poi_panel__actions .poi_panel__action__direction'); // Click on directions button
   await page.waitForSelector('#itinerary_input_destination');
   const destinationValue = await page.$eval('#itinerary_input_destination', el => el.value);
   expect(destinationValue).toEqual("Musée d'Orsay");
@@ -182,7 +182,7 @@ test('display details about the poi on a poi click', async () => {
       contact: document.querySelector('.poi_panel__info__contact').innerText,
       contactUrl: document.querySelector('.poi_panel__info__contact').href,
       hours: document.querySelector('.poi_panel .timetable-status').innerText,
-      phone: document.querySelector('.poi_phone_container_revealed').innerText,
+      phone: document.querySelector('.poi_panel__action__phone').innerText,
       website: document.querySelector('.poi_panel__info__link').innerText,
     };
   });
@@ -265,7 +265,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   await clickPoi(page);
   let poiPanel = await page.waitForSelector('.poi_panel__title');
   expect(poiPanel).not.toBeFalsy();
-  await page.click('.poi_panel__actions .poi_panel__actions__icon__store');
+  await page.click('.poi_panel__actions .poi_panel__action__favorite');
   await page.click('.poi_panel .panel-close');
   // we check that the first favorite item is our poi
   await toggleFavoritePanel(page);
@@ -280,7 +280,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   poiPanel = await page.waitForSelector('.poi_panel__title');
   expect(poiPanel).not.toBeFalsy();
 
-  await page.click('.poi_panel__actions .poi_panel__actions__icon__store');
+  await page.click('.poi_panel__actions .poi_panel__action__favorite');
   await page.click('.poi_panel .panel-close');
   // it should disappear from the favorites
   await toggleFavoritePanel(page);


### PR DESCRIPTION
## Description
- Updated design for PoiPanel actions
- Phone button still has an `href` attribute with `tel:` protocol handler
- Phone number visibility is no longer managed by `PoiPanel.jsx`, it's now `ActionsButtons.jsx` responsibility.
- Telemetry `phone` is now sent on a `onClickPhoneNumber` event, meanwhile it was sent only when requesting to show a number before.
- Added a phone block to keep existing behavior (on desktop and mobile, like others blocks for now)

## Screenshots
![mobile](https://user-images.githubusercontent.com/2981774/82437275-65fc6380-9a97-11ea-9c05-b4b1f72b3592.png)
### Without phone number
![no_phone](https://user-images.githubusercontent.com/2981774/82437365-90e6b780-9a97-11ea-9f65-30a3ad5a7160.png)

## Phone block
![phone-block](https://user-images.githubusercontent.com/2981774/82469569-7a0a8a00-9ac4-11ea-9cc8-6abc18cb3dea.png)

## PoiCard
![poi-card](https://user-images.githubusercontent.com/2981774/82687361-7eb37780-9c57-11ea-82de-7eea281fdc6c.png)
