### PR TITLE
Fix zoom on POI from a list

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -17,7 +17,6 @@ import { parseMapHash, getMapHash } from 'src/libs/url_utils';
 import { toUrl, getBestZoom } from 'src/libs/pois';
 import Error from 'src/adapters/error';
 import { fire, listen } from 'src/libs/customEvents';
-import { isNullOrEmpty } from 'src/libs/object';
 import locale from '../mapbox/locale';
 
 const baseUrl = nconf.get().system.baseUrl;
@@ -166,13 +165,12 @@ Scene.prototype.initMapBox = function() {
     this.fitMap(item, this.getCurrentPaddings(), forceAnimate);
   });
 
-  listen('map_mark_poi', (poi, options) => {
+  listen('ensure_poi_visible', (poi, options) => {
     this.ensureMarkerIsVisible(poi, options);
-    // The presence of poiFilters mean we are in the context of a list of POIs
-    // where we don't need to create a new icon as it already exists
-    if (isNullOrEmpty(options.poiFilters)) {
-      this.addMarker(poi, options);
-    }
+  });
+
+  listen('create_poi_marker', poi => {
+    this.addMarker(poi);
   });
 
   listen('clean_marker', () => {

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -93,10 +93,11 @@ export default class PoiPanel extends React.Component {
   }
 
   loadPois = () => {
-    const { poi } = this.props;
+    const { poi, poiFilters } = this.props;
     window.execOnMapLoaded(() => {
-      fire('add_category_markers', this.props.pois, this.props.poiFilters);
+      fire('add_category_markers', this.props.pois, poiFilters);
       fire('highlight_category_marker', poi, true);
+      fire('map_mark_poi', poi, { centerMap: true, poiFilters });
     });
   }
 


### PR DESCRIPTION
## Description
Restore the map zoom on the selected POI when clicking on it from the category panel, either from the map or the list.

The zoom didn't occur anymore since the fix on category markers https://github.com/QwantResearch/erdapfel/pull/695
The reason was the zoom action (`scene.ensureMarkerIsVisible(…)`) was called inside the handler of the `map_mark_poi` event, which wasn't fired by the PoiPanel for a POI from a list.
As the rules are quite complicated, I also tried to be more explicit with them and move special logic to the component, not the map.
