### PR TITLE
Fix opening hours display

### DIFF
--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -1,6 +1,7 @@
 /* global _ */
 import React from 'react';
 import classnames from 'classnames';
+import { capitalizeFirst } from 'src/libs/string';
 
 const getStatusMessage = status => {
   if (status === 'open') {
@@ -36,30 +37,25 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
     </div>;
   }
 
-  const Label = () => {
-    const displayedLabel = showNextOpenOnly && status === 'closed' ? '' : `${label}`;
-    return displayedLabel;
-  };
+  const getDescription = () => {
+    const parts = [];
 
-  const NextTransition = () => {
-    if (!nextTransition || showNextOpenOnly && status === 'open') {
-      return null;
+    if (!nextTransition || status !== 'closed' || !showNextOpenOnly) {
+      parts.push(label);
     }
 
-    const separator = showNextOpenOnly && status === 'closed' ? '' : ' - ';
-    const options = { nextTransitionTime: nextTransition };
-    const text = status === 'closed'
-      ? `${_('reopening at {nextTransitionTime}', 'hour panel', options)}`
-      : `${_('until {nextTransitionTime}', 'hour panel', options)}`;
+    if (nextTransition && (status === 'closed' || !showNextOpenOnly)) {
+      const options = { nextTransitionTime: nextTransition };
+      parts.push(status === 'closed'
+        ? _('reopening at {nextTransitionTime}', 'hour panel', options)
+        : _('until {nextTransitionTime}', 'hour panel', options));
+    }
 
-    return separator + text;
+    return capitalizeFirst(parts.join(' - '));
   };
 
   return <div className={classnames('openingHour', `openingHour--${status}`, className)}>
-    <span className="u-firstCap">
-      <Label />
-      <NextTransition />
-    </span>
+    <div>{getDescription()}</div>
     <div className="openingHour-circle u-ml-4" style={{ background: color }} />
   </div>;
 };

--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -29,15 +29,11 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
   const { isTwentyFourSeven, status, nextTransition } = schedule;
   const { label, color } = getStatusMessage(status);
 
-  if (isTwentyFourSeven && !showNextOpenOnly) {
-    return <div className="openingHour poi_panel__info__hours__24_7">
-      {_('Open 24/7', 'hour block')}
-      {' '}
-      <div className="openingHour-circle u-ml-4" style={{ background: color }} />
-    </div>;
-  }
-
   const getDescription = () => {
+    if (isTwentyFourSeven && !showNextOpenOnly) {
+      return _('Open 24/7', 'hour block');
+    }
+
     const parts = [];
 
     if (!nextTransition || status !== 'closed' || !showNextOpenOnly) {
@@ -54,7 +50,10 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
     return capitalizeFirst(parts.join(' - '));
   };
 
-  return <div className={classnames('openingHour', `openingHour--${status}`, className)}>
+  return <div className={classnames('openingHour', {
+    [`openingHour--${status}`]: status,
+    'openingHour--24-7': isTwentyFourSeven,
+  }, className)}>
     <div>{getDescription()}</div>
     <div className="openingHour-circle u-ml-4" style={{ background: color }} />
   </div>;

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -208,7 +208,7 @@ test('Test 24/7', async () => {
   await page.waitForSelector('.poiTitle');
 
   const hours = await page.evaluate(() => {
-    return document.querySelector('.poi_panel__info__hours__24_7').innerText.trim();
+    return document.querySelector('.openingHour--24-7').innerText.trim();
   });
 
   expect(hours).toEqual('Ouvert 24h/24 et 7j/7');


### PR DESCRIPTION
## Description
Fixes two bugs on opening hours that were detected after https://github.com/QwantResearch/erdapfel/pull/680 was merged.
 1. On Firefox the horizontal space between the text and the colour disc was too large, due to a known layout bug on this browser related to the use of the `::firstLetter` CSS
  => I used a JS function for the capitalization
 2. Hours with status `closed` but no known reopening time where displayed with just the circle, no label, making them hard to understand
  => I tried to rework the display conditions to make them easier to read.
In the process of these two fixes, I removed the "internal components" `Label` and `NextTransition` to use a single function, as everything was not so separated and the JS capitalization needed a real string anyway.

BTW @G-Ray I encountered useless re-render problems while playing with this pattern in another PR, and I'm sure that's an anti-pattern. As they have to be reinstantiated at each render of the parent component, they are considered new components each time and this makes the diff render algorithm inefficient. I'm totally ok to split things up for clarity, but if we need to do so, we have to make sure we create pure, isolated components, taking data as real props. In the same file is perfectly ok for me.

## Screenshots
|Before|After|
|---|---|
|![Screenshot_2020-06-18 Qwant Maps](https://user-images.githubusercontent.com/243653/85008928-ef1dbd80-b15d-11ea-8421-e7b69065dda9.png)|![Screenshot_2020-06-18 Qwant Maps(1)](https://user-images.githubusercontent.com/243653/85008962-fcd34300-b15d-11ea-915f-0d13ee4f5111.png)|

