### PR TITLE
Integration tests: provide utils to access forms and map

### DIFF
--- a/tests/integration/helpers/autocomplete.js
+++ b/tests/integration/helpers/autocomplete.js
@@ -1,6 +1,7 @@
 const SUGGEST_SELECTOR = '.autocomplete_suggestions li';
 const CLEAR_BUTTON_SELECTOR = '#clear_button';
 const SEARCH_INPUT_SELECTOR = '#search';
+import { getInputValue } from '../tools';
 
 export default class AutocompleteHelper {
   constructor(page) {
@@ -51,10 +52,6 @@ export default class AutocompleteHelper {
   }
 
   async getSearchInputValue() {
-    return this.page.evaluate(SEARCH_INPUT_SELECTOR => {
-      return document.querySelector(SEARCH_INPUT_SELECTOR).value;
-    }, SEARCH_INPUT_SELECTOR);
+    return getInputValue(this.page, SEARCH_INPUT_SELECTOR);
   }
-
-
 }

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser, getInputValue } from '../tools';
+import { clearStore, initBrowser, getInputValue, getMapView } from '../tools';
 import { storePoi } from '../favorites_tools';
 import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
@@ -167,15 +167,11 @@ test('move to on click', async () => {
   expect.assertions(2);
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
-  const map_position_before = await page.evaluate(() => {
-    return window.MAP_MOCK.center;
-  });
+  const { center: map_position_before } = await getMapView(page);
   await autocompleteHelper.typeAndWait('Hello');
   await page.waitForSelector('.autocomplete_suggestions');
   await page.click('.autocomplete_suggestions li:nth-child(3)');
-  const map_position_after = await page.evaluate(() => {
-    return window.MAP_MOCK.center;
-  });
+  const { center: map_position_after } = await getMapView(page);
   expect(map_position_before).not.toEqual(map_position_after);
   const [expectedLng, expectedLat] = mockAutocomplete.features[2].geometry.coordinates;
   expect(map_position_after).toEqual({ lat: expectedLat, lng: expectedLng });
@@ -188,9 +184,7 @@ test('center on select', async () => {
   await autocompleteHelper.typeAndWait('Hello');
   await page.waitForSelector('.autocomplete_suggestions');
   await page.click('.autocomplete_suggestion:nth-child(1)');
-  const { center, zoom } = await page.evaluate(() => {
-    return { center: window.MAP_MOCK.getCenter(), zoom: window.MAP_MOCK.getZoom() };
-  });
+  const { center, zoom } = await getMapView(page);
   expect(center).toEqual({ lat: 5, lng: 30 });
   expect(zoom).toEqual(16.5);
 
@@ -228,9 +222,7 @@ test('submit key', async () => {
   await page.keyboard.press('Enter');
   await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
 
-  let center = await page.evaluate(() =>
-    window.MAP_MOCK.getCenter()
-  );
+  const { center } = await getMapView(page);
 
   let firstFeatureCenter = mockAutocomplete.features[0].geometry.coordinates;
   expect(center).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
@@ -244,12 +236,9 @@ test('submit key', async () => {
 
   await page.waitFor(300);
 
-  center = await page.evaluate(() =>
-    window.MAP_MOCK.getCenter()
-  );
-
+  const { center: newCenter } = await getMapView(page);
   firstFeatureCenter = mockAutocompleteAllTypes.features[0].geometry.coordinates;
-  expect(center).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
+  expect(newCenter).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
 });
 
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser } from '../tools';
+import { clearStore, initBrowser, getInputValue } from '../tools';
 import { storePoi } from '../favorites_tools';
 import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
@@ -316,9 +316,7 @@ test('Search Query', async () => {
 
   const searchQuery = 'test';
   await page.goto(`${APP_URL}/?q=${searchQuery}`);
-  const searchValue = await page.evaluate(() => {
-    return document.querySelector('#search').value;
-  });
+  const searchValue = await getInputValue(page, '#search');
 
   // search input is filled with query
   expect(searchValue).toEqual(searchQuery);

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { initBrowser, simulateClickOnMap } from '../tools';
+import { initBrowser, simulateClickOnMap, getInputValue } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 const ROUTES_PATH = 'routes';
 const mockAutocomplete = require('../../__data__/autocomplete.json');
@@ -44,16 +44,12 @@ test('Start/end inputs are correctly filled', async () => {
   await page.waitForSelector('.autocomplete_suggestions');
   await page.keyboard.press('Enter');
 
-  const directionStartInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_origin').value
-  );
+  const directionStartInput = await getInputValue(page, '#itinerary_input_origin');
   expect(directionStartInput).toEqual(mockAutocomplete.features[0].properties.geocoding.name);
 
   responseHandler.addPreparedResponse(mockLatlonPoi, new RegExp('latlon:43.70324:7.25997'));
   await simulateClickOnMap(page, { lat: 43.70324, lng: 7.25997 });
-  const directionEndInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_destination').value
-  );
+  const directionEndInput = await getInputValue(page, '#itinerary_input_destination');
   expect(directionEndInput).toEqual(mockLatlonPoi.address.label);
 });
 
@@ -64,10 +60,10 @@ test('switch start end', async () => {
   await page.type('#itinerary_input_origin', 'start');
   await page.type('#itinerary_input_destination', 'end');
   await page.click('.itinerary_invert_origin_destination');
-  const inputValues = await page.evaluate(() => {
-    return { startInput: document.querySelector('#itinerary_input_origin').value, endInput: document.querySelector('#itinerary_input_destination').value };
-  });
-
+  const inputValues = {
+    startInput: await getInputValue(page, '#itinerary_input_origin'),
+    endInput: await getInputValue(page, '#itinerary_input_destination'),
+  };
   expect(inputValues).toEqual({ startInput: 'end', endInput: 'start' });
 });
 
@@ -93,15 +89,12 @@ test('route flag', async () => {
 
   await page.waitForSelector('#itinerary_input_origin');
   const smallToolBar = await page.waitForSelector('.top_bar--small');
-
   expect(smallToolBar).not.toBeNull();
-  const directionStartInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_origin').value
-  );
+
+  const directionStartInput = await getInputValue(page, '#itinerary_input_origin');
   expect(directionStartInput).toEqual('');
-  const directionEndInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_destination').value
-  );
+
+  const directionEndInput = await getInputValue(page, '#itinerary_input_destination');
   expect(directionEndInput).toEqual('');
 });
 
@@ -112,14 +105,10 @@ test('destination', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?destination=${mockPoi1.id}`);
   await page.waitForSelector('#itinerary_input_origin');
 
-  const directionStartInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_origin').value
-  );
+  const directionStartInput = await getInputValue(page, '#itinerary_input_origin');
   expect(directionStartInput).toEqual('');
 
-  const directionEndInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_destination').value
-  );
+  const directionEndInput = await getInputValue(page, '#itinerary_input_destination');
   expect(directionEndInput).toEqual(mockPoi1.name);
 });
 
@@ -131,14 +120,10 @@ test('origin & destination', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=${mockPoi2.id}`);
   await page.waitForSelector('#itinerary_input_origin');
 
-  const directionStartInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_origin').value
-  );
+  const directionStartInput = await getInputValue(page, '#itinerary_input_origin');
   expect(directionStartInput).toEqual(mockPoi1.name);
 
-  const directionEndInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_destination').value
-  );
+  const directionEndInput = await getInputValue(page, '#itinerary_input_destination');
   expect(directionEndInput).toEqual(mockPoi2.name);
 });
 
