### PR TITLE
suggest: Fix input value for intention and category during keyboard navigation

### DIFF
--- a/src/adapters/category.js
+++ b/src/adapters/category.js
@@ -4,7 +4,7 @@
  * Simple Category helper
  */
 import IconManager from '../adapters/icon_manager';
-import { findIndexIgnoreCase } from '../libs/string';
+import { findIndexIgnoreCase, capitalizeFirst } from '../libs/string';
 import { CATEGORY_TYPE } from '../../config/constants.yml';
 
 export default class Category {
@@ -21,7 +21,7 @@ export default class Category {
   }
 
   getInputValue() {
-    return this.label;
+    return capitalizeFirst(this.label);
   }
 
   isMatching(term) {

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 import { bool, string, func, object } from 'prop-types';
 
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
-import { fetchSuggests, selectItem, modifyList } from 'src/libs/suggest';
+import { fetchSuggests, getInputValue, selectItem, modifyList } from 'src/libs/suggest';
 import { DeviceContext } from 'src/libs/device';
 
 const SUGGEST_DEBOUNCE_WAIT = 100;
@@ -121,11 +121,11 @@ const Suggest = ({
         if (!item) {
           inputNode.value = lastQuery;
         } else {
-          inputNode.value = item.name;
+          inputNode.value = getInputValue(item);
         }
       }}
       onSelect={item => {
-        inputNode.value = item.name;
+        inputNode.value = getInputValue(item);
         close();
         if (onSelect) {
           onSelect(item);

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -43,6 +43,22 @@ export const selectItem = (selectedItem, { replaceUrl = false, fromQueryParams }
   }
 };
 
+export const getInputValue = item => {
+  if (item instanceof Poi) {
+    return item.name;
+  }
+  if (item instanceof Category) {
+    return item.getInputValue();
+  }
+  if (item instanceof Intention) {
+    if (item.category) {
+      return item.category.getInputValue();
+    }
+    return item.fullTextQuery;
+  }
+  return '';
+};
+
 export const fetchSuggests = (query, options = {}) =>
   suggestResults(query, {
     withCategories: options.withCategories || false,

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -13,7 +13,6 @@ import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import CategoryService from 'src/adapters/category_service';
 import { getVisibleBbox } from 'src/panel/layouts';
 import { fire, listen, unListen } from 'src/libs/customEvents';
-import { capitalizeFirst } from 'src/libs/string';
 import { boundsFromFlatArray, parseBboxString, boundsToString } from 'src/libs/bounds';
 
 const categoryConfig = nconf.get().category;
@@ -63,8 +62,10 @@ export default class CategoryPanel extends React.Component {
       if (category !== prevProps?.poiFilters?.category) {
         Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
       }
-      const { label } = CategoryService.getCategoryByName(category);
-      SearchInput.setInputValue(capitalizeFirst(label));
+      const value = CategoryService.getCategoryByName(category)?.getInputValue();
+      if (value) {
+        SearchInput.setInputValue(value);
+      }
     } else if (query) {
       SearchInput.setInputValue(query);
     }


### PR DESCRIPTION
## Why
`item.name` was hardcoded to be set as the input value for highlighted elements.  
This property exists for `Poi` items but is not correct for `Category` and `Intention` items.

This PR suggests to use a new function `getInputValue` defined in "libs/suggest.js" to handle all cases, similarly to how `selectItem` is currently defined.

