### PR TITLE
QMAPS-980 recompute routes when moving itinerary points during mobile preview

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -228,6 +228,7 @@ export default class DirectionPanel extends React.Component {
       [which]: point,
       isDirty: true,
       [which + 'InputText']: value || '',
+      activePreviewRoute: null,
     }, () => {
       this.update();
       // Retrieve addresses


### PR DESCRIPTION
## Description
quit mobile preview when moving start/end of current itinerary on the map, and recompute routes normally


## Screenshots
![previewfix](https://user-images.githubusercontent.com/1225909/84279153-eb72b100-ab35-11ea-9c8b-a43c5752465b.gif)

