### PR TITLE
Handle no result in suggest like a simpleLabel

### DIFF
--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,33 +1,46 @@
-/* global _ */
 import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { object, func, string, arrayOf, bool } from 'prop-types';
 
 import SuggestItem from './SuggestItem';
 
+const computeStyle = (isAttachedToInput, inputNode, suggestItems) => {
+  let style = {};
+
+  if (isAttachedToInput) {
+    // In case no output node is specified,
+    // suggestions are rendered just below inputNode
+    const boundingRect = inputNode.getBoundingClientRect();
+    style = {
+      ...style,
+      position: 'fixed',
+      top: boundingRect.bottom,
+      left: boundingRect.left,
+      width: boundingRect.width,
+    };
+  }
+
+  if (suggestItems.length > 0 && suggestItems[suggestItems.length - 1].simpleLabel) {
+    // Revove bottom padding if last item is a simple label (no results)
+    style = {
+      ...style,
+      paddingBottom: 0,
+    };
+  }
+
+  return style;
+};
+
 const SuggestsDropdown = ({
   inputNode,
   isAttachedToInput,
   className = '',
   suggestItems,
-  isLoading,
   onSelect,
   onHighlight,
 }) => {
   const [highlighted, setHighlighted] = useState(null);
-  const style = !isAttachedToInput
-    ? {}
-    : (() => {
-      // In case no output node is specified,
-      // suggestions are render just below inputNode
-      const boundingRect = inputNode.getBoundingClientRect();
-      return {
-        position: 'fixed',
-        top: boundingRect.bottom,
-        left: boundingRect.left,
-        width: boundingRect.width,
-      };
-    })();
+  const style = computeStyle(isAttachedToInput, inputNode, suggestItems);
 
   useEffect(() => {
     const keyDownHandler = e => {
@@ -103,18 +116,6 @@ const SuggestsDropdown = ({
           <SuggestItem item={suggest} />
         </li>
       )}
-      {inputNode.value !== ''
-      && !isLoading
-      && (
-        suggestItems.length === 0
-        || (suggestItems.length === 1 && suggestItems[0].id === 'geolocalisation')
-      )
-      && <li>
-        <div className="autocomplete_suggestion autocomplete_suggestion--no-result">
-          {_('No result found', 'suggest')}
-        </div>
-      </li>
-      }
     </ul>
   );
 };

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -71,12 +71,16 @@ export const fetchSuggests = (query, options = {}) =>
 export const modifyList = (items, withGeoloc) => {
   const firstFav = items.findIndex(item => item instanceof PoiStore);
 
-  if (firstFav !== -1) {
+  if (firstFav > -1) {
     items.splice(firstFav, 0, { simpleLabel: _('Favorites', 'autocomplete').toUpperCase() });
   }
 
   if (withGeoloc) {
     items.splice(0, 0, NavigatorGeolocalisationPoi.getInstance());
+  }
+
+  if (items.length === 0 || items.length === 1 && withGeoloc) {
+    items.push({ simpleLabel: _('No result found', 'suggest').toUpperCase() });
   }
 
   return items;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -179,10 +179,6 @@ input[type="search"] {
   line-height: 1.2;
   border-left: transparent solid 4px;
 
-  &--no-result {
-    padding: 15px 10px;
-  }
-
   .selected & {
     border-left-color: #FF3B4A;
     background-color: $background_active;

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -49,7 +49,10 @@ test('search with no suggest', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteEmpty, /autocomplete\?q=Goodbye/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Goodbye');
-  expect(await exists(page, '.autocomplete_suggestion--no-result')).toBeTruthy();
+  const title = await page.evaluate(() => {
+    return document.querySelector('.autocomplete_separator_label').innerText;
+  });
+  expect(title).toEqual('NO RESULT FOUND');
 });
 
 test('search has lang in query', async () => {


### PR DESCRIPTION
## Description
Handle no result case like a `simpleLabel`, which is the way we currently renders `favorites` in suggestions.

## Why
Extra `padding-bottom` exists with the new design and should be removed whend there is no results
mouse hover is uneeded
Code should be easier to maintain

## Screenshots

Before | After
--- | ---
![Peek 2020-07-06 16-32_1](https://user-images.githubusercontent.com/2981774/86605022-719fdd00-bfa6-11ea-8398-aa84e87abbfc.gif) | ![Peek 2020-07-06 16-28_2](https://user-images.githubusercontent.com/2981774/86604586-d9a1f380-bfa5-11ea-846b-6055e1c28ce3.gif)

