### PR TITLE
Fix auto-width ellipsis of address in PoiCard

### DIFF
--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -404,6 +404,11 @@ $HEADER_SIZE: 40px;
   position: fixed;
   padding: 16px;
 
+  .poiItem {
+    min-width: 0;
+    flex: 1;
+  }
+
   &__action_container {
     margin-top: 12px;
     margin-left: 6px;


### PR DESCRIPTION
## Description
Fix overflowing long addresses in POI cards.

## Why
`text-overflow: ellipsis` used inside a flexbox item requires to set `min-width: 0` on this item, otherwise it will refuse to shrink and its computed size will be the full width with the ellipsis not applied. This is according to specs (see https://bugzilla.mozilla.org/show_bug.cgi?id=1086218#c4).  The `flex: 1` should be useless but it's required to fix that behavior in IE 11. 
We already used these rules for the POI panel, but the POI card implies another level of flex so we need this here also.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_place_admin_osm_relation_170100@Nice_06000-06300(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/84669643-60266080-af25-11ea-84d8-ebd94ee82c0f.png)|![localhost_3000_place_admin_osm_relation_170100@Nice_06000-06300(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/84669739-80561f80-af25-11ea-96f9-2a56ca333003.png)|
