### PR TITLE
Use Idunn extend_bbox feature on category panel

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -36,9 +36,9 @@ export default class IdunnPoi extends Poi {
   }
 
   /* ?bbox={bbox}&category=<category-name>&size={size}&verbosity=long/ */
-  static async poiCategoryLoad(bbox, size, category, query, extendBBox = false) {
+  static async poiCategoryLoad(bbox, size, category, query, extendBbox = false) {
     const url = `${serviceConfig.idunn.url}/v1/places`;
-    const requestParams = { bbox, size, extend_bbox: extendBBox };
+    const requestParams = { bbox, size, extend_bbox: extendBbox };
     if (category) {
       requestParams['category'] = category;
     }

--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -36,9 +36,9 @@ export default class IdunnPoi extends Poi {
   }
 
   /* ?bbox={bbox}&category=<category-name>&size={size}&verbosity=long/ */
-  static async poiCategoryLoad(bbox, size, category, query) {
+  static async poiCategoryLoad(bbox, size, category, query, extendBBox) {
     const url = `${serviceConfig.idunn.url}/v1/places`;
-    const requestParams = { bbox, size };
+    const requestParams = { bbox, size, extend_bbox: !!extendBBox };
     if (category) {
       requestParams['category'] = category;
     }

--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -36,9 +36,9 @@ export default class IdunnPoi extends Poi {
   }
 
   /* ?bbox={bbox}&category=<category-name>&size={size}&verbosity=long/ */
-  static async poiCategoryLoad(bbox, size, category, query, extendBBox) {
+  static async poiCategoryLoad(bbox, size, category, query, extendBBox = false) {
     const url = `${serviceConfig.idunn.url}/v1/places`;
-    const requestParams = { bbox, size, extend_bbox: !!extendBBox };
+    const requestParams = { bbox, size, extend_bbox: extendBBox };
     if (category) {
       requestParams['category'] = category;
     }

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -284,7 +284,7 @@ Scene.prototype.fitBbox = function(bbox,
 Scene.prototype.fitMap = function(item, padding, forceAnimate) {
 
   // BBox
-  if (item._ne && item._sw) {
+  if (item instanceof LngLatBounds || Array.isArray(item)) {
     this.fitBbox(item, padding, forceAnimate);
   } else { // PoI
     if (item.bbox) { // poi Bbox

--- a/src/libs/bounds.js
+++ b/src/libs/bounds.js
@@ -6,6 +6,6 @@ export const parseBboxString = bboxString =>
 
 export const boundsToString = llBounds =>
   llBounds.toArray()
-    .flat()
+    .reduce((flatArray, current) => flatArray.concat(current), []) // flatten
     .map(coord => coord.toFixed(7))
     .join(',');

--- a/src/libs/bounds.js
+++ b/src/libs/bounds.js
@@ -1,0 +1,11 @@
+export const boundsFromFlatArray = coords =>
+  [[coords[0], coords[1]], [coords[2], coords[3]]];
+
+export const parseBboxString = bboxString =>
+  boundsFromFlatArray(bboxString.split(',').map(coord => Number(coord)));
+
+export const boundsToString = llBounds =>
+  llBounds.toArray()
+    .flat()
+    .map(coord => coord.toFixed(7))
+    .join(',');

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -77,7 +77,7 @@ export default class CategoryPanel extends React.Component {
 
   fitMap() {
     if (this.props.bbox) {
-      window.map.mb.fitBounds(parseBboxString(this.props.bbox), { animate: false });
+      fire('fit_map', parseBboxString(this.props.bbox), true);
       return;
     }
 
@@ -126,7 +126,7 @@ export default class CategoryPanel extends React.Component {
     if (bbox_extended) {
       // The returned bbox is sure to contain at least one POI.
       // Extend the current one to include it.
-      window.map.mb.fitBounds(currentBounds.extend(boundsFromFlatArray(contentBbox)));
+      fire('fit_map', currentBounds.extend(boundsFromFlatArray(contentBbox)), true);
     }
 
     fire('add_category_markers', places, this.props.poiFilters);

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -77,7 +77,7 @@ export default class CategoryPanel extends React.Component {
 
   fitMap() {
     if (this.props.bbox) {
-      fire('fit_map', parseBboxString(this.props.bbox), true);
+      fire('fit_map', parseBboxString(this.props.bbox));
       return;
     }
 

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -108,13 +108,13 @@ export default class CategoryPanel extends React.Component {
     const { category, query } = this.props.poiFilters;
     const currentBounds = getVisibleBbox(window.map.mb);
 
-    const extendBBox = this.state.initialLoading;
-    const { places, source, bbox: contentBBox, bbox_extended } = await IdunnPoi.poiCategoryLoad(
+    const extendBbox = this.state.initialLoading;
+    const { places, source, bbox: contentBbox, bbox_extended } = await IdunnPoi.poiCategoryLoad(
       boundsToString(currentBounds),
       MAX_PLACES,
       category,
       query,
-      extendBBox
+      extendBbox
     );
 
     this.setState({
@@ -126,7 +126,7 @@ export default class CategoryPanel extends React.Component {
     if (bbox_extended) {
       // The returned bbox is sure to contain at least one POI.
       // Extend the current one to include it.
-      window.map.mb.fitBounds(currentBounds.extend(boundsFromFlatArray(contentBBox)));
+      window.map.mb.fitBounds(currentBounds.extend(boundsFromFlatArray(contentBbox)));
     }
 
     fire('add_category_markers', places, this.props.poiFilters);

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -98,6 +98,8 @@ export default class CategoryPanel extends React.Component {
       window.map.mb.flyTo({ center: [2.35, 48.85], zoom: 12 });
     } else if (currentZoom < 12) { // Zoom < 12: zoom up to zoom 12
       window.map.mb.flyTo({ zoom: 12 });
+    } else if (currentZoom > 18) { // Zoom > 18: dezoom to zoom 18
+      window.map.mb.flyTo({ zoom: 18 });
     } else {
       // setting the same view still triggers the moveend event
       window.map.mb.jumpTo({ zoom: currentZoom, center: window.map.mb.getCenter() });

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -14,6 +14,7 @@ import CategoryService from 'src/adapters/category_service';
 import { getVisibleBbox } from 'src/panel/layouts';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import { capitalizeFirst } from 'src/libs/string';
+import { boundsFromFlatArray, parseBboxString, boundsToString } from 'src/libs/bounds';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);
@@ -37,28 +38,22 @@ export default class CategoryPanel extends React.Component {
   componentDidMount() {
     this.updateSearchBarContent();
     this.mapMoveHandler = listen('map_moveend', this.fetchData);
-    window.execOnMapLoaded(() => { this.fitMapAndFetch(); });
+    window.execOnMapLoaded(() => { this.fitMap(); });
   }
 
   componentDidUpdate(prevProps) {
     this.updateSearchBarContent(prevProps);
-    const { bbox, poiFilters } = this.props;
 
     const panelContent = document.querySelector('.panel-content');
     if (panelContent) {
       panelContent.scrollTop = 0;
     }
 
-    // Check for a new, or changed poiFilter
-    for (const key in poiFilters) {
-      if (poiFilters[key] !== prevProps.poiFilters[key]) {
-        this.fetchData();
-        break;
-      }
-    }
-
-    if (bbox && bbox !== prevProps.bbox) {
-      window.execOnMapLoaded(() => { this.fitMapAndFetch(); });
+    if (JSON.stringify(prevProps.poiFilters) !== JSON.stringify(this.props.poiFilters)
+     || prevProps.bbox !== this.props.bbox) {
+      this.setState({ initialLoading: true }, () => {
+        window.execOnMapLoaded(() => { this.fitMap(); });
+      });
     }
   }
 
@@ -80,11 +75,10 @@ export default class CategoryPanel extends React.Component {
     unListen(this.mapMoveHandler);
   }
 
-  fitMapAndFetch() {
-    const rawBbox = (this.props.bbox || '').split(',');
-    const bbox = rawBbox.length === 4 && [[rawBbox[0], rawBbox[1]], [rawBbox[2], rawBbox[3]]];
-    if (bbox) {
-      window.map.mb.fitBounds(bbox, { animate: false });
+  fitMap() {
+    if (this.props.bbox) {
+      window.map.mb.fitBounds(parseBboxString(this.props.bbox), { animate: false });
+      return;
     }
 
     if (window.map.mb.isMoving()) {
@@ -104,26 +98,23 @@ export default class CategoryPanel extends React.Component {
       window.map.mb.flyTo({ center: [2.35, 48.85], zoom: 12 });
     } else if (currentZoom < 12) { // Zoom < 12: zoom up to zoom 12
       window.map.mb.flyTo({ zoom: 12 });
-    } else if (currentZoom > 16) { // Zoom > 16: dezoom to zoom 16
-      window.map.mb.flyTo({ zoom: 16 });
     } else {
-      this.fetchData();
+      // setting the same view still triggers the moveend event
+      window.map.mb.jumpTo({ zoom: currentZoom, center: window.map.mb.getCenter() });
     }
   }
 
   fetchData = async () => {
     const { category, query } = this.props.poiFilters;
-    const bbox = getVisibleBbox(window.map.mb);
+    const currentBounds = getVisibleBbox(window.map.mb);
 
-    const urlBBox = [bbox.getWest(), bbox.getSouth(), bbox.getEast(), bbox.getNorth()]
-      .map(cardinal => cardinal.toFixed(7))
-      .join(',');
-
-    const { places, source } = await IdunnPoi.poiCategoryLoad(
-      urlBBox,
+    const extendBBox = this.state.initialLoading;
+    const { places, source, bbox: contentBBox, bbox_extended } = await IdunnPoi.poiCategoryLoad(
+      boundsToString(currentBounds),
       MAX_PLACES,
       category,
-      query
+      query,
+      extendBBox
     );
 
     this.setState({
@@ -131,6 +122,12 @@ export default class CategoryPanel extends React.Component {
       dataSource: source,
       initialLoading: false,
     });
+
+    if (bbox_extended) {
+      // The returned bbox is sure to contain at least one POI.
+      // Extend the current one to include it.
+      window.map.mb.fitBounds(currentBounds.extend(boundsFromFlatArray(contentBBox)));
+    }
 
     fire('add_category_markers', places, this.props.poiFilters);
     fire('save_location');

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -125,7 +125,7 @@ export default class CategoryPanel extends React.Component {
       initialLoading: false,
     });
 
-    if (bbox_extended) {
+    if (bbox_extended && contentBbox) {
       // The returned bbox is sure to contain at least one POI.
       // Extend the current one to include it.
       fire('fit_map', currentBounds.extend(boundsFromFlatArray(contentBbox)), true);


### PR DESCRIPTION
*Alternative to https://github.com/QwantResearch/erdapfel/pull/675 with minimal changes, for easier review. I mixed far too many refacto with features in the other one…*

## Description

Allow the Idunn API call to take an `extend_bbox` parameter to use the auto BBOX extension feature introduced in https://github.com/QwantResearch/idunn/pull/146.
We use the bbox extension feature only when loading the first results of a category/query, not on subsequent map pans and zooms. This is to avoid changing the view when the user is interacting with the map. I re-used the `initialLoading` state as an indication of that.

## Why
Be more helpful to the user when no data is returned in the first place

## Screenshots
![Peek 22-06-2020 10-46](https://user-images.githubusercontent.com/243653/85269850-c6a50480-b478-11ea-9094-8aac9a885fbd.gif)