### PR TITLE
Improve standard button style and use it for CRO contributing

### DIFF
--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
 
 const Button = ({
-  children, icon, variant, className = '', type = 'button',
-  href, onClick, ...rest
+  children, icon, variant = 'outline', type = 'button',
+  href, onClick, className, ...rest
 }) => {
   const Tag = href ? 'a' : 'button';
 
@@ -17,6 +18,16 @@ const Button = ({
     {icon && <span className={`button-icon icon-${icon}`} />}
     {children && <div className="button-content">{children}</div>}
   </Tag>;
+};
+
+Button.propTypes = {
+  children: PropTypes.node,
+  icon: PropTypes.string,
+  variant: PropTypes.oneOf(['outline', 'primary', 'noBorder']),
+  type: PropTypes.string,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
+  className: PropTypes.string,
 };
 
 export default Button;

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -23,7 +23,7 @@ const Button = ({
 Button.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.string,
-  variant: PropTypes.oneOf(['outline', 'primary', 'noBorder']),
+  variant: PropTypes.oneOf(['outline', 'primary']),
   type: PropTypes.string,
   href: PropTypes.string,
   onClick: PropTypes.func,

--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -39,7 +39,6 @@ const MobileRouteDetails =
       <div className="u-bold">{_('Details', 'direction')}</div>
       {vehicle !== 'publicTransport' && <Button
         onClick={() => { openPreview(id); }}
-        variant="noBorder"
         icon="chevrons-right"
       >
         {_('Preview', 'direction')}

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -33,7 +33,7 @@ export default class ActionButtons extends React.Component {
       {this.props.isDirectionActive &&
         <Button
           className="button--noBorder poi_panel__action__direction"
-          variant="invert"
+          variant="primary"
           onClick={this.props.openDirection}
         >
           { _('Directions', 'poi panel') }

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -32,7 +32,7 @@ export default class ActionButtons extends React.Component {
     return <div className="poi_panel__actions">
       {this.props.isDirectionActive &&
         <Button
-          className="button--noBorder poi_panel__action__direction"
+          className="poi_panel__action__direction"
           variant="primary"
           onClick={this.props.openDirection}
         >

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -44,7 +44,7 @@ class PoiCard extends React.Component {
         </div>
         { !!openDirection &&
           <Button
-            className="button--noBorder poi_card__action__direction"
+            className="poi_card__action__direction"
             variant="primary"
             onClick={openDirection}
           >

--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -45,7 +45,7 @@ class PoiCard extends React.Component {
         { !!openDirection &&
           <Button
             className="button--noBorder poi_card__action__direction"
-            variant="invert"
+            variant="primary"
             onClick={openDirection}
           >
             { _('Directions', 'poi panel') }

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -1,27 +1,22 @@
 .button {
-  background-color: white;
   display: inline-flex;
   align-items: center;
   height: 36px;
   padding: 0 9px;
   border-radius: 18px;
   font-size: 14px;
-  color: $action-blue-base;
   pointer-events: all;
   cursor: pointer;
 
   &--outline {
+    background-color: white;
     border: 1px solid $action-blue-base;
-  }
-
-  &--noBorder {
-    border-color: transparent;
-    padding: 0px;
+    color: $action-blue-base;
   }
 
   &--primary {
-    border: 1px solid $action-blue-base;
     background-color: $action-blue-base;
+    border: 1px solid $action-blue-base;
     color: white;
     font-weight: bold;
   }

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -5,18 +5,22 @@
   height: 36px;
   padding: 0 9px;
   border-radius: 18px;
-  border: 1px solid $action-blue-base;
   font-size: 14px;
   color: $action-blue-base;
   pointer-events: all;
   cursor: pointer;
 
+  &--outline {
+    border: 1px solid $action-blue-base;
+  }
+
   &--noBorder {
     border-color: transparent;
-    padding: 0;
+    padding: 0px;
   }
 
   &--primary {
+    border: 1px solid $action-blue-base;
     background-color: $action-blue-base;
     color: white;
     font-weight: bold;

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -5,27 +5,27 @@
   height: 36px;
   padding: 0 9px;
   border-radius: 18px;
-  border: 1px solid $primary_clear;
-  font-size: 12px;
-  font-weight: bold;
-  color: $primary_text;
+  border: 1px solid $action-blue-base;
+  font-size: 14px;
+  color: $action-blue-base;
   pointer-events: all;
   cursor: pointer;
-
-  &--invert {
-    background-color: $primary_text;
-    border-color: $primary_text;
-    color: white;
-  }
 
   &--noBorder {
     border-color: transparent;
     padding: 0;
   }
 
+  &--primary {
+    background-color: $action-blue-base;
+    color: white;
+    font-weight: bold;
+  }
+
   &-content {
     flex-grow: 1;
     text-align: center;
+    padding: 0 3px;
     /* secure long content */
     white-space: nowrap;
     overflow: hidden;
@@ -33,7 +33,6 @@
   }
 
   &-icon {
-    vertical-align: middle;
     font-size: 16px;
     width: 16px;
   }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -924,8 +924,9 @@ button.direction_shortcut {
       font-size: 14px;
       text-transform: uppercase;
 
-      & .button-content {
-        text-transform: uppercase;
+      & .button {
+        border: none;
+        padding: 0;
       }
     }
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -761,7 +761,6 @@ button.direction_shortcut {
 
     button {
       margin-right: 6px;
-      text-transform: uppercase;
     }
   }
 

--- a/src/scss/includes/panels/covid.scss
+++ b/src/scss/includes/panels/covid.scss
@@ -59,20 +59,13 @@
     color: $secondary_text;
     margin-top: 6px;
 
-    a {
+    a:not(.covid19-contributeLink) {
       color: $secondary_text;
     }
   }
 
   &-contributeLink {
-    text-transform: uppercase;
-    font-weight: normal !important;
-    transition: background-color 0.25s;
     margin-top: 20px;
-
-    &:hover {
-      background-color: $background_hover;
-    }
   }
 
   &-changeWarning {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -137,14 +137,7 @@ $HEADER_SIZE: 40px;
   }
 
   .poi_panel__action__direction {
-    font-size: 14px;
-    background-color: $action-blue-base;
     flex-grow: 1;
-  }
-
-  .poi_panel__action__button {
-    border-color: $action-blue-base;
-    color: $action-blue-base;
   }
 }
 
@@ -510,14 +503,6 @@ $HEADER_SIZE: 40px;
 
   .poi_card__action__direction {
     margin-bottom: 9px;
-    font-size: 14px;
-    background-color: $action-blue-base;
-  }
-
-  .poi_card__action__see-more {
-    font-size: 14px;
-    color: $action-blue-base;
-    border-color: $action-blue-base;
   }
 }
 


### PR DESCRIPTION
## Description
Put the colors and `primary` CTA variant directly in the `<Button>` component style, as well as some tweaks according to the design.
As a result, remove some style over-specifity where `<Button>` was used.
Then change the style of the button to contribute to CaResteOuvert in the POI panel. 

## Why
Consistency \o/

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-05-26 à 14 56 30](https://user-images.githubusercontent.com/243653/82903868-e6243c80-9f61-11ea-96f0-74f962ae38a1.png)|![Capture d’écran 2020-05-26 à 14 56 02](https://user-images.githubusercontent.com/243653/82903974-14a21780-9f62-11ea-9f58-15d5ea5c927a.png)|

