### PR TITLE
Load .env with dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ bench/report.json
 bench/results.har
 
 stats.json
+
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ system:
   timeout: 5
 ```
 
-is overriden by `TILEVIEW_system_timeout=3`
+**Loading .env file**
+
+You can define your environment variables within a `.env` file, at the root directory of the project. Define you env variables inside this file, they will be loaded when starting erdapfel.
 
 
 ### Run from sources

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,6 @@
 /* globals require */
 
+require('dotenv').config();
 const configBuilt = require('@qwant/nconf-builder');
 const App = require('./app');
 const config = configBuilt.get();

--- a/package-lock.json
+++ b/package-lock.json
@@ -7741,6 +7741,11 @@
         "domelementtype": "1"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "dtrace-provider": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "classnames": "^2.2.6",
     "color": "^3.1.2",
     "compression": "^1.7.3",
+    "dotenv": "^8.2.0",
     "ejs": "^2.6.1",
     "express": "^4.16.3",
     "express-static-gzip": "^1.1.3",


### PR DESCRIPTION
## Description
Load environment file `.env` with `dotenv` (https://github.com/motdotla/dotenv#readme).

## Why
Simplify starting the app (`npm start` script) without having to export environment variables manually.
Simplify .env using syntax like
```sh
TILEVIEW_mapStyle_poiMapUrl=["https://tileserver/maps/tiles/ozpoi/{z}/{x}/{y}.pbf"]
```