### PR TITLE
PoiCard: move mobile button on resize

### DIFF
--- a/src/panel/poi/PoiCard.jsx
+++ b/src/panel/poi/PoiCard.jsx
@@ -8,15 +8,23 @@ class PoiCard extends React.Component {
   constructor(props) {
     super(props);
     this.cardRef = React.createRef();
+    this.handleResize = this.handleResize.bind(this);
   }
 
   componentDidMount() {
-    window.execOnMapLoaded(() => {
-      fire(
-        'move_mobile_bottom_ui',
-        this.cardRef.current.offsetHeight + 10
-      );
-    });
+    window.execOnMapLoaded(this.handleResize);
+    addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    removeEventListener('resize', this.handleResize);
+  }
+
+  handleResize() {
+    fire(
+      'move_mobile_bottom_ui',
+      this.cardRef.current.offsetHeight + 10
+    );
   }
 
   render() {


### PR DESCRIPTION
Geolocate control was previously not resized when changing window's size. This caused some UX issues where the button would be under the poi's card.

![Peek 2020-06-22 18-06](https://user-images.githubusercontent.com/2981774/85309614-23bdac00-b4b3-11ea-8b35-e2d752f756c6.gif)
