### PR TITLE
QMAPS-1624 multiline addresses in poi panel

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -5,6 +5,7 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
+import { filter } from '../libs/address';
 
 const PoiItem = ({ poi,
   withOpeningHours,
@@ -18,7 +19,9 @@ const PoiItem = ({ poi,
 
   const Address = () =>
     poi.subClassName !== 'latlon' && address.label
-      ? <div className="u-text--subtitle poiItem-address">{address.label}</div>
+      ? <div className="u-text--subtitle poiItem-address">
+        { filter(address).map(item => <div key={item}>{item}</div>) }
+      </div>
       : null
   ;
 

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -5,7 +5,7 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
-import { toArray } from '../libs/address';
+import MultilineAddress from 'src/components/ui/MultilineAddress';
 
 const PoiItem = ({ poi,
   withOpeningHours,
@@ -20,7 +20,7 @@ const PoiItem = ({ poi,
   const Address = () =>
     poi.subClassName !== 'latlon' && address.label
       ? <div className="u-text--subtitle poiItem-address">
-        { toArray(address).map((item, index) => <div key={index}>{item}</div>) }
+        <MultilineAddress address={address}/>
       </div>
       : null
   ;

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -5,7 +5,7 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
-import { filter } from '../libs/address';
+import { toArray } from '../libs/address';
 
 const PoiItem = ({ poi,
   withOpeningHours,
@@ -20,7 +20,7 @@ const PoiItem = ({ poi,
   const Address = () =>
     poi.subClassName !== 'latlon' && address.label
       ? <div className="u-text--subtitle poiItem-address">
-        { filter(address).map(item => <div key={item}>{item}</div>) }
+        { toArray(address).map((item, index) => <div key={index}>{item}</div>) }
       </div>
       : null
   ;

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -39,7 +39,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
   return <div className="poiTitle">
     <h2 className="poiTitle-main u-text--smallTitle">{title || subclass}</h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
-      <MultilineAddress address={address}/>
+      {alternative}
     </div>}
     {title && <div className="poiTitle-subclass u-text--subtitle">{subclass}</div>}
   </div>;

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import { capitalizeFirst } from 'src/libs/string';
+import { filter } from 'src/libs/address';
 
 const PoiTitle = ({ poi, withAlternativeName }) => {
   const { name, localName, subClassName, address } = poi;
@@ -11,10 +12,12 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
     const latLon = name;
 
     // Close to (address) + GPS coordinates
-    if (address?.label) {
+    if (address) {
       return <div className="poiTitle">
         <div className="u-text--subtitle u-italic u-mb-4">{ _('Close to', 'poi')}</div>
-        <h2 className="poiTitle-main u-text--smallTitle u-mb-4">{address?.label}</h2>
+        <h2 className="poiTitle-main u-text--smallTitle u-mb-4">{
+          filter(address).map(item => <div key={item}>{item}</div>)
+        }</h2>
         <div className="poiTitle-position">{latLon}</div>
       </div>;
     }
@@ -32,10 +35,11 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
   const alternative = (withAlternativeName && name && localName && localName !== name) && localName;
   const subclass = capitalizeFirst(poiSubClass(subClassName));
 
+  // Location / address
   return <div className="poiTitle">
     <h2 className="poiTitle-main u-text--smallTitle">{title || subclass}</h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
-      {alternative}
+      { filter(address).map(item => <div key={item}>{item}</div>) }
     </div>}
     {title && <div className="poiTitle-subclass u-text--subtitle">{subclass}</div>}
   </div>;

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -16,7 +16,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
       return <div className="poiTitle">
         <div className="u-text--subtitle u-italic u-mb-4">{ _('Close to', 'poi')}</div>
         <h2 className="poiTitle-main u-text--smallTitle u-mb-4">{
-          filter(address).map(item => <div key={item}>{item}</div>)
+          filter(address).map((item, index) => <div key={index}>{item}</div>)
         }</h2>
         <div className="poiTitle-position">{latLon}</div>
       </div>;
@@ -39,7 +39,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
   return <div className="poiTitle">
     <h2 className="poiTitle-main u-text--smallTitle">{title || subclass}</h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
-      { filter(address).map(item => <div key={item}>{item}</div>) }
+      { filter(address).map((item, index) => <div key={index}>{item}</div>) }
     </div>}
     {title && <div className="poiTitle-subclass u-text--subtitle">{subclass}</div>}
   </div>;

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import { capitalizeFirst } from 'src/libs/string';
-import { filter } from 'src/libs/address';
+import MultilineAddress from 'src/components/ui/MultilineAddress';
 
 const PoiTitle = ({ poi, withAlternativeName }) => {
   const { name, localName, subClassName, address } = poi;
@@ -15,9 +15,9 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
     if (address) {
       return <div className="poiTitle">
         <div className="u-text--subtitle u-italic u-mb-4">{ _('Close to', 'poi')}</div>
-        <h2 className="poiTitle-main u-text--smallTitle u-mb-4">{
-          filter(address).map((item, index) => <div key={index}>{item}</div>)
-        }</h2>
+        <h2 className="poiTitle-main u-text--smallTitle u-mb-4">
+          <MultilineAddress address={address}/>
+        </h2>
         <div className="poiTitle-position">{latLon}</div>
       </div>;
     }
@@ -39,7 +39,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
   return <div className="poiTitle">
     <h2 className="poiTitle-main u-text--smallTitle">{title || subclass}</h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
-      { filter(address).map((item, index) => <div key={index}>{item}</div>) }
+      <MultilineAddress address={address}/>
     </div>}
     {title && <div className="poiTitle-subclass u-text--subtitle">{subclass}</div>}
   </div>;

--- a/src/components/ui/MultilineAddress.jsx
+++ b/src/components/ui/MultilineAddress.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { toArray } from '../../libs/address';
+import { toArray } from 'src/libs/address';
 
-const MultilineAddress = address =>
-  <div className={'multiline-address'}>
-    { toArray(address).map((item, index) => <div key={index}>{item}</div>) }
+const MultilineAddress = ({ address }) =>
+  <div>
+    {toArray(address).map((item, index) => <div key={index}>{item}</div>)}
   </div>;
 
 MultilineAddress.propTypes = {

--- a/src/components/ui/MultilineAddress.jsx
+++ b/src/components/ui/MultilineAddress.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { toArray } from '../../libs/address';
+
+const MultilineAddress = address =>
+  <div className={'multiline-address'}>
+    { toArray(address).map((item, index) => <div key={index}>{item}</div>) }
+  </div>;
+
+MultilineAddress.propTypes = {
+  address: PropTypes.object.isRequired,
+};
+
+export default MultilineAddress;

--- a/src/libs/address.js
+++ b/src/libs/address.js
@@ -4,11 +4,11 @@ import IdunnPoi from '../adapters/poi/idunn_poi';
  * Filter an address and return an array with the relevant items
  * @param {*} address - an address object
  */
-export function filter(address) {
+export function toArray(address) {
 
   if (!address) {return [];}
 
-  const city = address.postcode && address.city
+  const cityAndPostcode = address.postcode && address.city
     ? address.postcode + ' ' + address.city
     : address.city;
 
@@ -16,7 +16,7 @@ export function filter(address) {
     return [
       address.suburb,
       address.cityDistrict,
-      city,
+      address.city,
       address.stateDistrict,
       address.state,
       address.countryRegion,
@@ -26,7 +26,7 @@ export function filter(address) {
       .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]); // remove consecutive duplicated name
   }
 
-  return [address.street, city, address.country]
+  return [address.street, cityAndPostcode, address.country]
     .filter(i => i); // Filter out any undefined value
 }
 /**
@@ -35,7 +35,7 @@ export function filter(address) {
  * @param string separator - how items are joined
  */
 export function format(address, separator = ', ') {
-  return filter(address).join(separator);
+  return toArray(address).join(separator);
 }
 
 /**
@@ -73,7 +73,7 @@ export function normalize(type, raw) {
     };
   }
 
-  if (type === 'idunn' || type === 'latlon') {
+  if (type === 'idunn') {
     return {
       street: raw.address?.name,
       suburb: findAdminIdunn(raw, 'suburb')?.name,

--- a/src/libs/address.js
+++ b/src/libs/address.js
@@ -1,30 +1,41 @@
 import IdunnPoi from '../adapters/poi/idunn_poi';
 
 /**
- * Format an address given an address object (name, city, country, label, and other regions)
+ * Filter an address and return an array with the relevant items
  * @param {*} address - an address object
  */
-export function format(address) {
-  if (!address) {return '';}
+export function filter(address) {
+
+  if (!address) {return [];}
+
+  const city = address.postcode && address.city
+    ? address.postcode + ' ' + address.city
+    : address.city;
 
   if (!address.street) {
     return [
       address.suburb,
       address.cityDistrict,
-      address.city,
+      city,
       address.stateDistrict,
       address.state,
       address.countryRegion,
       address.country,
     ]
       .filter(i => i)
-      .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]) // remove consecutive duplicated name
-      .join(', ');
+      .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]); // remove consecutive duplicated name
   }
 
-  return [address.street, address.city, address.country]
-    .filter(i => i) // Filter out any undefined value
-    .join(', ');
+  return [address.street, city, address.country]
+    .filter(i => i); // Filter out any undefined value
+}
+/**
+ * Format an address given an address object (name, city, country, label, and other regions)
+ * @param {*} address - an address object
+ * @param string separator - how items are joined
+ */
+export function format(address, separator = ', ') {
+  return filter(address).join(separator);
 }
 
 /**
@@ -48,12 +59,12 @@ export function normalize(type, raw) {
       // Street address is received in the name field
       street = raw.geocoding.name;
     }
-
     return {
       street,
       suburb: findAdminBragi(raw, 'suburb')?.name,
       cityDistrict: findAdminBragi(raw, 'city_district')?.name,
       city: findAdminBragi(raw, 'city')?.name,
+      postcode: raw.geocoding.address?.street?.postcode,
       stateDistrict: findAdminBragi(raw, 'state_district')?.name,
       state: findAdminBragi(raw, 'state')?.name,
       countryRegion: findAdminBragi(raw, 'country_region')?.name,
@@ -62,12 +73,13 @@ export function normalize(type, raw) {
     };
   }
 
-  if (type === 'idunn') {
+  if (type === 'idunn' || type === 'latlon') {
     return {
       street: raw.address?.name,
       suburb: findAdminIdunn(raw, 'suburb')?.name,
       cityDistrict: findAdminIdunn(raw, 'city_district')?.name,
       city: findAdminIdunn(raw, 'city')?.name,
+      postcode: raw.address?.postcode,
       stateDistrict: findAdminIdunn(raw, 'state_district')?.name,
       state: findAdminIdunn(raw, 'state')?.name,
       countryRegion: findAdminIdunn(raw, 'country_region')?.name,

--- a/src/libs/address.js
+++ b/src/libs/address.js
@@ -8,10 +8,6 @@ export function toArray(address) {
 
   if (!address) {return [];}
 
-  const cityAndPostcode = address.postcode && address.city
-    ? address.postcode + ' ' + address.city
-    : address.city;
-
   if (!address.street) {
     return [
       address.suburb,
@@ -25,6 +21,10 @@ export function toArray(address) {
       .filter(i => i)
       .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]); // remove consecutive duplicated name
   }
+
+  const cityAndPostcode = address.postcode && address.city
+    ? address.postcode + ' ' + address.city
+    : address.city;
 
   return [address.street, cityAndPostcode, address.country]
     .filter(i => i); // Filter out any undefined value

--- a/tests/__data__/poi.json
+++ b/tests/__data__/poi.json
@@ -4,7 +4,7 @@
         "source": "osm"
     },
     "name": "Musée d'Orsay",
-    "local_name": "Musée d'Orsay",
+    "local_name": "Orsay museum",
     "class_name": "museum",
     "subclass_name": "museum",
     "type" : "poi",

--- a/tests/__data__/poi.json
+++ b/tests/__data__/poi.json
@@ -13,7 +13,92 @@
         "type": "Point"
     },
     "address": {
-        "label": "1 Rue de la Légion d'Honneur (Paris)"
+        "id": "addr_poi:osm:way:63178753",
+        "name": "1 Rue de la Légion d'Honneur",
+        "label": "1 Rue de la Légion d'Honneur (Paris)",
+        "housenumber": "1",
+        "street": {
+            "id": "street_poi:osm:way:63178753",
+            "name": "Rue de la Légion d'Honneur",
+            "label": "Rue de la Légion d'Honneur (Paris)",
+            "postcodes": [
+                "75007"
+            ]
+        },
+        "postcode": "75007",
+        "admins": [
+            {
+                "id": "admin:osm:relation:2188567",
+                "name": "Quartier Saint-Thomas-d'Aquin",
+                "label": "Quartier Saint-Thomas-d'Aquin (75007), Paris 7e Arrondissement, Paris, Île-de-France, France",
+                "class_name": "suburb",
+                "postcodes": [
+                    "75007"
+                ]
+            },
+            {
+                "id": "admin:osm:relation:9521",
+                "name": "Paris 7e Arrondissement",
+                "label": "Paris 7e Arrondissement (75007), Paris, Île-de-France, France",
+                "class_name": "city_district",
+                "postcodes": [
+                    "75007"
+                ]
+            },
+            {
+                "id": "admin:osm:relation:7444",
+                "name": "Paris",
+                "label": "Paris (75000-75116), Île-de-France, France",
+                "class_name": "city",
+                "postcodes": [
+                    "75000",
+                    "75001",
+                    "75002",
+                    "75003",
+                    "75004",
+                    "75005",
+                    "75006",
+                    "75007",
+                    "75008",
+                    "75009",
+                    "75010",
+                    "75011",
+                    "75012",
+                    "75013",
+                    "75014",
+                    "75015",
+                    "75016",
+                    "75017",
+                    "75018",
+                    "75019",
+                    "75020",
+                    "75116"
+                ]
+            },
+            {
+                "id": "admin:osm:relation:71525",
+                "name": "Paris",
+                "label": "Paris, Île-de-France, France",
+                "class_name": "state_district",
+                "postcodes": []
+            },
+            {
+                "id": "admin:osm:relation:8649",
+                "name": "Île-de-France",
+                "label": "Île-de-France, France",
+                "class_name": "state",
+                "postcodes": []
+            },
+            {
+                "id": "admin:osm:relation:2202162",
+                "name": "France",
+                "label": "France",
+                "class_name": "country",
+                "postcodes": []
+            }
+        ],
+        "admin": null,
+        "country_code": "FR"
     },
     "blocks": [{
         "type": "opening_hours",

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -45,7 +45,7 @@ test('load a poi from url', async () => {
     };
   });
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur \(Paris\)/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris\nFrance/);
 });
 
 test('load a poi from url and click on directions', async () => {
@@ -67,7 +67,7 @@ test('load a poi from url with simple id', async () => {
     };
   });
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur \(Paris\)/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris\nFrance/);
 });
 
 test('load a poi from url on mobile', async () => {
@@ -84,7 +84,7 @@ test('load a poi from url on mobile', async () => {
     };
   });
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur \(Paris\)/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris\nFrance/);
   expect(await exists(page, '.poi_card .openingHour--closed')).toBeTruthy();
 });
 
@@ -181,7 +181,7 @@ test('display details about the poi on a poi click', async () => {
 });
 
 test('Poi name i18n', async () => {
-  await page.goto(`${APP_URL}/place/osm:way:453203@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
+  await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=16.50/48.8602571/2.3262281`);
   await page.waitForSelector('.poiTitle');
 
   const title = await getTitle(page);


### PR DESCRIPTION
## Description
Display multiline addresses for PoIs, locations, latlons

## Screenshots
POI
![image](https://user-images.githubusercontent.com/1225909/88184751-60f09780-cc33-11ea-9e11-532816760c09.png)

Address from geocoder
![image](https://user-images.githubusercontent.com/1225909/88184851-84b3dd80-cc33-11ea-94cf-fb2fcf65ca36.png)

Street name from geocoder
![image](https://user-images.githubusercontent.com/1225909/88184910-97c6ad80-cc33-11ea-931a-7f56cac72455.png)

Area
![image](https://user-images.githubusercontent.com/1225909/88184997-b036c800-cc33-11ea-852e-68f41020f352.png)

Latlon near an address
![image](https://user-images.githubusercontent.com/1225909/88185055-c17fd480-cc33-11ea-810d-a92154094e39.png)

Pages Jaunes list
![image](https://user-images.githubusercontent.com/1225909/88185136-dceadf80-cc33-11ea-9382-5c271b1770d4.png)

Pages jaunes item
![image](https://user-images.githubusercontent.com/1225909/88185173-eaa06500-cc33-11ea-804a-50af6b4b7fb4.png)

(addresses in suggest stay unchanged)

PS: After doing F5 on a poi panel, the address appears without postal code, then <1s later, it's redrawn with the postal code.
I don't understand where that behavior comes from and why we can't have the postal code from the beginning...help?
![wut](https://user-images.githubusercontent.com/1225909/88185434-394dff00-cc34-11ea-816f-e5639f9f2f04.gif)

PS 2: I don't understand why the tests don't pass, more exactly why `address: document.querySelector('.poiItem-address').innerText` is "" when a PoI (musée d'orsay) is loaded. In my console it's not empty but "1 Rue de la Légion d'Honneur\n75007 Paris\nFrance"