### PR TITLE
Use Idunn extend_bbox feature on category panel

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -53,9 +53,9 @@ export default class IdunnPoi extends Poi {
     }
   }
   /* ?bbox={bbox}&category=<category-name>&size={size}&verbosity=long/ */
-  static async poiCategoryLoad(bbox, size, category, query) {
+  static async poiCategoryLoad(bbox, size, category, query, extendBbox) {
     const url = `${serviceConfig.idunn.url}/v1/places`;
-    const requestParams = { bbox, size };
+    const requestParams = { bbox, size, extend_bbox: !!extendBbox };
     if (category) {
       requestParams['category'] = category;
     }

--- a/src/libs/bounds.js
+++ b/src/libs/bounds.js
@@ -1,0 +1,11 @@
+
+export const boundsFromFlatArray = coords => [[coords[0], coords[1]], [coords[2], coords[3]]];
+
+export const parseBboxString = bboxString =>
+  boundsFromFlatArray(bboxString.split(',').map(coord => Number(coord)));
+
+export const boundsToString = llBounds =>
+  llBounds.toArray()
+    .flat()
+    .map(coord => coord.toFixed(7))
+    .join(',');

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -97,12 +97,13 @@ const CategoryPanel = ({ poiFilters = {}, bbox = '' }) => {
   const fetchData = async () => {
     const currentBounds = getVisibleBbox(window.map.mb);
 
+    const extendBBox = initialLoading;
     const { places, source, bbox: contentBBox, bbox_extended } = await IdunnPoi.poiCategoryLoad(
       boundsToString(currentBounds),
       MAX_PLACES,
       category,
       query,
-      initialLoading
+      extendBBox
     );
 
     setPois(places);

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -57,41 +57,41 @@ const CategoryPanel = ({ poiFilters = {}, bbox = '' }) => {
       SearchInput.setInputValue(query);
     }
 
-    window.execOnMapLoaded(() => { fitMapAndFetch(); });
+    window.execOnMapLoaded(fitMap);
 
     return function unmount() {
       SearchInput.setInputValue('');
     };
   }, [poiFilters, bbox]);
 
-  function fitMapAndFetch() {
+  function fitMap() {
+    const map = window.map.mb;
     const rawBbox = bbox.split(',');
     const mapBbox = rawBbox.length === 4 && [[rawBbox[0], rawBbox[1]], [rawBbox[2], rawBbox[3]]];
     if (mapBbox) {
-      window.map.mb.fitBounds(bbox, { animate: false });
+      map.fitBounds(mapBbox, { animate: false });
+      return;
     }
 
-    if (window.map.mb.isMoving()) {
-      /*
-        Do not trigger API search and zoom change when the map
-        is already moving, to avoid flickering.
-        The search will be triggered on moveend.
-      */
+    if (map.isMoving()) {
+      // If the map is already moving, let it finish its transition.
+      // The data loading will be triggered on moveend.
       return;
     }
 
     // Apply correct zoom when opening a category
-    const currentZoom = window.map.mb.getZoom();
+    const currentZoom = map.getZoom();
 
     // Zoom < 5: focus on Paris
     if (currentZoom < 5) {
-      window.map.mb.flyTo({ center: [2.35, 48.85], zoom: 12 });
+      map.flyTo({ center: [2.35, 48.85], zoom: 12 });
     } else if (currentZoom < 12) { // Zoom < 12: zoom up to zoom 12
-      window.map.mb.flyTo({ zoom: 12 });
+      map.flyTo({ zoom: 12 });
     } else if (currentZoom > 16) { // Zoom > 16: dezoom to zoom 16
-      window.map.mb.flyTo({ zoom: 16 });
+      map.flyTo({ zoom: 16 });
     } else {
-      fetchData();
+      // setting the same view still triggers the moveend event
+      map.jumpTo({ zoom: currentZoom, center: map.getCenter() });
     }
   }
 

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -1,6 +1,6 @@
 /* global _ */
 import React, { useState, useEffect } from 'react';
-import PropTypes, { checkPropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import Panel from 'src/components/ui/Panel';
 import PoiItemList from './PoiItemList';
 import PoiItemListPlaceholder from './PoiItemListPlaceholder';

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -40,7 +40,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox = '' }) => {
     return function unmount() {
       unListen(mapMoveHandler);
     };
-  });
+  }, []);
 
   useEffect(() => {
     const panelContent = document.querySelector('.panel-content');

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -66,6 +66,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox = '' }) => {
 
   function fitMap() {
     const map = window.map.mb;
+    // @TODO: put bbox parsing in a dedicated lib
     const rawBbox = bbox.split(',');
     const mapBbox = rawBbox.length === 4 && [[rawBbox[0], rawBbox[1]], [rawBbox[2], rawBbox[3]]];
     if (mapBbox) {
@@ -97,8 +98,8 @@ const CategoryPanel = ({ poiFilters = {}, bbox = '' }) => {
 
   const fetchData = async () => {
     const { category, query } = poiFilters;
+    // @TODO: put bbox => string in a dedicated lib
     const bbox = getVisibleBbox(window.map.mb);
-
     const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
       .map(cardinal => cardinal.toFixed(7))
       .join(',');


### PR DESCRIPTION
## Description
Allow the Idunn API call to take an `extend_bbox` parameter to use the auto BBOX extension feature introduced in https://github.com/QwantResearch/idunn/pull/146.

I refactored the CategoryPanel before that (notably turning it into a functional component with hooks) to have a clearer lifecycle and separate more cleanly the map management, data loading, and rendering.
I thought (now I'm not so sure -_-) it was necessary to avoid falling into dead locks with auto bbox and such, and the resulting hooks are clear as long as you pay attention to when they are actually called.
As a reminder:
```js
  useEffect(() => {
    // ...
  }, [category, query]); // i.e. this hook will be called only when `category` or `query` has changed
```

We use the bbox extension feature, only when loading the first results of a category/query, not on subsequent map pans and zooms. This is to avoid changing the view when the user is interacting with the map. I re-used the `initialLoading` state as an indication of that.

## Why
 - Be more helpful to the user when no data is returned in the first place
 - Try to simplify the CategoryPanel component lifecycle

## Screenshots
![Peek 22-06-2020 10-46](https://user-images.githubusercontent.com/243653/85269850-c6a50480-b478-11ea-9094-8aac9a885fbd.gif)
