### PR TITLE
Prevent losing focus when clearing suggests fields

### DIFF
--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -81,13 +81,12 @@ class DirectionInput extends React.Component {
     }
   }
 
-  focus = () => {
-    setTimeout(() => { this.props.inputRef.current.focus(); }, 0);
-  }
-
-  clear = () => {
+  clear = e => {
+    e.preventDefault(); // prevent losing focus
     this.props.onChangePoint('', null);
-    this.focus();
+    this.props.inputRef.current.value = '';
+    // Trigger an input event to refresh Suggest's state
+    this.props.inputRef.current.dispatchEvent(new Event('input'));
   }
 
   render() {

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -28,16 +28,19 @@ export default class SearchInput {
 
     window.__searchInput = new SearchInput(tagSelector);
 
-    window.clearSearch = () => {
+    window.clearSearch = e => {
+      e.preventDefault(); // Prevent losing focus
+      const inputElement = document.querySelector(tagSelector);
       const isMobile = isMobileDevice();
-      const isActive = document.activeElement.id === window.__searchInput.searchInputHandle.id;
-      window.__searchInput.searchInputHandle.value = '';
-      window.app.navigateTo('/');
+      const isActive = document.activeElement.id === inputElement.id;
+      inputElement.value = '';
+
       if (!isMobile || isMobile && isActive) {
-        setTimeout(() => {
-          document.querySelector(tagSelector).focus();
-        }, 0);
+        // Trigger an input event to refresh Suggest's state
+        inputElement.dispatchEvent(new Event('input'));
       }
+
+      window.app.navigateTo('/');
     };
 
     window.submitSearch = () => {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,7 +43,7 @@
         <% } %> >
         <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
         <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">
-        <button id="clear_button" class="search_form__clear icon-x" type="button" onmousedown="clearSearch()"></button>
+        <button id="clear_button" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
         <span class="search_form__logo"></span>
         <div class="main_field_return"><span class="icon-arrow-left"></span></div>
       </form><!-- no whitespace


### PR DESCRIPTION
## Description
Prevent losing focus when clearing suggests fields with `preventDefault()`, on both top search bar, and direction fields.

## Why
This fixes the "flickering" effect when clearing an autocomplete field, while keeping the actual mobile behavior : The top search field is re-focused only if the input is currently focused.

## Screenshots
![clear autocomplete fields](https://user-images.githubusercontent.com/2981774/85860840-aa2e0280-b7bf-11ea-97cd-f8519f3b09c0.gif)


