### PR TITLE
[Clean-up] Remove setting to disable categories

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -84,7 +84,6 @@ direction:
     enabled: false
 
 category:
-  enabled: false
   maxPlaces: 40
 
 events:

--- a/src/adapters/category_service.js
+++ b/src/adapters/category_service.js
@@ -1,15 +1,10 @@
 import Category from './category';
-import nconf from '@qwant/nconf-getter';
 import categories from 'config/categories.yml';
 import { normalize } from '../libs/string';
 
 export default class CategoryService {
 
   static getCategories() {
-    if (!nconf.get().category.enabled) {
-      return [];
-    }
-
     if (!window.__categoriesCache) {
       window.__categoriesCache = categories.map(categ => Category.create(categ));
     }

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -14,7 +14,6 @@ import { isNullOrEmpty } from 'src/libs/object';
 import { isMobileDevice } from 'src/libs/device';
 
 const performanceEnabled = nconf.get().performance.enabled;
-const categoryEnabled = nconf.get().category.enabled;
 const directionConf = nconf.get().direction;
 
 const directSearchRouteName = 'Direct search query';
@@ -66,21 +65,19 @@ export default class PanelManager extends React.Component {
   initRouter() {
     const router = this.props.router;
 
-    if (categoryEnabled) {
-      router.addRoute('Category', '/places/(.*)', placesParams => {
-        const { type: category, q: query, ...otherOptions } = parseQueryString(placesParams);
-        this.setState({
-          ActivePanel: CategoryPanel,
-          options: {
-            poiFilters: {
-              category,
-              query,
-            },
-            ...otherOptions,
+    router.addRoute('Category', '/places/(.*)', placesParams => {
+      const { type: category, q: query, ...otherOptions } = parseQueryString(placesParams);
+      this.setState({
+        ActivePanel: CategoryPanel,
+        options: {
+          poiFilters: {
+            category,
+            query,
           },
-        });
+          ...otherOptions,
+        },
       });
-    }
+    });
 
     router.addRoute('POI', '/place/(.*)', async (poiUrl, options = {}) => {
       const poiId = poiUrl.split('@')[0];

--- a/tests/integration/test_config.js
+++ b/tests/integration/test_config.js
@@ -8,7 +8,6 @@ config.services.idunn.url = 'http://idunn_test.test';
 config.services.geocoder.url = 'http://geocoder.test/autocomplete';
 config.direction.enabled = true;
 config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox format
-config.category.enabled = true;
 config.events.enabled = true;
 config.masq.enabled = false;
 config.system.baseUrl = '/maps/';


### PR DESCRIPTION
## Description
Remove the config setting to disable categories and the remaining checks of it.

## Why
 - We have no plans and no designs for an app without categories.
 - Some important parts of the app (ex: ServicePanel) already assume categories are always enabled, so this makes no sense to test the setting only in some places.