@@ -150,14 +135,10 @@ test('origin & latlon destination & mode', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=${mockLatlonPoi.id}&mode=walking`);
   await page.waitForSelector('#itinerary_input_origin');
 
-  const directionStartInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_origin').value
-  );
+  const directionStartInput = await getInputValue(page, '#itinerary_input_origin');
   expect(directionStartInput).toEqual(mockPoi1.name);
 
-  const directionEndInput = await page.evaluate(() =>
-    document.getElementById('itinerary_input_destination').value
-  );
+  const directionEndInput = await getInputValue(page, '#itinerary_input_destination');
   expect(directionEndInput).toEqual(mockLatlonPoi.address.label);
 
   const activeLabel = await page.evaluate(() => {

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { initBrowser, simulateClickOnMap, getInputValue } from '../tools';
+import { initBrowser, simulateClickOnMap, getInputValue, getMapView } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 const ROUTES_PATH = 'routes';
 const mockAutocomplete = require('../../__data__/autocomplete.json');
@@ -170,10 +170,7 @@ test('select itinerary step', async () => {
   await page.click('.itinerary_leg_via_details');
   await page.click('.itinerary_roadmap_item:nth-of-type(2)');
 
-  const center = await page.evaluate(() => {
-    return window.MAP_MOCK.getCenter();
-  });
-
+  const { center } = await getMapView(page);
   expect(center).toEqual({ 'lat': 48.823566, 'lng': 2.290454 });
 });
 

--- a/tests/integration/tests/favorite.js
+++ b/tests/integration/tests/favorite.js
@@ -1,4 +1,4 @@
-import { initBrowser, clearStore } from '../tools';
+import { initBrowser, clearStore, getMapView } from '../tools';
 import { toggleFavoritePanel, storePoi } from '../favorites_tools';
 
 let browser;
@@ -71,7 +71,7 @@ test('center map after a favorite poi click', async () => {
   await toggleFavoritePanel(page);
   await page.waitForSelector('.favorite_panel__item__title');
   await page.click('.favorite_panel__item__title');
-  const center = await page.evaluate(() => window.MAP_MOCK.getCenter());
+  const { center } = await getMapView(page);
   expect(center).toEqual(favoritePoiCoordinates);
 });
 

--- a/tests/integration/tests/map.js
+++ b/tests/integration/tests/map.js
@@ -1,4 +1,4 @@
-import { initBrowser, store, clearStore } from '../tools';
+import { initBrowser, store, clearStore, getMapView } from '../tools';
 let browser;
 let page;
 
@@ -17,10 +17,8 @@ test('priority order with url & local-storage', async () => {
   await page.goto(`${APP_URL}/#map=2.00/${center.lat}/${center.lng}`);
   await page.reload(); // force reload
 
-  const pageCenter = await page.evaluate(() => {
-    return window.MAP_MOCK.center;
-  });
-  expect(pageCenter).toEqual(center);
+  const { center: mapCenter } = await getMapView(page);
+  expect(mapCenter).toEqual(center);
 });
 
 test('test local storage map center', async () => {
@@ -32,10 +30,8 @@ test('test local storage map center', async () => {
   await page.goto(APP_URL);
   await page.reload(); // force reload
 
-  const pageCenter = await page.evaluate(() => {
-    return window.MAP_MOCK.center;
-  });
-  expect(pageCenter).toEqual(center);
+  const { center: mapCenter } = await getMapView(page);
+  expect(mapCenter).toEqual(center);
 });
 
 afterEach(async () => {

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -1,7 +1,7 @@
 const poiMock = require('../../__data__/poi.json');
 
 import ResponseHandler from '../helpers/response_handler';
-import { initBrowser, getText, clearStore } from '../tools';
+import { initBrowser, getText, clearStore, getInputValue } from '../tools';
 import { getFavorites, toggleFavoritePanel, storePoi } from '../favorites_tools';
 import { languages } from '../../../config/constants.yml';
 
@@ -56,7 +56,7 @@ test('load a poi from url and click on directions', async () => {
   await page.waitForSelector('.poi_panel__title');
   await page.click('.poi_panel__actions .poi_panel__action__direction'); // Click on directions button
   await page.waitForSelector('#itinerary_input_destination');
-  const destinationValue = await page.$eval('#itinerary_input_destination', el => el.value);
+  const destinationValue = await getInputValue(page, '#itinerary_input_destination');
   expect(destinationValue).toEqual("Musée d'Orsay");
 });
 

--- a/tests/integration/tools.js
+++ b/tests/integration/tools.js
@@ -52,3 +52,7 @@ export async function simulateClickOnMap(page, latLng) {
     return fireEvent('set_direction_point', poi);
   }, new LatLngPoi(latLng));
 }
+
+export async function getInputValue(page, selector) {
+  return await page.evaluate(s => document.querySelector(s)?.value, selector);
+}

--- a/tests/integration/tools.js
+++ b/tests/integration/tools.js
@@ -56,3 +56,10 @@ export async function simulateClickOnMap(page, latLng) {
 export async function getInputValue(page, selector) {
   return await page.evaluate(s => document.querySelector(s)?.value, selector);
 }
+
+export async function getMapView(page) {
+  return await page.evaluate(() => ({
+    center: window.MAP_MOCK.getCenter(),
+    zoom: window.MAP_MOCK.getZoom(),
+  }));
+}


### PR DESCRIPTION
## Description
Add two util functions to our integration test helpers to factorize common actions:
 - `getInputValue`: to access the value of an input given by its selector
 - `getMapView`: to access the current zoom and center of the map

## Why
Small step to simplify our tests