### PR TITLE
Search input mobile: focus only if active

### DIFF
--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -1,5 +1,6 @@
 
 import { selectItem, fetchSuggests } from 'src/libs/suggest';
+import { isMobileDevice } from 'src/libs/device';
 
 const MAPBOX_RESERVED_KEYS = [
   'ArrowLeft', // ←
@@ -11,6 +12,8 @@ const MAPBOX_RESERVED_KEYS = [
   '=', // =
 ];
 
+const SEARCH_INPUT_ID = 'search';
+
 export default class SearchInput {
 
   constructor(tagSelector) {
@@ -21,24 +24,29 @@ export default class SearchInput {
 
   /* Singleton */
   static initSearchInput(tagSelector) {
-    if (! window.__searchInput) {
-      window.__searchInput = new SearchInput(tagSelector);
-
-      window.clearSearch = () => {
-        window.__searchInput.searchInputHandle.value = '';
-        window.app.navigateTo('/');
-        setTimeout(() => {
-          document.getElementById('search').focus();
-        }, 0);
-
-      };
-
-      window.submitSearch = () => {
-        if (window.__searchInput.searchInputHandle.value.length > 0) {
-          this.executeSearch(window.__searchInput.searchInputHandle.value);
-        }
-      };
+    if (window.__searchInput) {
+      return window.__searchInput;
     }
+
+    window.__searchInput = new SearchInput(tagSelector);
+
+    window.clearSearch = () => {
+      const isMobile = isMobileDevice();
+      window.__searchInput.searchInputHandle.value = '';
+      window.app.navigateTo('/');
+      if (!isMobile || isMobile && document.activeElement.id === SEARCH_INPUT_ID) {
+        setTimeout(() => {
+          document.getElementById(SEARCH_INPUT_ID).focus();
+        }, 0);
+      }
+    };
+
+    window.submitSearch = () => {
+      if (window.__searchInput.searchInputHandle.value.length > 0) {
+        this.executeSearch(window.__searchInput.searchInputHandle.value);
+      }
+    };
+
     return window.__searchInput;
   }
 
@@ -74,7 +82,7 @@ export default class SearchInput {
         if (document.activeElement
           && document.activeElement.tagName !== 'INPUT'
           && window.__searchInput.isEnabled) {
-          document.getElementById('search').focus();
+          document.getElementById(SEARCH_INPUT_ID).focus();
         }
       }
     };

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -12,8 +12,6 @@ const MAPBOX_RESERVED_KEYS = [
   '=', // =
 ];
 
-const SEARCH_INPUT_ID = 'search';
-
 export default class SearchInput {
 
   constructor(tagSelector) {
@@ -32,11 +30,12 @@ export default class SearchInput {
 
     window.clearSearch = () => {
       const isMobile = isMobileDevice();
+      const isActive = document.activeElement.id === window.__searchInput.searchInputHandle.id;
       window.__searchInput.searchInputHandle.value = '';
       window.app.navigateTo('/');
-      if (!isMobile || isMobile && document.activeElement.id === SEARCH_INPUT_ID) {
+      if (!isMobile || isMobile && isActive) {
         setTimeout(() => {
-          document.getElementById(SEARCH_INPUT_ID).focus();
+          document.querySelector(tagSelector).focus();
         }, 0);
       }
     };
@@ -74,7 +73,7 @@ export default class SearchInput {
   }
 
   handleKeyboard() {
-    document.onkeydown = function(e) {
+    document.onkeydown = e => {
       if (MAPBOX_RESERVED_KEYS.find(key => key === e.key)) {
         return;
       }
@@ -82,7 +81,7 @@ export default class SearchInput {
         if (document.activeElement
           && document.activeElement.tagName !== 'INPUT'
           && window.__searchInput.isEnabled) {
-          document.getElementById(SEARCH_INPUT_ID).focus();
+          this.searchInputHandle.focus();
         }
       }
     };


### PR DESCRIPTION
## Description
On mobile, clearing the input with the "close" icon currently triggers a focus on the input.

This PR checks if the input is already focused (suggestions are displayed), and triggers a focus only if it's the case. If the input is not focused, The input is only cleared.
Desktop's behavior is unchanged.

![Peek 2020-06-17 12-30](https://user-images.githubusercontent.com/2981774/84888630-dd71e280-b097-11ea-970c-f9963b563429.gif)
