### PR TITLE
QMAPS-1232: error message in the search/itinerary suggests list if it's empty

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -21,7 +21,7 @@ const Suggest = ({
   const [items, setItems] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [lastQuery, setLastQuery] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const isMobile = useContext(DeviceContext);
   let currentQuery = null;
 

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -22,6 +22,7 @@ const Suggest = ({
   const [isOpen, setIsOpen] = useState(false);
   const [lastQuery, setLastQuery] = useState('');
   const isMobile = useContext(DeviceContext);
+  let isLoading = false;
   let currentQuery = null;
 
   const close = () => {
@@ -52,6 +53,7 @@ const Suggest = ({
         currentQuery.abort();
       }
 
+      isLoading = true;
       const query = fetchSuggests(value, {
         withCategories,
       });
@@ -63,6 +65,7 @@ const Suggest = ({
         .then(items => {
           setItems(items);
           currentQuery = null;
+          isLoading = false;
         })
         .catch(() => { /* Query aborted. Just ignore silently */ });
     }, SUGGEST_DEBOUNCE_WAIT);
@@ -113,6 +116,7 @@ const Suggest = ({
       inputNode={inputNode}
       isAttachedToInput={!outputNode}
       suggestItems={items}
+      isLoading={isLoading}
       onHighlight={item => {
         if (!item) {
           inputNode.value = lastQuery;

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -21,8 +21,8 @@ const Suggest = ({
   const [items, setItems] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [lastQuery, setLastQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const isMobile = useContext(DeviceContext);
-  let isLoading = false;
   let currentQuery = null;
 
   const close = () => {
@@ -53,7 +53,7 @@ const Suggest = ({
         currentQuery.abort();
       }
 
-      isLoading = true;
+      setIsLoading(true);
       const query = fetchSuggests(value, {
         withCategories,
       });
@@ -65,7 +65,7 @@ const Suggest = ({
         .then(items => {
           setItems(items);
           currentQuery = null;
-          isLoading = false;
+          setIsLoading(false);
         })
         .catch(() => { /* Query aborted. Just ignore silently */ });
     }, SUGGEST_DEBOUNCE_WAIT);

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -100,12 +100,16 @@ const SuggestsDropdown = ({
           <SuggestItem item={suggest} />
         </li>
       )}
-      {suggestItems.length === 0 && inputNode.value !== '' &&
-        <li>
-          <div className="autocomplete_suggestion autocomplete_suggestion--no-result">
-            {_('No result found', 'suggest')}
-          </div>
-        </li>
+      {inputNode.value !== ''
+      && (
+        suggestItems.length === 0
+        || (suggestItems.length === 1 && suggestItems[0].id === 'geolocalisation')
+      )
+      && <li>
+        <div className="autocomplete_suggestion autocomplete_suggestion--no-result">
+          {_('No result found', 'suggest')}
+        </div>
+      </li>
       }
     </ul>
   );

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,3 +1,4 @@
+/* global _ */
 import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { object, func, string, arrayOf, bool } from 'prop-types';

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -100,6 +100,13 @@ const SuggestsDropdown = ({
           <SuggestItem item={suggest} />
         </li>
       )}
+      {suggestItems.length === 0 && inputNode.value !== '' &&
+        <li>
+          <div className="autocomplete_suggestion autocomplete_suggestion--no-result">
+            {_('No result found', 'suggest')}
+          </div>
+        </li>
+      }
     </ul>
   );
 };

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -10,6 +10,7 @@ const SuggestsDropdown = ({
   isAttachedToInput,
   className = '',
   suggestItems,
+  isLoading,
   onSelect,
   onHighlight,
 }) => {
@@ -102,6 +103,7 @@ const SuggestsDropdown = ({
         </li>
       )}
       {inputNode.value !== ''
+      && !isLoading
       && (
         suggestItems.length === 0
         || (suggestItems.length === 1 && suggestItems[0].id === 'geolocalisation')

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -148,6 +148,11 @@ input[type="search"] {
   line-height: 1.2;
   border-left: transparent solid 4px;
 
+  &--no-result {
+    font-style: italic;
+    padding: 15px 10px;
+  }
+
   .selected & {
     border-left-color: #FF3B4A;
     background-color: $background_active;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -149,7 +149,6 @@ input[type="search"] {
   border-left: transparent solid 4px;
 
   &--no-result {
-    font-style: italic;
     padding: 15px 10px;
   }
 

--- a/tests/__data__/autocomplete_empty.json
+++ b/tests/__data__/autocomplete_empty.json
@@ -1,0 +1,1 @@
+{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""},"intentions":[],"features":[]}

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -13,6 +13,7 @@ let autocompleteHelper;
 let responseHandler;
 const mockAutocomplete = require('../../__data__/autocomplete.json');
 const mockAutocompleteAllTypes = require('../../__data__/autocomplete_type.json');
+const mockAutocompleteEmpty = require('../../__data__/autocomplete_empty.json');
 const mockPoi = require('../../__data__/poi.json');
 
 beforeAll(async () => {
@@ -45,8 +46,9 @@ test('search and clear', async () => {
 });
 
 test('search with no suggest', async () => {
+  responseHandler.addPreparedResponse(mockAutocompleteEmpty, /autocomplete\?q=Goodbye/);
   await page.goto(APP_URL);
-  await autocompleteHelper.typeAndWait('No result');
+  await autocompleteHelper.typeAndWait('Goodbye');
   await page.waitForSelector('.autocomplete_suggestion--no-result');
 });
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -29,7 +29,6 @@ beforeEach(async () => {
 
 test('search and clear', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
-  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Helloa/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Hello');
   expect(await exists(page, '#clear_button')).toBeTruthy();

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -252,8 +252,7 @@ test('suggestions should not reappear after fast submit', async () => {
   await page.keyboard.type('paris');
   await page.keyboard.press('Enter');
   await page.waitFor(600);
-  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
-  expect(await exists(page, '.autocomplete_suggestions')).toBeFalsy();
+  expect(await page.waitForSelector('.autocomplete_suggestions', { hidden: true })).toBeTruthy();
 });
 
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -252,7 +252,7 @@ test('suggestions should not reappear after fast submit', async () => {
   await page.keyboard.type('paris');
   await page.keyboard.press('Enter');
   await page.waitFor(600);
-  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
+  expect(await exists(page, '.autocomplete_suggestions')).toBeFalsy();
 });
 
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -49,7 +49,7 @@ test('search with no suggest', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteEmpty, /autocomplete\?q=Goodbye/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Goodbye');
-  await page.waitForSelector('.autocomplete_suggestion--no-result');
+  expect(await exists(page, '.autocomplete_suggestion--no-result')).toBeTruthy();
 });
 
 test('search has lang in query', async () => {

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -44,6 +44,12 @@ test('search and clear', async () => {
   expect(searchValueAfterClear).toEqual('');
 });
 
+test('search with no suggest', async () => {
+  await page.goto(APP_URL);
+  await autocompleteHelper.typeAndWait('No result');
+  await page.waitForSelector('.autocomplete_suggestion--no-result');
+});
+
 test('search has lang in query', async () => {
   const langPage = await browser.newPage();
   await langPage.setDefaultTimeout(2000); // to raise Puppeteer timeout early on fail

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -34,6 +34,7 @@ test('search and clear', async () => {
   await autocompleteHelper.typeAndWait('Hello');
   expect(await exists(page, '#clear_button')).toBeTruthy();
 
+  await page.waitForSelector('.autocomplete_suggestion--no-result', { hidden: true, timeout: 100 });
   const autocompleteItems = await autocompleteHelper.getSuggestList();
   expect(autocompleteItems.length).toEqual(SUGGEST_MAX_ITEMS);
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -44,6 +44,14 @@ test('search and clear', async () => {
   expect(searchValueAfterClear).toEqual('');
 });
 
+test('search with no suggest', async () => {
+  await page.goto(APP_URL);
+  await autocompleteHelper.typeAndWait('No result');
+
+  const autocompleteItems = await autocompleteHelper.getSuggestList();
+  expect(autocompleteItems.length).toEqual(0);
+});
+
 test('search has lang in query', async () => {
   const langPage = await browser.newPage();
   await langPage.setDefaultTimeout(2000); // to raise Puppeteer timeout early on fail

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -34,7 +34,6 @@ test('search and clear', async () => {
   await autocompleteHelper.typeAndWait('Hello');
   expect(await exists(page, '#clear_button')).toBeTruthy();
 
-  await page.waitForSelector('.autocomplete_suggestion--no-result', { hidden: true, timeout: 100 });
   const autocompleteItems = await autocompleteHelper.getSuggestList();
   expect(autocompleteItems.length).toEqual(SUGGEST_MAX_ITEMS);
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -252,6 +252,7 @@ test('suggestions should not reappear after fast submit', async () => {
   await page.keyboard.type('paris');
   await page.keyboard.press('Enter');
   await page.waitFor(600);
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
   expect(await exists(page, '.autocomplete_suggestions')).toBeFalsy();
 });
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -47,9 +47,7 @@ test('search and clear', async () => {
 test('search with no suggest', async () => {
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('No result');
-
-  const autocompleteItems = await autocompleteHelper.getSuggestList();
-  expect(autocompleteItems.length).toEqual(0);
+  await page.waitForSelector('.autocomplete_suggestion--no-result');
 });
 
 test('search has lang in query', async () => {

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -252,7 +252,7 @@ test('suggestions should not reappear after fast submit', async () => {
   await page.keyboard.type('paris');
   await page.keyboard.press('Enter');
   await page.waitFor(600);
-  expect(await page.waitForSelector('.autocomplete_suggestions', { hidden: true })).toBeTruthy();
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
 });
 
 

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -44,12 +44,6 @@ test('search and clear', async () => {
   expect(searchValueAfterClear).toEqual('');
 });
 
-test('search with no suggest', async () => {
-  await page.goto(APP_URL);
-  await autocompleteHelper.typeAndWait('No result');
-  await page.waitForSelector('.autocomplete_suggestion--no-result');
-});
-
 test('search has lang in query', async () => {
   const langPage = await browser.newPage();
   await langPage.setDefaultTimeout(2000); // to raise Puppeteer timeout early on fail


### PR DESCRIPTION
## Description
Use the message: "No result found" / "Aucun résultat trouvé" when the suggest list is empty.
(in Directions panel, empty means there's only 1 item: "Your position", that is always visible)

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/85422061-72cc1580-b575-11ea-9bb4-d49808fee7c5.png)

![image](https://user-images.githubusercontent.com/1225909/85422132-87a8a900-b575-11ea-8412-db42e860f541.png)
