### PR TITLE
Telemetry: add metadata about URL params on "app_start" and "suggest_selection" events

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -3,7 +3,7 @@ module.exports = {
     /* App */
     'app_start',
     /* Suggest*/
-    'suggest_click',
+    'suggest_selection',
     /* Favorite */
     'favorite_open',
     'favorite_close',

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -15,7 +15,7 @@ const SUGGEST_MAX_ITEMS = geocoderConfig.maxItems;
 const SUGGEST_USE_FOCUS = geocoderConfig.useFocus;
 const SUGGEST_FOCUS_MIN_ZOOM = 11;
 
-export const selectItem = (selectedItem, replaceUrl = false) => {
+export const selectItem = (selectedItem, { replaceUrl = false, fromQueryParams } = {}) => {
   if (selectedItem instanceof Poi) {
     window.app.navigateTo(`/place/${toUrl(selectedItem)}`, {
       poi: selectedItem,
@@ -26,14 +26,16 @@ export const selectItem = (selectedItem, replaceUrl = false) => {
       {}, { replace: replaceUrl });
   } else if (selectedItem instanceof Intention) {
     Telemetry.add(
-      Telemetry.SUGGEST_CLICK,
+      Telemetry.SUGGEST_SELECTION,
       null,
       null,
       {
-        useNlu: geocoderConfig.useNlu,
+        item: 'intention',
         category: selectedItem.category ? selectedItem.category.name : null,
-        hasFullTextQuery: !!selectedItem.fullTextQuery,
-        hasPlace: !!selectedItem.place,
+        has_full_text_query: !!selectedItem.fullTextQuery,
+        has_place: !!selectedItem.place,
+        from_url_query: !!fromQueryParams?.q,
+        url_client: fromQueryParams?.client || null,
       }
     );
     window.app.navigateTo(`/places/${selectedItem.toQueryString()}`,

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -2,10 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SearchInput from '../ui_components/search_input';
 import nconf from '@qwant/nconf-getter';
-import Telemetry from '../libs/telemetry';
 import Router from 'src/proxies/app_router';
 import { parseMapHash, joinPath, getCurrentUrl } from 'src/libs/url_utils';
-import { isMobileDevice } from 'src/libs/device';
 import { listen } from 'src/libs/customEvents';
 import RootComponent from './RootComponent';
 
@@ -21,11 +19,6 @@ export default class App {
     this.initMap();
 
     SearchInput.initSearchInput('#search');
-
-    Telemetry.add(Telemetry.APP_START, null, null, {
-      'language': window.getLang(),
-      'is_mobile': isMobileDevice(),
-    });
     if (performanceEnabled) {
       listen('map_loaded', () => { window.times.mapLoaded = Date.now(); });
     }

--- a/src/proxies/app_router.js
+++ b/src/proxies/app_router.js
@@ -35,5 +35,6 @@ export default class Router {
       return;
     }
     applyRoute(routeDef, urlWithoutHash, state);
+    return routeDef;
   }
 }

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -90,12 +90,12 @@ export default class SearchInput {
     };
   }
 
-  static async executeSearch(query) {
+  static async executeSearch(query, { fromQueryParams } = {}) {
     window.__searchInput.searchInputHandle.value = query;
     const results = await fetchSuggests(query, { withCategories: true });
     if (results && results.length > 0) {
       const firstResult = results[0];
-      selectItem(firstResult, true);
+      selectItem(firstResult, { replaceUrl: true, fromQueryParams });
       window.__searchInput.searchInputHandle.blur();
     }
   }


### PR DESCRIPTION
## Description

* Rename "suggest_click" to "suggest_selection" for clarification (the item may be selected automatically from the URL without user action)
* Move "app_start" trigger to PanelManager `componentDidMount` to access the initialRoute used by the app
* Standardize telemetry metadata to use snake_case keys
* Add fields with context extracted from the URL