### PR TITLE
Integration tests: simplify assertions

### DIFF
--- a/tests/integration/helpers/autocomplete.js
+++ b/tests/integration/helpers/autocomplete.js
@@ -1,5 +1,4 @@
 const SUGGEST_SELECTOR = '.autocomplete_suggestions li';
-const CLEAR_BUTTON_SELECTOR = '#clear_button';
 const SEARCH_INPUT_SELECTOR = '#search';
 import { getInputValue } from '../tools';
 
@@ -32,14 +31,6 @@ export default class AutocompleteHelper {
         return cssClass.trim() === 'selected';
       });
     });
-  }
-
-  async getClearFieldButton() {
-    await this.page.waitForSelector(CLEAR_BUTTON_SELECTOR);
-  }
-
-  async clearField() {
-    return await this.page.click(CLEAR_BUTTON_SELECTOR);
   }
 
   async getSuggestList() {

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser, getInputValue, getMapView } from '../tools';
+import { clearStore, initBrowser, getInputValue, getMapView, exists } from '../tools';
 import { storePoi } from '../favorites_tools';
 import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
@@ -32,17 +32,15 @@ test('search and clear', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Helloa/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Hello');
-  const cleanHandle = await autocompleteHelper.getClearFieldButton();
-  expect(cleanHandle).not.toBeNull();
+  expect(await exists(page, '#clear_button')).toBeTruthy();
 
   const autocompleteItems = await autocompleteHelper.getSuggestList();
   expect(autocompleteItems.length).toEqual(SUGGEST_MAX_ITEMS);
 
-
   const searchValue = await autocompleteHelper.getSearchInputValue();
   expect(searchValue).toEqual('Hello');
 
-  await autocompleteHelper.clearField();
+  await page.click('#clear_button');
   const searchValueAfterClear = await autocompleteHelper.getSearchInputValue();
   expect(searchValueAfterClear).toEqual('');
 });
