### PR TITLE
Direction: check if origin exists before focus

### DIFF
--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -30,10 +30,12 @@ export default class DirectionForm extends React.Component {
     if (isMobileDevice() || this.props.isInitializing) {
       return;
     }
-    const { origin, destination, originInputText, destinationInputText } = this.props;
-    if (!originInputText && (prevProps.destination !== destination || prevProps.isInitializing)) {
+
+    const { origin, destination } = this.props;
+
+    if (!origin && destination && (prevProps.destination !== destination || prevProps.isInitializing)) {
       this.originRef.current.focus();
-    } else if (!destinationInputText && prevProps.origin !== origin) {
+    } else if (origin && !destination && prevProps.origin !== origin) {
       this.destinationRef.current.focus();
     }
   }

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -35,14 +35,18 @@ export default class DirectionForm extends React.Component {
 
     if (!originInputText && !destinationInputText && prevProps.isInitializing) {
       // If both text fields are empty, focus on origin
-      this.originRef.current.focus();
+      this.focus(this.originRef.current);
     } else if (!origin && destination) {
       // a destination is set, origin is empty, so let's focus on origin
-      this.originRef.current.focus();
+      this.focus(this.originRef.current);
     } else if (origin && !destination) {
       // an origin is set, destination is empty, so let's focus on destination
-      this.destinationRef.current.focus();
+      this.focus(this.destinationRef.current);
     }
+  }
+
+  focus(node) {
+    setTimeout(() => { node.focus(); }, 0);
   }
 
   onChangePoint = (which, value, point) => {

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -33,9 +33,12 @@ export default class DirectionForm extends React.Component {
 
     const { origin, destination } = this.props;
 
-    if (!origin && destination && (prevProps.destination !== destination || prevProps.isInitializing)) {
+    if (!origin && destination &&
+        (prevProps.destination !== destination || prevProps.isInitializing)) {
+      // a destination is set, origin is empty, so let's focus on origin
       this.originRef.current.focus();
     } else if (origin && !destination && prevProps.origin !== origin) {
+      // an origin is set, destination is empty, so let's focus on destination
       this.destinationRef.current.focus();
     }
   }

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -31,13 +31,15 @@ export default class DirectionForm extends React.Component {
       return;
     }
 
-    const { origin, destination } = this.props;
+    const { origin, destination, originInputText, destinationInputText } = this.props;
 
-    if (!origin && destination &&
-        (prevProps.destination !== destination || prevProps.isInitializing)) {
+    if (!originInputText && !destinationInputText && prevProps.isInitializing) {
+      // If both text fields are empty, focus on origin
+      this.originRef.current.focus();
+    } else if (!origin && destination) {
       // a destination is set, origin is empty, so let's focus on origin
       this.originRef.current.focus();
-    } else if (origin && !destination && prevProps.origin !== origin) {
+    } else if (origin && !destination) {
       // an origin is set, destination is empty, so let's focus on destination
       this.destinationRef.current.focus();
     }

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -31,9 +31,9 @@ export default class DirectionForm extends React.Component {
       return;
     }
 
-    const { origin, destination, originInputText, destinationInputText } = this.props;
+    const { origin, destination } = this.props;
 
-    if (!originInputText && !destinationInputText && prevProps.isInitializing) {
+    if (!origin && !destination && prevProps.isInitializing) {
       // If both text fields are empty, focus on origin
       this.focus(this.originRef.current);
     } else if (!origin && destination) {


### PR DESCRIPTION
Fix Focus being stolen when trying to editing the origin while destination was empty.

From now, focus will be given to a field where a POI has not been selected. However, this currently only works when selecting a POI with Enter key.