### PR TITLE
Qmaps 1232 no suggest error message (fix)

### DIFF
--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -71,9 +71,18 @@ const SeparatorLabel = ({ label }) =>
     {label}
   </h3>;
 
+const ErrorLabel = ({ label }) =>
+  <div className="autocomplete_error">
+    {label}
+  </div>;
+
 const SuggestItem = ({ item }) => {
   if (item.simpleLabel) {
     return <SeparatorLabel label={item.simpleLabel} />;
+  }
+
+  if (item.errorLabel) {
+    return <ErrorLabel label={item.errorLabel} />;
   }
 
   if (item instanceof NavigatorGeolocalisationPoi) {

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -80,7 +80,7 @@ export const modifyList = (items, withGeoloc) => {
   }
 
   if (items.length === 0 || items.length === 1 && withGeoloc) {
-    items.push({ simpleLabel: _('No result found', 'suggest').toUpperCase() });
+    items.push({ errorLabel: _('No result found', 'suggest') });
   }
 
   return items;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -254,6 +254,12 @@ input[type="search"] {
   padding: 9px 18px;
 }
 
+.autocomplete_error {
+  padding: 15px 10px 5px;
+  color: $primary_text;
+  cursor: default;
+}
+
 @media (max-width: 640px) {
   .search_form__wrapper {
     padding: 0 9px 0 12px;

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -50,9 +50,9 @@ test('search with no suggest', async () => {
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Goodbye');
   const title = await page.evaluate(() => {
-    return document.querySelector('.autocomplete_separator_label').innerText;
+    return document.querySelector('.autocomplete_error').innerText;
   });
-  expect(title).toEqual('NO RESULT FOUND');
+  expect(title).toEqual('No result found');
 });
 
 test('search has lang in query', async () => {


### PR DESCRIPTION
## Description
- fix error message style (introduce an ErrorLabel suggest item type)
- ~~fix line-height in general for the "normal" suggest items (letters can get truncated sometimes, esp. on W10 + System zoom >= 125%)~~ (Edit by @bbecquet: design team is investigating how to fix that in a generic way, as it seems the problem is with SegoeUI font everywhere. Let's fix that separately)

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/86807241-fe679b00-c079-11ea-8c0c-4d0212048c41.png)

