### PR TITLE
Toggle category toggle visibility with the service panel itself

### DIFF
--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -1,5 +1,10 @@
-.panel-hidden .panel:not(.direction_panel) {
-  display: none;
+.panel-hidden {
+  .panel:not(.direction_panel) {
+    display: none;
+  }
+  .service_panel__category_toggle {
+    display: none;
+  }
 }
 
 .panel {


### PR DESCRIPTION
## Why
#713 showed that the category toggle remained visible on focus, following changes in #691 

This PR updates the css rules specific to `.panel-hidden` to hide this button too.

