### PR TITLE
suggest: Do not return errors if no query

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -69,7 +69,7 @@ const Suggest = ({
       currentQuery = query;
 
       query
-        .then(suggestions => modifyList(suggestions, withGeoloc))
+        .then(suggestions => modifyList(suggestions, withGeoloc, value))
         .then(items => {
           setItems(items);
           currentQuery = null;

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -20,7 +20,8 @@ const computeStyle = (isAttachedToInput, inputNode, suggestItems) => {
     };
   }
 
-  if (suggestItems.length > 0 && suggestItems[suggestItems.length - 1].simpleLabel) {
+  if (suggestItems.length === 0 ||
+      suggestItems.length > 0 && suggestItems[suggestItems.length - 1].simpleLabel) {
     // Revove bottom padding if last item is a simple label (no results)
     style = {
       ...style,

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -68,7 +68,7 @@ export const fetchSuggests = (query, options = {}) =>
     maxFavorites: options.maxFavorites || !query ? 5 : 2,
   });
 
-export const modifyList = (items, withGeoloc) => {
+export const modifyList = (items, withGeoloc, query) => {
   const firstFav = items.findIndex(item => item instanceof PoiStore);
 
   if (firstFav > -1) {
@@ -79,7 +79,7 @@ export const modifyList = (items, withGeoloc) => {
     items.splice(0, 0, NavigatorGeolocalisationPoi.getInstance());
   }
 
-  if (items.length === 0 || items.length === 1 && withGeoloc) {
+  if (query.length > 0 && (items.length === 0 || items.length === 1 && withGeoloc)) {
     items.push({ errorLabel: _('No result found', 'suggest') });
   }
 


### PR DESCRIPTION
## Description
Fix "no result" label being displayed when there is no query typed and there is no favorites stored.