### PR TITLE
Fix mobile nav preview step button states

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -828,7 +828,7 @@ button.direction_shortcut {
     justify-content: center;
     align-items: center;
 
-    &:read-only {
+    &:disabled {
       color: $primary_clear;
     }
   }


### PR DESCRIPTION
## Description
Restore the style of step buttons in the mobile preview of itineraries. Black for possible next or previous step, gray when no more step.

## Why
We wrongly changed the style of these buttons in this commit, and this wasn't caught during the review 
https://github.com/QwantResearch/erdapfel/commit/1e346e38ac7f5de7a25fd9b645620a01c01cd54c

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_43 79734_6 98812 destination=latlon_43 76159_6 97054 mode=driving pt=true (3)](https://user-images.githubusercontent.com/243653/84672922-5ef73280-af29-11ea-9df3-f1436c01440d.png)|![localhost_3000_routes__origin=latlon_43 79734_6 98812 destination=latlon_43 76159_6 97054 mode=driving pt=true](https://user-images.githubusercontent.com/243653/84672932-60285f80-af29-11ea-892d-e6e384d535aa.png)|

