### PR TITLE
QMAPS-1073 fix default icons and display for latlon pois and administrative places

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4508,8 +4508,8 @@
       "dev": true
     },
     "@qwant/qwant-basic-gl-style": {
-      "version": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#8940a60da089fd2748fb207061c267acd926fd8b",
-      "from": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#8940a60"
+      "version": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#1b6c173a5ca297649e33c854b473a903346f626e",
+      "from": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#1b6c173"
     },
     "@qwant/telemetry": {
       "version": "file:local_modules/telemetry"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@qwant/merge-po": "file:local_modules/merge-po",
     "@qwant/nconf-builder": "file:local_modules/nconf_builder",
     "@qwant/po-js": "file:local_modules/po-js",
-    "@qwant/qwant-basic-gl-style": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#8940a60",
+    "@qwant/qwant-basic-gl-style": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#1b6c173",
     "@qwant/telemetry": "file:local_modules/telemetry",
     "@qwant/uri": "file:local_modules/uri",
     "@turf/bbox": "^6.0.1",

--- a/src/adapters/icon_manager.js
+++ b/src/adapters/icon_manager.js
@@ -5,16 +5,23 @@ const nameToClass = iconName => iconName.match(/^(.*?)-[0-9]{1,2}$/)[1];
 export default class IconManager {
   static get({ className, subClassName, type }) {
 
+    // Get the category icon of a PoI
     if (type === 'poi' || type === 'category') {
       const icons = styleIcons.mappings;
+
+      // Matching class and subclass
       let icon = icons.find(iconProperty => {
         return iconProperty.subclass === subClassName && iconProperty.class === className;
       });
+
+      // Or: no class and matching subclass
       if (!icon) {
         icon = icons.find(iconProperty => {
           return iconProperty.subclass === subClassName && !iconProperty.class;
         });
       }
+
+      // Or: matching class and no subclass
       if (!icon) {
         icon = icons.find(iconProperty => {
           return iconProperty.class === className && !iconProperty.subclass;
@@ -32,17 +39,24 @@ export default class IconManager {
         iconClass: nameToClass(styleIcons.defaultIcon),
         color: styleIcons.defaultColor,
       };
+
+    // Get the icon of a location / area that is not a PoI:
+    // Exact address
     } else if (type === 'house' || type === 'address') {
       return {
         iconClass: nameToClass(styleIcons.defaultAddressIcon),
         color: styleIcons.defaultAddressColor,
       };
+
+    // Road / street without house number
     } else if (type === 'street') {
       return {
         iconClass: nameToClass(styleIcons.defaultStreetIcon),
         color: styleIcons.defaultStreetColor,
       };
-    } else { // administrative zones
+
+    // administrative zones (city, area, country)
+    } else {
       return {
         iconClass: nameToClass(styleIcons.defaultAdministrativeIcon),
         color: styleIcons.defaultAdministrativeColor,

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -6,8 +6,11 @@ import { capitalizeFirst } from 'src/libs/string';
 const PoiTitle = ({ poi, withAlternativeName }) => {
   const { name, localName, subClassName, address } = poi;
 
+  // LatLon PoI
   if (subClassName === 'latlon') {
     const latLon = name;
+
+    // Close to (address) + GPS coordinates
     if (address?.label) {
       return <div className="poiTitle">
         <div className="u-text--subtitle u-italic u-mb-4">{ _('Close to', 'poi')}</div>
@@ -16,8 +19,12 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
       </div>;
     }
 
+    // GPS coordinates only
     return <div className="poiTitle">
-      <h2 className="poiTitle-main poiTitle-position u-text--smallTitle">{latLon}</h2>
+      <h2 className="poiTitle-main u-text--smallTitle u-mb-4">
+        { _('Geographic coordinates', 'poi')}
+      </h2>
+      <div className="poiTitle-position">{latLon}</div>
     </div>;
   }
 

--- a/src/panel/poi/PoiTitleImage.jsx
+++ b/src/panel/poi/PoiTitleImage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import IconManager from 'src/adapters/icon_manager';
 import { toCssUrl } from 'src/libs/url_utils';
 
-const defaultIcon = { iconClass: 'location', color: '#444648' };
+const defaultIcon = { iconClass: 'marker2', color: '#444648' };
 
 const PoiTitleImage = ({ poi, iconOnly }) => {
   if (poi.topImageUrl && !iconOnly) {


### PR DESCRIPTION
## Description
- Write "Geographic coordinates" on top of latlon panels with no address + use the default icon "marker2" on the right
![image](https://user-images.githubusercontent.com/1225909/88060010-ed348900-cb65-11ea-9ebe-c699775b897e.png)
- Also use marker2 icon on latlon pois with address, cities, regions and countries (but they generally have a picture)
![image](https://user-images.githubusercontent.com/1225909/88060099-03dae000-cb66-11ea-908c-7670408d3c95.png)
- Keep "home" icon on exact addresses
![image](https://user-images.githubusercontent.com/1225909/88060515-aabf7c00-cb66-11ea-88fd-47cda6bd6c63.png)
- Keep "residential" icon on streets/roads
![image](https://user-images.githubusercontent.com/1225909/88060702-db9fb100-cb66-11ea-9793-7768dd736bf8.png)

