### PR TITLE
Popup: close on move

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -47,6 +47,10 @@ PoiPopup.prototype.addListener = function(layer) {
     }, WAIT_BEFORE_DISPLAY);
   });
 
+  this.map.on('move', () => {
+    this.close();
+  });
+
   this.map.on('mouseleave', layer, async () => {
     this.close();
     clearTimeout(this.timeOutHandler);

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -51,6 +51,10 @@ PoiPopup.prototype.addListener = function(layer) {
     this.close();
   });
 
+  this.map.on('click', () => {
+    this.close();
+  });
+
   this.map.on('mouseleave', layer, async () => {
     this.close();
     clearTimeout(this.timeOutHandler);
@@ -76,7 +80,6 @@ PoiPopup.prototype.showPopup = function(poi, event) {
   const popupOptions = {
     className: 'poi_popup__container',
     closeButton: false,
-    closeOnClick: true,
     maxWidth: 'none',
     offset: 18, //px,
     anchor: this.getPopupAnchor(event),


### PR DESCRIPTION
## Description
close popup on map `move`. An option named `closeOnMove` can be passed to `Popup()`, but we would miss the chance to clear our `popupHandle` in this case.

## Why
When hovering a poi, a popup appears.
However, if we dezoom the map, the poi will eventually disappear meanwhile the popup will stay.