### PR TITLE
telemetry: Do not trigger poi_category_open event on each map move

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -41,7 +41,7 @@ export default class CategoryPanel extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    this.updateSearchBarContent();
+    this.updateSearchBarContent(prevProps);
     const { bbox, poiFilters } = this.props;
 
     const panelContent = document.querySelector('.panel-content');
@@ -62,10 +62,12 @@ export default class CategoryPanel extends React.Component {
     }
   }
 
-  updateSearchBarContent() {
+  updateSearchBarContent(prevProps) {
     const { category, query } = this.props.poiFilters;
     if (category) {
-      Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
+      if (category !== prevProps?.poiFilters?.category) {
+        Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
+      }
       const { label } = CategoryService.getCategoryByName(category);
       SearchInput.setInputValue(capitalizeFirst(label));
     } else if (query) {


### PR DESCRIPTION
## Description
Since #636, the telemetry event `poi_category_open` is triggered on each `CategoryPanel` update, i.e after each map move.  

The meaning of this telemetry event is probably easier to grasp if this event is only sent when the `category` has changed.