### PR TITLE
Telemetry: fix "itinerary_share" sent from route results and favorites

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -26,18 +26,17 @@ module.exports = {
     'poi_backtolist',
     'poi_restore',
     'poi_see_more',
+    'poi_share',
     /* OSM */
     'poi_osm_open',
     'poi_osm_go',
     'poi_osm_favorite', // Favorite toggle
-    'poi_osm_share',
     'poi_osm_phone',
     'poi_osm_website',
     /* Pages Jaunes Poi */
     'poi_pages_jaunes_open',
     'poi_pages_jaunes_go',
     'poi_pages_jaunes_favorite', // Favorite toggle
-    'poi_pages_jaunes_share',
     'poi_pages_jaunes_phone',
     'poi_pages_jaunes_website',
     'poi_pages_jaunes_reviews',

--- a/src/components/ui/ShareMenu.jsx
+++ b/src/components/ui/ShareMenu.jsx
@@ -1,7 +1,6 @@
 /* global _ */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Telemetry from '../../libs/telemetry';
 
 const facebookShareUrl = location => {
   return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(location)}`;
@@ -53,7 +52,6 @@ export default class ShareMenu extends React.Component {
     document.addEventListener('click', this.close);
     (document.querySelector(this.props.scrollableParent) || document.body)
       .addEventListener('scroll', this.close);
-    Telemetry.add(Telemetry.ITINERARY_SHARE);
   }
 
   close = () => {

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -5,6 +5,8 @@ import { formatDuration, formatDistance, getVehicleIcon } from 'src/libs/route_u
 import RouteVia from './RouteVia';
 import Button from 'src/components/ui/Button';
 import ShareMenu from 'src/components/ui/ShareMenu';
+import Telemetry from 'src/libs/telemetry';
+
 
 export default class RouteSummary extends React.Component {
   static propTypes = {
@@ -27,6 +29,11 @@ export default class RouteSummary extends React.Component {
 
   onClickPreview = () => {
     this.props.openPreview(this.props.id);
+  }
+
+  onShareClick = (e, handler) => {
+    Telemetry.add(Telemetry.ITINERARY_SHARE);
+    return handler(e);
   }
 
   render() {
@@ -53,7 +60,7 @@ export default class RouteSummary extends React.Component {
         {openMenu => <div
           className="itinerary_panel__item__share"
           title={_('Share', 'direction')}
-          onClick={openMenu}
+          onClick={e => this.onShareClick(e, openMenu)}
         >
           <i className="icon-share-2" />
         </div>}
@@ -63,7 +70,11 @@ export default class RouteSummary extends React.Component {
           {_('Details', 'direction')}
         </Button>
         <ShareMenu url={window.location.toString()} scrollableParent=".panel-content">
-          {openMenu => <Button title={_('Share', 'direction')} onClick={openMenu} icon="share-2" />}
+          {openMenu => <Button
+            title={_('Share', 'direction')}
+            onClick={e => this.onShareClick(e, openMenu)}
+            icon="share-2"
+          />}
         </ShareMenu>
       </div>
     </div>;

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -27,6 +27,11 @@ export default class FavoritePoi extends React.Component {
     this.props.removeFavorite(this.props.poi);
   };
 
+  onShareClick = (e, handler) => {
+    Telemetry.add(Telemetry.FAVORITE_SHARE);
+    return handler(e);
+  }
+
   render() {
     const { poi } = this.props;
     const icon = IconManager.get(poi);
@@ -49,7 +54,11 @@ export default class FavoritePoi extends React.Component {
       </div>
       <ShareMenu url={toAbsoluteUrl(this.props.poi)} scrollableParent=".panel-content">
         {openMenu =>
-          <div className="favorite_panel__item__share" title={_('Share')} onClick={openMenu}>
+          <div
+            className="favorite_panel__item__share"
+            title={_('Share')}
+            onClick={e => this.onShareClick(e, openMenu)}
+          >
             <i className="icon-share-2" />
           </div>}
       </ShareMenu>

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -1,6 +1,7 @@
 /* globals _ */
 import React from 'react';
 import PropTypes from 'prop-types';
+import Telemetry from 'src/libs/telemetry';
 import { Flex, ShareMenu, Button } from 'src/components/ui';
 
 const ActionButtons = ({
@@ -11,6 +12,11 @@ const ActionButtons = ({
   isPoiInFavorite,
   toggleStorePoi,
 }) => {
+  const onShareClick = (e, handler) => {
+    Telemetry.add(Telemetry.POI_SHARE);
+    return handler(e);
+  };
+
   return <Flex className="u-mb-24 poi_panel__actions">
     {isDirectionActive && <Button
       className="poi_panel__action__direction"
@@ -44,7 +50,7 @@ const ActionButtons = ({
       {openMenu => <Button className="poi_panel__action__share"
         title={_('Share', 'poi panel')}
         icon="share-2"
-        onClick={openMenu}
+        onClick={e => onShareClick(e, openMenu)}
       />}
     </ShareMenu>
   </Flex>;


### PR DESCRIPTION
## Description
After recent refactoring in #663, the "itinerary_share" event was sent from the ShareMenu component.

This PR defines a wrapper on the click handler to trigger a specific telemetry event in each context where the share menu is used.