### PR TITLE
OpeningHour: hide close status

### DIFF
--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -55,7 +55,7 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
     return separator + text;
   };
 
-  return <div className={classnames('openingHour', className)}>
+  return <div className={classnames('openingHour', `openingHour--${status}`, className)}>
     <span className="u-firstCap">
       <Label />
       <NextTransition />

--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -32,29 +32,35 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
     return <div className="openingHour poi_panel__info__hours__24_7">
       {_('Open 24/7', 'hour block')}
       {' '}
-      <div className="openingHour-circle" style={{ background: color }} />
+      <div className="openingHour-circle u-ml-4" style={{ background: color }} />
     </div>;
   }
 
+  const Label = () => {
+    const displayedLabel = showNextOpenOnly && status === 'closed' ? '' : `${label}`;
+    return displayedLabel;
+  };
+
   const NextTransition = () => {
-    if (!nextTransition || showNextOpenOnly && status !== 'closed') {
+    if (!nextTransition || showNextOpenOnly && status === 'open') {
       return null;
     }
 
+    const separator = showNextOpenOnly && status === 'closed' ? '' : ' - ';
     const options = { nextTransitionTime: nextTransition };
-
     const text = status === 'closed'
-      ? ` - ${_('reopening at {nextTransitionTime}', 'hour panel', options)}`
-      : ` - ${_('until {nextTransitionTime}', 'hour panel', options)}`;
+      ? `${_('reopening at {nextTransitionTime}', 'hour panel', options)}`
+      : `${_('until {nextTransitionTime}', 'hour panel', options)}`;
 
-    return text;
+    return separator + text;
   };
 
   return <div className={classnames('openingHour', className)}>
-    {label}
-    <NextTransition />
-    {' '}
-    <div className="openingHour-circle" style={{ background: color }} />
+    <span className="u-firstCap">
+      <Label />
+      <NextTransition />
+    </span>
+    <div className="openingHour-circle u-ml-4" style={{ background: color }} />
   </div>;
 };
 

--- a/src/scss/includes/openingHour.scss
+++ b/src/scss/includes/openingHour.scss
@@ -6,7 +6,6 @@
   &-circle {
     width: 8px;
     height: 8px;
-    margin-left: 4px;
     border-radius: 50%;
   }
 }

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -61,6 +61,10 @@
   font-weight: bold;
 }
 
+.u-ml-4 {
+  margin-left: 4px;
+}
+
 .u-mr-4 {
   margin-right: 4px;
 }

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -77,16 +77,15 @@ test('load a poi from url on mobile', async () => {
   });
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poiTitle');
-  const { title, address, hours } = await page.evaluate(() => {
+  const { title, address } = await page.evaluate(() => {
     return {
       title: document.querySelector('.poi_card .poiTitle').innerText,
       address: document.querySelector('.poi_card .poiItem-address').innerText,
-      hours: document.querySelector('.poi_card .openingHour').innerText,
     };
   });
   expect(title).toMatch(/Musée d'Orsay/);
   expect(address).toMatch(/1 Rue de la Légion d'Honneur \(Paris\)/);
-  expect(hours).toMatch(/Fermé/);
+  expect(await exists(page, '.poi_card .openingHour--closed')).toBeTruthy();
 });
 
 test('load a poi already in my favorite from url', async () => {
@@ -165,16 +164,15 @@ test('display details about the poi on a poi click', async () => {
   });
   expect(infoTitle.trim()).toEqual('Services & informations');
 
-  const { contact, contactUrl, hours, phone, website } = await page.evaluate(() => {
+  const { contact, contactUrl, phone, website } = await page.evaluate(() => {
     return {
       contact: document.querySelector('.poi_panel__info__contact').innerText,
       contactUrl: document.querySelector('.poi_panel__info__contact').href,
-      hours: document.querySelector('.poi_panel .timetable-status').innerText,
       phone: document.querySelector('.poi_panel__info__section--phone').innerText,
       website: document.querySelector('.poi_panel__info__link').innerText,
     };
   });
-  expect(hours.trim()).toMatch('Fermé');
+  expect(await exists(page, '.poi_panel .openingHour--closed')).toBeTruthy();
   expect(phone).toMatch('01 40 49 48 14');
   expect(website).toMatch('www.musee-orsay.fr');
   expect(contactUrl).toMatch('mailto:admin@orsay.fr');


### PR DESCRIPTION
- Hide Close status, display only `reopening at` (nextTransition)
- Capitalize with css and add `u-ml-4` class
- Improved readability

![image](https://user-images.githubusercontent.com/2981774/84774647-69273880-afde-11ea-879e-064b45c430a3.png)
