### PR TITLE
Fix: restore panel visibility when coming back from routes

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -17,6 +17,7 @@ const Suggest = ({
   withGeoloc,
   onSelect = selectItem,
   onClear,
+  hidePanelOnOpen,
   className,
 }) => {
   const [items, setItems] = useState([]);
@@ -32,7 +33,9 @@ const Suggest = ({
   };
 
   useEffect(() => {
-    togglePanelVisibility(!isOpen);
+    if (hidePanelOnOpen) {
+      togglePanelVisibility(!isOpen);
+    }
   }, [isOpen]);
 
   useEffect(() => {
@@ -151,6 +154,7 @@ Suggest.propTypes = {
   withGeoloc: bool,
   onSelect: func,
   onClear: func,
+  hidePanelOnOpen: bool,
   className: string,
 };
 

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -40,6 +40,7 @@ const RootComponent = ({
       inputNode={searchBarInputNode}
       outputNode={document.querySelector('.search_form__result')}
       withCategories
+      hidePanelOnOpen
     />
   </DeviceContext.Provider>;
 };


### PR DESCRIPTION
## Description
Fix the bug where the previous panel is not restored when navigating back from the routes panel.

Cause: the direction panel uses two instances of the `<Suggest>` components, that had the behavior of hiding the main panel, which should be used only for the top bar suggest. Introduce a bool prop on `<Suggest>` to activate this behavior conditionnaly.