@@ -204,8 +202,7 @@ test('favorite search', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await storePoi(page, { title: 'hello' });
   await page.keyboard.type('Hello');
-  const favTitle = await page.waitForSelector('.autocomplete_separator_label');
-  expect(favTitle).not.toBeNull();
+  expect(await exists(page, '.autocomplete_separator_label')).toBeTruthy();
 });
 
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -28,7 +28,6 @@ beforeEach(async () => {
 });
 
 test('search and clear', async () => {
-  expect.assertions(4);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Helloa/);
   await page.goto(APP_URL);
@@ -164,7 +163,6 @@ test('mouse navigation', async () => {
 });
 
 test('move to on click', async () => {
-  expect.assertions(2);
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   const { center: map_position_before } = await getMapView(page);
@@ -178,7 +176,6 @@ test('move to on click', async () => {
 });
 
 test('center on select', async () => {
-  expect.assertions(2);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Hello');
@@ -203,7 +200,6 @@ test('center on select', async () => {
 });
 
 test('favorite search', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await storePoi(page, { title: 'hello' });
@@ -257,7 +253,6 @@ test('suggestions should not reappear after fast submit', async () => {
 
 
 test('check template', async () => {
-  expect.assertions(8);
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=type/);
   await page.goto(APP_URL);
   await page.keyboard.type('type');

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -23,7 +23,6 @@ beforeEach(async () => {
 });
 
 test('check "My position" label', async () => {
-  expect.assertions(1);
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
 
   // wait for autocomplete library starting-up
@@ -35,7 +34,6 @@ test('check "My position" label', async () => {
 });
 
 test('Start/end inputs are correctly filled', async () => {
-  expect.assertions(2);
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
   await page.waitForSelector('#itinerary_input_origin');
 
@@ -54,7 +52,6 @@ test('Start/end inputs are correctly filled', async () => {
 });
 
 test('switch start end', async () => {
-  expect.assertions(1);
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
   await page.waitForSelector('#itinerary_input_origin');
   await page.type('#itinerary_input_origin', 'start');
@@ -68,7 +65,6 @@ test('switch start end', async () => {
 });
 
 test('simple search', async () => {
-  expect.assertions(1);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=direction/);
   responseHandler.addPreparedResponse(mockMapBox, /\/30\.0000000,5\.0000000;30\.0000000,5\.0000000/);
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
@@ -79,12 +75,10 @@ test('simple search', async () => {
   await page.keyboard.press('Enter');
 
   const leg0 = await page.waitForSelector('.itinerary_leg');
-
   expect(leg0).not.toBeNull();
 });
 
 test('route flag', async () => {
-  expect.assertions(3);
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
 
   await page.waitForSelector('#itinerary_input_origin');
@@ -101,7 +95,6 @@ test('route flag', async () => {
 test('destination', async () => {
   responseHandler.addPreparedResponse(mockPoi1, new RegExp(`places/${mockPoi1.id}`));
 
-  expect.assertions(2);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?destination=${mockPoi1.id}`);
   await page.waitForSelector('#itinerary_input_origin');
 
@@ -116,7 +109,6 @@ test('origin & destination', async () => {
   responseHandler.addPreparedResponse(mockPoi1, new RegExp(`places/${mockPoi1.id}`));
   responseHandler.addPreparedResponse(mockPoi2, new RegExp(`places/${mockPoi2.id}`));
 
-  expect.assertions(2);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=${mockPoi2.id}`);
   await page.waitForSelector('#itinerary_input_origin');
 
@@ -131,7 +123,6 @@ test('origin & latlon destination & mode', async () => {
   responseHandler.addPreparedResponse(mockPoi1, new RegExp(`places/${mockPoi1.id}`));
   responseHandler.addPreparedResponse(mockLatlonPoi, new RegExp(`places/${mockLatlonPoi.id}`));
 
-  expect.assertions(3);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=${mockPoi1.id}&destination=${mockLatlonPoi.id}&mode=walking`);
   await page.waitForSelector('#itinerary_input_origin');
 
@@ -150,7 +141,6 @@ test('origin & latlon destination & mode', async () => {
 // There is no current way with the MapBox-GL-mock to test changes of state or style
 // on a feature. Let's disable this test it until we improve our map testing tools.
 // test('select itinerary leg', async () => {
-//   expect.assertions(1);
 //   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.0000000,6\.6000000/);
 //   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.0`);
 //   await page.waitForSelector('#itinerary_leg_0');
@@ -161,7 +151,6 @@ test('origin & latlon destination & mode', async () => {
 // });
 
 test('select itinerary step', async () => {
-  expect.assertions(1);
   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
 
@@ -198,7 +187,6 @@ test('show itinerary roadmap on mobile', async () => {
 });
 
 test('api error handling', async () => {
-  expect.assertions(1);
   /* prepare "error" response */
   responseHandler.addPreparedResponse({}, /\/7\.5000000,47\.4000000;6\.6000000,6\.6000000/, { status: 422 });
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.6`);
@@ -207,7 +195,6 @@ test('api error handling', async () => {
 });
 
 test('api wait effect', async () => {
-  expect.assertions(2);
   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.7000000,6\.6000000/, { delay: 1000 });
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.7`);
   const placeholderHandler = await page.waitForSelector('.itinerary_leg--placeholder');

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { initBrowser, simulateClickOnMap, getInputValue, getMapView } from '../tools';
+import { initBrowser, simulateClickOnMap, getInputValue, getMapView, exists } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 const ROUTES_PATH = 'routes';
 const mockAutocomplete = require('../../__data__/autocomplete.json');
@@ -29,8 +29,7 @@ test('check "My position" label', async () => {
   await page.click('#itinerary_input_origin');
   await page.waitForSelector('.autocomplete_suggestions');
 
-  const yourPositionItem = await page.waitForSelector('.autocomplete_suggestion--geoloc', { visible: true });
-  expect(yourPositionItem).not.toBeNull();
+  expect(await exists(page, '.autocomplete_suggestion--geoloc')).toBeTruthy();
 });
 
 test('Start/end inputs are correctly filled', async () => {
@@ -73,17 +72,14 @@ test('simple search', async () => {
   await page.keyboard.press('Enter');
   await page.type('#itinerary_input_destination', 'direction');
   await page.keyboard.press('Enter');
-
-  const leg0 = await page.waitForSelector('.itinerary_leg');
-  expect(leg0).not.toBeNull();
+  expect(await exists(page, '.itinerary_leg')).toBeTruthy();
 });
 
 test('route flag', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
 
   await page.waitForSelector('#itinerary_input_origin');
-  const smallToolBar = await page.waitForSelector('.top_bar--small');
-  expect(smallToolBar).not.toBeNull();
+  expect(await exists(page, '.top_bar--small')).toBeTruthy();
 
   const directionStartInput = await getInputValue(page, '#itinerary_input_origin');
   expect(directionStartInput).toEqual('');
@@ -190,17 +186,14 @@ test('api error handling', async () => {
   /* prepare "error" response */
   responseHandler.addPreparedResponse({}, /\/7\.5000000,47\.4000000;6\.6000000,6\.6000000/, { status: 422 });
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.6`);
-  const errorMessageHandler = await page.waitForSelector('.itinerary_no-result');
-  expect(errorMessageHandler).not.toBeNull();
+  expect(await exists(page, '.itinerary_no-result')).toBeTruthy();
 });
 
 test('api wait effect', async () => {
   responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.7000000,6\.6000000/, { delay: 1000 });
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.7`);
-  const placeholderHandler = await page.waitForSelector('.itinerary_leg--placeholder');
-  expect(placeholderHandler).not.toBeNull();
-  const firstLeg = await page.waitForSelector('.itinerary_leg:not(.itinerary_leg--placeholder)');
-  expect(firstLeg).not.toBeNull();
+  expect(await exists(page, '.itinerary_leg--placeholder')).toBeTruthy();
+  expect(await exists(page, '.itinerary_leg:not(.itinerary_leg--placeholder)')).toBeTruthy();
 });
 
 afterAll(async () => {

--- a/tests/integration/tests/favorite.js
+++ b/tests/integration/tests/favorite.js
@@ -11,7 +11,6 @@ beforeAll(async () => {
 });
 
 test('toggle favorite panel', async () => {
-  expect.assertions(2);
   await page.goto(APP_URL);
   await page.waitForSelector('.panel_container', { visible: true });
   expect(await page.evaluate(() => {
@@ -23,7 +22,6 @@ test('toggle favorite panel', async () => {
 });
 
 test('favorite added is present in favorite panel', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   await storePoi(page, { title: 'some poi' });
   await toggleFavoritePanel(page);
@@ -32,7 +30,6 @@ test('favorite added is present in favorite panel', async () => {
 });
 
 test('restore favorite from localStorage', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   const testTitle = 'demo_fav';
   await storePoi(page, { title: testTitle });
@@ -45,7 +42,6 @@ test('restore favorite from localStorage', async () => {
 });
 
 test('remove favorite using favorite panel', async () => {
-  expect.assertions(2);
   await page.goto(APP_URL);
   await storePoi(page, { title: 'some poi i will remove' });
   await toggleFavoritePanel(page);

--- a/tests/integration/tests/favorite.js
+++ b/tests/integration/tests/favorite.js
@@ -1,4 +1,4 @@
-import { initBrowser, clearStore, getMapView } from '../tools';
+import { initBrowser, clearStore, getMapView, exists } from '../tools';
 import { toggleFavoritePanel, storePoi } from '../favorites_tools';
 
 let browser;
@@ -25,8 +25,7 @@ test('favorite added is present in favorite panel', async () => {
   await page.goto(APP_URL);
   await storePoi(page, { title: 'some poi' });
   await toggleFavoritePanel(page);
-  const items = await page.waitForSelector('.favorite_panel__items');
-  expect(items).not.toBeNull();
+  expect(await exists(page, '.favorite_panel__items')).toBeTruthy();
 });
 
 test('restore favorite from localStorage', async () => {
@@ -45,16 +44,14 @@ test('remove favorite using favorite panel', async () => {
   await page.goto(APP_URL);
   await storePoi(page, { title: 'some poi i will remove' });
   await toggleFavoritePanel(page);
-  let items = await page.waitForSelector('.favorite_panel__items');
-  expect(items).not.toBeNull();
+  expect(await exists(page, '.favorite_panel__items')).toBeTruthy();
 
   /* remove it */
   await page.waitForSelector('.contextMenu-button');
   await page.click('.contextMenu-button');
   await page.click('.contextMenu-menuItem:nth-child(2)');
 
-  items = await page.waitForSelector('.favorite_panel__container__empty');
-  expect(items).not.toBeNull();
+  expect(await exists(page, '.favorite_panel__container__empty')).toBeTruthy();
 });
 
 test('center map after a favorite poi click', async () => {

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -1,4 +1,4 @@
-import { initBrowser } from '../tools';
+import { initBrowser, exists } from '../tools';
 let browser;
 let page;
 
@@ -10,20 +10,17 @@ beforeAll(async () => {
 
 test('is dom loaded', async () => {
   await page.goto(APP_URL);
-  const sceneContent = await page.waitForSelector('#scene_container');
-  expect(sceneContent).not.toBeFalsy();
+  expect(await exists(page, '#scene_container')).toBeTruthy();
 });
 
 test('is panels loaded', async () => {
   await page.goto(APP_URL);
-  const sceneContent = await page.waitForSelector('.service_panel');
-  expect(sceneContent).not.toBeFalsy();
+  expect(await exists(page, '.service_panel')).toBeTruthy();
 });
 
 test('is map loaded', async () => {
   await page.goto(APP_URL);
-  const sceneContent = await page.waitForSelector('.mapboxgl-canvas');
-  expect(sceneContent).not.toBeFalsy();
+  expect(await exists(page, '.mapboxgl-canvas')).toBeTruthy();
 });
 
 afterAll(async () => {

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -9,21 +9,18 @@ beforeAll(async () => {
 });
 
 test('is dom loaded', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   const sceneContent = await page.waitForSelector('#scene_container');
   expect(sceneContent).not.toBeFalsy();
 });
 
 test('is panels loaded', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   const sceneContent = await page.waitForSelector('.service_panel');
   expect(sceneContent).not.toBeFalsy();
 });
 
 test('is map loaded', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   const sceneContent = await page.waitForSelector('.mapboxgl-canvas');
   expect(sceneContent).not.toBeFalsy();

--- a/tests/integration/tests/map.js
+++ b/tests/integration/tests/map.js
@@ -11,7 +11,6 @@ beforeAll(async () => {
 test('priority order with url & local-storage', async () => {
   const center = { lng: 11.1, lat: 43.3 };
 
-  expect.assertions(1);
   await page.goto(APP_URL);
   await store(page, 'qmaps_v1_last_location', { lng: 19, lat: 47, zoom: 18 });
   await page.goto(`${APP_URL}/#map=2.00/${center.lat}/${center.lng}`);
@@ -24,7 +23,6 @@ test('priority order with url & local-storage', async () => {
 test('test local storage map center', async () => {
   const center = { lng: 11.1, lat: 43.3 };
 
-  expect.assertions(1);
   await page.goto(APP_URL);
   await store(page, 'qmaps_v1_last_location', center);
   await page.goto(APP_URL);

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -15,7 +15,6 @@ beforeAll(async () => {
 
 
 test('test menu toggling', async () => {
-  expect.assertions(3);
   await page.goto(APP_URL);
   page.waitForSelector('.menu__button');
   let panel = await page.waitForSelector('.menu__panel', { hidden: true });
@@ -31,7 +30,6 @@ test('test menu toggling', async () => {
 });
 
 test('menu open favorite', async () => {
-  expect.assertions(2);
   await page.goto(APP_URL);
   page.waitForSelector('.menu__button');
 
@@ -51,7 +49,6 @@ test('menu open favorite', async () => {
 });
 
 test('close service panel when opening direction', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   await page.click('.service_panel__item__direction');
   const servicePanelClose = await page.waitForSelector('.service_panel', { hidden: true });

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser } from '../tools';
+import { clearStore, initBrowser, exists, isHidden } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 
 let browser;
@@ -13,20 +13,16 @@ beforeAll(async () => {
   await responseHandler.prepareResponse();
 });
 
-
 test('test menu toggling', async () => {
   await page.goto(APP_URL);
   page.waitForSelector('.menu__button');
-  let panel = await page.waitForSelector('.menu__panel', { hidden: true });
-  expect(panel).toBeNull();
+  expect(await isHidden(page, '.menu__panel')).toBeTruthy();
 
   await page.click('.menu__button');
-  panel = await page.waitForSelector('.menu__panel', { visible: true });
-  expect(panel).not.toBeNull();
+  expect(await exists(page, '.menu__panel')).toBeTruthy();
 
   await page.click('.menu__panel__top__close');
-  panel = await page.waitForSelector('.menu__panel', { hidden: true });
-  expect(panel).toBeNull();
+  expect(await isHidden(page, '.menu_panel')).toBeTruthy();
 });
 
 test('menu open favorite', async () => {
@@ -37,22 +33,19 @@ test('menu open favorite', async () => {
   await page.waitForSelector('.menu__panel');
   page.click('.menu__panel__action:nth-child(2)');
 
-  const itinerary = await page.waitForSelector('.direction_panel');
-  expect(itinerary).not.toBeNull();
+  expect(await exists(page, '.direction_panel')).toBeTruthy();
 
   page.click('.menu__button');
   await page.waitForSelector('.menu__panel__action');
   page.click('.menu__panel__action:nth-child(3)');
 
-  const favorites = await page.waitForSelector('.favorite_panel');
-  expect(favorites).not.toBeNull();
+  expect(await exists(page, '.favorite_panel')).toBeTruthy();
 });
 
 test('close service panel when opening direction', async () => {
   await page.goto(APP_URL);
   await page.click('.service_panel__item__direction');
-  const servicePanelClose = await page.waitForSelector('.service_panel', { hidden: true });
-  expect(servicePanelClose).toBeNull();
+  expect(await isHidden(page, '.service_panel')).toBeTruthy();
 });
 
 afterEach(async () => {

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -28,7 +28,6 @@ beforeEach(async () => {
 });
 
 test('click on a poi', async () => {
-  expect.assertions(2);
   await page.goto(APP_URL);
   await clickPoi(page);
   const poiPanel = await page.waitForSelector('.poi_panel__title');
@@ -38,7 +37,6 @@ test('click on a poi', async () => {
 });
 
 test('load a poi from url', async () => {
-  expect.assertions(2);
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poi_panel__title');
   const { title, address } = await page.evaluate(() => {
@@ -61,7 +59,6 @@ test('load a poi from url and click on directions', async () => {
 });
 
 test('load a poi from url with simple id', async () => {
-  expect.assertions(2);
   await page.goto(`${APP_URL}/place/osm:way:63178753`);
   await page.waitForSelector('.poi_panel__title');
   const { title, address } = await page.evaluate(() => {
@@ -94,7 +91,6 @@ test('load a poi from url on mobile', async () => {
 });
 
 test('load a poi already in my favorite from url', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   await storePoi(page, { id: 'osm:way:63178753' });
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
@@ -103,7 +99,6 @@ test('load a poi already in my favorite from url', async () => {
 });
 
 test('update url after a poi click', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   await clickPoi(page);
   const location = await page.evaluate(() => {
@@ -113,7 +108,6 @@ test('update url after a poi click', async () => {
 });
 
 test('update url after a favorite poi click', async () => {
-  expect.assertions(1);
   await page.goto(APP_URL);
   await storePoi(page, { id: poiMock.id, title: poiMock.name });
   await toggleFavoritePanel(page);
@@ -126,7 +120,6 @@ test('update url after a favorite poi click', async () => {
 });
 
 test('open poi from autocomplete selection', async () => {
-  expect.assertions(2);
   await page.goto(APP_URL);
   await page.keyboard.type('test');
   await page.waitForSelector('.autocomplete_suggestion');
@@ -146,7 +139,6 @@ test('open poi from autocomplete selection', async () => {
 test('center the map to the poi on a poi click', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poi_panel__title');
-  expect.assertions(1);
   await page.evaluate(() => {
     window.MAP_MOCK.flyTo({ center: { lat: 0, lng: 0 }, zoom: 10 });
   });
@@ -163,7 +155,6 @@ test('center the map to the poi on a poi click', async () => {
 test('display details about the poi on a poi click', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/48.8605833/2.3261037`);
   await page.waitForSelector('.poi_panel__title');
-  expect.assertions(8);
 
   await page.click('.poi_panel__content .poi_panel__description_container');
   let infoTitle = await page.evaluate(() => {
@@ -197,8 +188,6 @@ test('display details about the poi on a poi click', async () => {
 });
 
 test('Poi name i18n', async () => {
-  expect.assertions(2);
-
   await page.goto(`${APP_URL}/place/osm:way:453203@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poi_panel__title');
 
@@ -209,8 +198,6 @@ test('Poi name i18n', async () => {
 
 
 test('Test 24/7', async () => {
-  expect.assertions(1);
-
   const poi = { ...poiMock };
   poi.blocks.forEach(block => {
     if (block.type === 'opening_hours') {

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -1,7 +1,7 @@
 const poiMock = require('../../__data__/poi.json');
 
 import ResponseHandler from '../helpers/response_handler';
-import { initBrowser, getText, clearStore, getInputValue } from '../tools';
+import { initBrowser, getText, clearStore, getInputValue, exists } from '../tools';
 import { getFavorites, toggleFavoritePanel, storePoi } from '../favorites_tools';
 import { languages } from '../../../config/constants.yml';
 
@@ -30,8 +30,7 @@ beforeEach(async () => {
 test('click on a poi', async () => {
   await page.goto(APP_URL);
   await clickPoi(page);
-  const poiPanel = await page.waitForSelector('.poi_panel__title');
-  expect(poiPanel).not.toBeFalsy();
+  expect(await exists(page, '.poi_panel__title')).toBeTruthy();
   const translatedSubClass = await getText(page, '.poi_panel__description');
   expect(translatedSubClass).toEqual('musée');
 });
@@ -94,8 +93,7 @@ test('load a poi already in my favorite from url', async () => {
   await page.goto(APP_URL);
   await storePoi(page, { id: 'osm:way:63178753' });
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
-  const plainStar = await page.waitForSelector('.icon-icon_star-filled');
-  expect(plainStar).not.toBeFalsy();
+  expect(await exists(page, '.icon-icon_star-filled')).toBeTruthy();
 });
 
 test('update url after a poi click', async () => {
@@ -131,9 +129,8 @@ test('open poi from autocomplete selection', async () => {
 
   // url is updated
   expect(location.href).toMatch(/osm:way:63178753@Mus%C3%A9e_dOrsay/);
-
   // poi panel is visible
-  expect(await page.$('.poi_panel.poi_panel--hidden')).toBeFalsy();
+  expect(await exists(page, '.poi_panel')).toBeTruthy();
 });
 
 test('center the map to the poi on a poi click', async () => {
@@ -182,9 +179,7 @@ test('display details about the poi on a poi click', async () => {
   expect(website).toMatch('www.musee-orsay.fr');
   expect(contactUrl).toMatch('mailto:admin@orsay.fr');
   expect(contact).toMatch('admin@orsay.fr');
-
-  const wiki_block = await page.waitForSelector('.poi_panel__info__wiki');
-  expect(wiki_block).not.toBeFalsy();
+  expect(await exists(page, '.poi_panel__info__wiki')).toBeTruthy();
 });
 
 test('Poi name i18n', async () => {
@@ -250,8 +245,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
 
   // we select a poi and 'star' it
   await clickPoi(page);
-  let poiPanel = await page.waitForSelector('.poi_panel__title');
-  expect(poiPanel).not.toBeFalsy();
+  expect(await exists(page, '.poi_panel')).toBeTruthy();
   await page.click('.poi_panel__actions .poi_panel__action__favorite');
   await page.click('.poi_panel .panel-close');
   // we check that the first favorite item is our poi
@@ -264,8 +258,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
 
   // we then reopen the poi panel and 'unstar' the poi.
   await page.click('.favorite_panel__item');
-  poiPanel = await page.waitForSelector('.poi_panel__title');
-  expect(poiPanel).not.toBeFalsy();
+  expect(await exists(page, '.poi_panel')).toBeTruthy();
 
   await page.click('.poi_panel__actions .poi_panel__action__favorite');
   await page.click('.poi_panel .panel-close');

--- a/tests/integration/tools.js
+++ b/tests/integration/tools.js
@@ -63,3 +63,21 @@ export async function getMapView(page) {
     zoom: window.MAP_MOCK.getZoom(),
   }));
 }
+
+export async function exists(page, selector) {
+  try {
+    const result = await page.waitForSelector(selector);
+    return !!result;
+  } catch {
+    return false;
+  }
+}
+
+export async function isHidden(page, selector) {
+  try {
+    const result = await page.waitForSelector(selector, { hidden: true });
+    return result === null;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Description
- Remove useless `expect.assertions` everywhere. They are a way of ensuring Jest is getting the right number of assertions in the case of asynchronous cases, especially when testing error cases. All our tests are testing very linear paths with the use of `await`, so we don't need them.
- Use a correct assertion for testing the presence of some element.
  Previously we used this pattern:
  ```js
  const elementFound = await page.waitForSelector('.elementSelector');
  expect(elementFound).not.toBeNull();
  ```
  But when failing, `waitForSelector` doesn't return `null`. Instead, the Promise rejects. This caused hard to read error messages in our test suite. I replaced that with a simple util `exists`, returning really true or false, and the above pattern can become:
  ```js
  expect(await exists(page, '.elementSelector')).toBeTruthy();
  ```

## Why
Try to simplify integration tests writing and reading.