### PR TITLE
Qmaps 1599 - Fix markers

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -17,6 +17,7 @@ import { parseMapHash, getMapHash } from 'src/libs/url_utils';
 import { toUrl, getBestZoom } from 'src/libs/pois';
 import Error from 'src/adapters/error';
 import { fire, listen } from 'src/libs/customEvents';
+import { isNullOrEmpty } from 'src/libs/object';
 import locale from '../mapbox/locale';
 
 const baseUrl = nconf.get().system.baseUrl;
@@ -167,7 +168,11 @@ Scene.prototype.initMapBox = function() {
 
   listen('map_mark_poi', (poi, options) => {
     this.ensureMarkerIsVisible(poi, options);
-    this.addMarker(poi, options);
+    // The presence of poiFilters mean we are in the context of a list of POIs
+    // where we don't need to create a new icon as it already exists
+    if (isNullOrEmpty(options.poiFilters)) {
+      this.addMarker(poi, options);
+    }
   });
 
   listen('clean_marker', () => {
@@ -328,15 +333,6 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
 };
 
 Scene.prototype.addMarker = function(poi) {
-  if (this.currentMarker) {
-    // Prevent setting the same poi multiple times
-    const currentLngLat = this.currentMarker.getLngLat();
-    if (currentLngLat.lat === poi.latLon.lat &&
-        currentLngLat.lon === poi.latLon.lon) {
-      return;
-    }
-  }
-
   const type = poi.type;
 
   // Create a default marker (white circle on red background) when the PoI is clicked.

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -60,7 +60,7 @@ export default class SceneCategory {
         poi.marker_id = `marker_${id}`;
         marker.onclick = function(e) {
           e.stopPropagation();
-          fire('click_category_poi', { poi, poiFilters });
+          fire('click_category_poi', { poi, poiFilters, pois });
         };
         marker.onmouseover = function(e) {
           fire('open_popup', poi, e);

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -20,12 +20,12 @@ export default class SceneCategory {
     listen('highlight_category_marker', (poi, highlight) => {
       this.highlightPoiMarker(poi, highlight);
     });
-    listen('click_category_poi', (poi, poiFilters) => {
-      this.selectPoi(poi, poiFilters);
+    listen('click_category_poi', state => {
+      this.selectPoi(state);
     });
   }
 
-  selectPoi = (poi, poiFilters) => {
+  selectPoi = ({ poi, poiFilters, pois }) => {
     const previousMarker = document.querySelector('.mapboxgl-marker.active');
     if (previousMarker) {
       previousMarker.classList.remove('active');
@@ -45,6 +45,7 @@ export default class SceneCategory {
     window.app.navigateTo(`/place/${toUrl(poi)}`, {
       poi,
       poiFilters,
+      pois,
       centerMap: true,
     });
     this.highlightPoiMarker(poi, true);
@@ -59,7 +60,7 @@ export default class SceneCategory {
         poi.marker_id = `marker_${id}`;
         marker.onclick = function(e) {
           e.stopPropagation();
-          fire('click_category_poi', poi, poiFilters);
+          fire('click_category_poi', { poi, poiFilters });
         };
         marker.onmouseover = function(e) {
           fire('open_popup', poi, e);

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -139,7 +139,7 @@ export default class PanelManager extends React.Component {
     });
 
     // Route the initial URL
-    return router.routeUrl(getCurrentUrl());
+    return router.routeUrl(getCurrentUrl(), window.history.state || {});
   }
 
   toggleMinify = () => {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -141,7 +141,8 @@ export default class CategoryPanel extends React.Component {
 
   selectPoi = poi => {
     const { poiFilters } = this.props;
-    fire('click_category_poi', poi, poiFilters);
+    const { pois } = this.state;
+    fire('click_category_poi', { poi, poiFilters, pois });
   }
 
   highlightPoiMarker = (poi, highlight) => {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -208,10 +208,6 @@ export default class DirectionPanel extends React.Component {
   onClose = () => {
     if (this.state.activePreviewRoute) {
       this.setState({ activePreviewRoute: null });
-    } else if (this.props.poi) {
-      // indicates we come from a POI panel,
-      // let's just trust the router to restore it
-      window.history.back();
     } else {
       window.app.navigateTo('/');
     }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -60,7 +60,10 @@ export default class PoiPanel extends React.Component {
 
   componentDidMount() {
     fire('mobile_direction_button_visibility', false);
-    this.loadPoi();
+
+    // Load poi or pois
+    !this.props.pois ? this.loadPoi() : this.loadPois();
+
     this.storeAddHandler = listen('poi_added_to_favs', poi => {
       if (poi === this.state.fullPoi) {
         this.setState({ isPoiInFavorite: true });
@@ -87,6 +90,14 @@ export default class PoiPanel extends React.Component {
     fire('clean_marker');
     fire('mobile_direction_button_visibility', true);
     SearchInput.setInputValue('');
+  }
+
+  loadPois = () => {
+    const { poi, poiFilters, pois } = this.props;
+    window.execOnMapLoaded(() => {
+      fire('add_category_markers', this.props.pois, this.props.poiFilters);
+      fire('click_category_poi', { poi, poiFilters, pois });
+    });
   }
 
   loadPoi = async () => {
@@ -131,7 +142,7 @@ export default class PoiPanel extends React.Component {
   }
 
   _updateMapPoi(poi, options = {}) {
-    window.execOnMapLoaded(function() {
+    window.execOnMapLoaded(() => {
       fire('map_mark_poi', poi, options);
     });
   }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -93,10 +93,10 @@ export default class PoiPanel extends React.Component {
   }
 
   loadPois = () => {
-    const { poi, poiFilters, pois } = this.props;
+    const { poi } = this.props;
     window.execOnMapLoaded(() => {
       fire('add_category_markers', this.props.pois, this.props.poiFilters);
-      fire('click_category_poi', { poi, poiFilters, pois });
+      fire('highlight_category_marker', poi, true);
     });
   }
 


### PR DESCRIPTION
## Description
* Add a precondition to avoid setting same poi marker multiple times
* When closing DirectionPanel, go to `/` route, ignoring a previously selected poi.
* Reload categories pois and poiFilters from `history.state` when refeshing app.

When closing directionPanel, expected behavior is now to go back to the default panel.
