### PR TITLE
[Fix] Recycling POIs in directions

### DIFF
--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -9,7 +9,7 @@ export function toUrl(poi) {
   if (poi.id === 'geolocalisation' || poi.type === 'latlon') {
     return `latlon:${poi.latLon.lat.toFixed(5)}:${poi.latLon.lng.toFixed(5)}`;
   }
-  return `${poi.id}@${ExtendedString.slug(poi.name)}`;
+  return poi.name ? `${poi.id}@${ExtendedString.slug(poi.name)}` : poi.id;
 }
 
 export function toAbsoluteUrl(poi) {

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -12,6 +12,18 @@ export function toUrl(poi) {
   return poi.name ? `${poi.id}@${ExtendedString.slug(poi.name)}` : poi.id;
 }
 
+export async function getInputValue(poi) {
+  if (poi.type === 'latlon' || !poi.name) {
+    return await reverseGeocode(poi);
+  }
+  return poi.getInputValue();
+}
+
+async function reverseGeocode(poi) {
+  const address = await IdunnPoi.poiApiLoad(poi);
+  return address.alternativeName || address.name;
+}
+
 export function toAbsoluteUrl(poi) {
   const { protocol, host } = window.location;
   const baseUrl = window.baseUrl;

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -14,12 +14,12 @@ export function toUrl(poi) {
 
 export async function getInputValue(poi) {
   if (poi.type === 'latlon' || !poi.name) {
-    return await reverseGeocode(poi);
+    return await fetchAddressLabel(poi);
   }
   return poi.getInputValue();
 }
 
-async function reverseGeocode(poi) {
+async function fetchAddressLabel(poi) {
   const address = await IdunnPoi.poiApiLoad(poi);
   return address.alternativeName || address.name;
 }

--- a/src/panel/category/PoiCategoryItem.jsx
+++ b/src/panel/category/PoiCategoryItem.jsx
@@ -6,6 +6,7 @@ import PhoneNumber from './PhoneNumber';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import nconf from '@qwant/nconf-getter';
+import { getInputValue } from 'src/libs/pois';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -19,7 +20,7 @@ const PoiCategoryItem = ({ poi, onShowPhoneNumber }) => {
   return <div className="category__panel__item">
     <PoiTitleImage poi={poi} />
 
-    <h3 className="u-text--smallTitle">{poi.getInputValue()}</h3>
+    <h3 className="u-text--smallTitle">{getInputValue(poi)}</h3>
 
     {poi.subClassName && <p className="category__panel__type u-text--subtitle">
       {poiSubClass(poi.subClassName)}

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -8,6 +8,7 @@ import Error from 'src/adapters/error';
 import { fire } from 'src/libs/customEvents';
 import { fetchSuggests } from 'src/libs/suggest';
 import { DeviceContext } from 'src/libs/device';
+import { getInputValue } from 'src/libs/pois';
 
 class DirectionInput extends React.Component {
   static propTypes = {
@@ -70,12 +71,12 @@ class DirectionInput extends React.Component {
       }
 
       if (selectedPoi.status === navigatorGeolocationStatus.FOUND) {
-        this.props.onChangePoint(selectedPoi.getInputValue(), selectedPoi);
+        this.props.onChangePoint(getInputValue(selectedPoi), selectedPoi);
       }
 
       this.setState({ readOnly: false });
     } else {
-      this.props.onChangePoint(selectedPoi.getInputValue(), selectedPoi);
+      this.props.onChangePoint(getInputValue(selectedPoi), selectedPoi);
     }
   }
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -6,13 +6,12 @@ import DirectionForm from './DirectionForm';
 import RouteResult from './RouteResult';
 import DirectionApi, { modes } from 'src/adapters/direction_api';
 import Telemetry from 'src/libs/telemetry';
-import { toUrl as poiToUrl, fromUrl as poiFromUrl } from 'src/libs/pois';
+import { toUrl as poiToUrl, fromUrl as poiFromUrl, getInputValue } from 'src/libs/pois';
 import { DeviceContext } from 'src/libs/device';
 import Error from 'src/adapters/error';
 import Poi from 'src/adapters/poi/poi.js';
 import { getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
-import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 
 export default class DirectionPanel extends React.Component {
@@ -78,31 +77,15 @@ export default class DirectionPanel extends React.Component {
     document.body.classList.remove('directions-open');
   }
 
-  setTextInput(which, poi) {
-    if (poi) {
-      if (poi.type === 'latlon') {
-        this.getAddress(which, poi);
-      } else {
-        this.setState({ [which + 'InputText']: poi.getInputValue() || '' });
-      }
-    } else {
-      this.setState({ [which + 'InputText']: '' });
-    }
-  }
-
-  async getAddress(which, poi) {
-    const address = await IdunnPoi.poiApiLoad(poi);
-    this.setState({ [which + 'InputText']: address.alternativeName || address.name });
+  async setTextInput(which, poi) {
+    const inputValue = poi ? await getInputValue(poi) : '';
+    this.setState({ [which + 'InputText']: inputValue });
   }
 
   restorePoints({ origin: originUrlValue, destination: destinationUrlValue }) {
     const poiRestorePromises = [
-      originUrlValue
-        ? poiFromUrl(originUrlValue)
-        : Promise.resolve(this.state.origin),
-      destinationUrlValue
-        ? poiFromUrl(destinationUrlValue)
-        : Promise.resolve(this.state.destination),
+      originUrlValue ? poiFromUrl(originUrlValue) : this.state.origin,
+      destinationUrlValue ? poiFromUrl(destinationUrlValue) : this.state.destination,
     ];
     Promise.all(poiRestorePromises).then(([ origin, destination ]) => {
       // Set markers


### PR DESCRIPTION
## Description
Fixes two bugs related to recycling POIs used as origin or destination in the Direction panel:
 1. when clicking on a recycling POI, then choosing the Direction button, an error occured when generating the URL part describing the POI
  *Fix: don't serialize the `name` part in the URL if non-existent* 
 2. when already in the Direction panel and clicking on a recycling POI to fill one of the direction points, the field renamed empty
  *Fix: display the address/position of the POI (like for `latlon` POI) if name is non-existent*

## Why
The recycling POI are special because for now they are the only kind of interactive POIs which don't have a name. This caused problems for some operations on direction origin/destination points, which assumed the POIs were either raw locations (`latlon`, already managed as a special case) or interactive POIs with a mandatory name.
