### PR TITLE
Service panel redesign: collapsible category list on desktop

### DIFF
--- a/src/components/CategoryList.jsx
+++ b/src/components/CategoryList.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import CategoryService from 'src/adapters/category_service';
 import MainActionButton from 'src/components/ui/MainActionButton';
 
-const CategoryList = ({ className }) =>
+const CategoryList = ({ className, limit = Number.MAX_VALUE }) =>
   <div className={className}>
-    {CategoryService.getCategories().map(category =>
-      <MainActionButton
+    {CategoryService.getCategories()
+      .slice(0, limit)
+      .map(category => <MainActionButton
         key={category.name}
         onClick={() => { window.app.navigateTo(`/places/?type=${category.name}`); }}
         variant="category"

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -23,7 +23,7 @@ const Button = ({
 Button.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.string,
-  variant: PropTypes.oneOf(['outline', 'primary']),
+  variant: PropTypes.oneOf(['outline', 'primary', 'shadow']),
   type: PropTypes.string,
   href: PropTypes.string,
   onClick: PropTypes.func,

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 const Button = ({
-  children, icon, variant = 'outline', type = 'button',
+  children, icon, variant = 'secondary', type = 'button',
   href, onClick, className, ...rest
 }) => {
   const Tag = href ? 'a' : 'button';
@@ -23,7 +23,7 @@ const Button = ({
 Button.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.string,
-  variant: PropTypes.oneOf(['outline', 'primary', 'shadow']),
+  variant: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),
   type: PropTypes.string,
   href: PropTypes.string,
   onClick: PropTypes.func,

--- a/src/panel/service/ServicePanelDesktop.jsx
+++ b/src/panel/service/ServicePanelDesktop.jsx
@@ -23,7 +23,7 @@ const ServicePanelDesktop = () => {
         icon={collapsed ? 'icon_chevron-down' : 'icon_chevron-up'}
         onClick={() => setCollapsed(!collapsed)}
       >
-        {collapsed ? _('Display more proximity services') : _('Reduce')}
+        {collapsed ? _('See more nearby services') : _('Reduce')}
       </Button>
     </div>
   </Fragment>;

--- a/src/panel/service/ServicePanelDesktop.jsx
+++ b/src/panel/service/ServicePanelDesktop.jsx
@@ -18,7 +18,8 @@ const ServicePanelDesktop = () => {
     </Panel>
     <div className="u-center">
       <Button
-        variant="shadow"
+        className="service_panel__category_toggle"
+        variant="tertiary"
         icon={collapsed ? 'icon_chevron-down' : 'icon_chevron-up'}
         onClick={() => setCollapsed(!collapsed)}
       >

--- a/src/panel/service/ServicePanelDesktop.jsx
+++ b/src/panel/service/ServicePanelDesktop.jsx
@@ -1,15 +1,31 @@
 /* global _ */
-import React from 'react';
-import Panel from 'src/components/ui/Panel';
+import React, { Fragment, useState } from 'react';
+import { Panel, Button } from 'src/components/ui';
 import CategoryList from 'src/components/CategoryList';
 
 const ServicePanelDesktop = () => {
-  return <Panel className="service_panel" white>
-    <h3 className="u-text--smallTitle u-mb-12">
-      {_('Search around this place', 'service panel')}
-    </h3>
-    <CategoryList className="service_panel__categories" />
-  </Panel>;
+  const [ collapsed, setCollapsed ] = useState(true);
+
+  return <Fragment>
+    <Panel className="service_panel u-mb-8" white>
+      <h3 className="u-text--smallTitle u-mb-12">
+        {_('Search around this place', 'service panel')}
+      </h3>
+      <CategoryList
+        className="service_panel__categories"
+        limit={collapsed ? 4 : undefined}
+      />
+    </Panel>
+    <div className="u-center">
+      <Button
+        variant="shadow"
+        icon={collapsed ? 'icon_chevron-down' : 'icon_chevron-up'}
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        {collapsed ? _('Display more proximity services') : _('Reduce')}
+      </Button>
+    </div>
+  </Fragment>;
 };
 
 export default ServicePanelDesktop;

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -14,6 +14,12 @@
     color: $action-blue-base;
   }
 
+  &--shadow {
+    background-color: white;
+    color: $action-blue-base;
+    box-shadow: 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);
+  }
+
   &--primary {
     background-color: $action-blue-base;
     border: 1px solid $action-blue-base;
@@ -37,13 +43,16 @@
   }
 
   &-icon + &-content {
-    margin-left: 6px;
+    margin-left: 4px;
   }
 
   &::-moz-focus-inner {
     border: 0;
   }
 
+  &:not(.button--primary):hover {
+    background: $action-lighter;
+  }
 }
 
 a.button {

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -8,23 +8,22 @@
   pointer-events: all;
   cursor: pointer;
 
-  &--outline {
-    background-color: white;
-    border: 1px solid $action-blue-base;
-    color: $action-blue-base;
-  }
-
-  &--shadow {
-    background-color: white;
-    color: $action-blue-base;
-    box-shadow: 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);
-  }
-
   &--primary {
     background-color: $action-blue-base;
     border: 1px solid $action-blue-base;
     color: white;
     font-weight: bold;
+  }
+
+  &--secondary {
+    background-color: white;
+    border: 1px solid $action-blue-base;
+    color: $action-blue-base;
+  }
+
+  &--tertiary {
+    background-color: white;
+    color: $action-blue-base;
   }
 
   &-content {

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.service_panel__category_toggle {
+  box-shadow: 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);
+}
+
 @media (max-width: 640px){
   .panel.service_panel {
     height: 260px;


### PR DESCRIPTION
## Description
Implement the new default view of the service panel displaying only the 4 first categories and a button to show/hide the remaining ones.

*For now on desktop only, as it's still unclear on which screen should have that on mobile.*

## Screenshots
|Collapsed|Open|
|---|---|
|![localhost_3000_ (9)](https://user-images.githubusercontent.com/243653/87154913-5391ef80-c2ba-11ea-91dd-0a490b812d42.png)|![localhost_3000_ (10)](https://user-images.githubusercontent.com/243653/87154906-51c82c00-c2ba-11ea-8fa1-116992ad7ab3.png)|

