### PR TITLE
Dynamic poi panel size

### DIFF
--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -1,23 +1,23 @@
 /* globals _ */
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import Telemetry from 'src/libs/telemetry';
 import { Flex, ShareMenu, Button } from 'src/components/ui';
 
-const ActionButtons = ({
+const ActionButtons = forwardRef(({
   poi,
   isDirectionActive,
   openDirection,
   onClickPhoneNumber,
   isPoiInFavorite,
   toggleStorePoi,
-}) => {
+}, ref) => {
   const onShareClick = (e, handler) => {
     Telemetry.add(Telemetry.POI_SHARE);
     return handler(e);
   };
 
-  return <Flex className="u-mb-24 poi_panel__actions">
+  return <Flex className="u-mb-24 poi_panel__actions" ref={ref}>
     {isDirectionActive && <Button
       className="poi_panel__action__direction"
       variant="primary"
@@ -54,7 +54,9 @@ const ActionButtons = ({
       />}
     </ShareMenu>
   </Flex>;
-};
+});
+
+ActionButtons.displayName = 'ActionButtons';
 
 ActionButtons.propTypes = {
   poi: PropTypes.object.isRequired,

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -55,6 +55,7 @@ export default class PoiPanel extends React.Component {
     };
     this.isDirectionActive = nconf.get().direction.enabled;
     this.isMasqEnabled = nconf.get().masq.enabled;
+    this.defaultSizeTargetRef = React.createRef();
   }
 
   componentDidMount() {
@@ -268,6 +269,7 @@ export default class PoiPanel extends React.Component {
       resizable
       title={header}
       close={this.closeAction}
+      defaultSizeTargetRef={this.defaultSizeTargetRef}
       className={classnames('poi_panel', {
         'poi_panel--empty-header':
           !isFromPagesJaunes(poi) &&
@@ -278,6 +280,7 @@ export default class PoiPanel extends React.Component {
       <div className="poi_panel__content">
         <PoiItem poi={poi} withAlternativeName className="u-mb-24" onClick={this.center} />
         <ActionButtons
+          ref={this.defaultSizeTargetRef}
           poi={poi}
           isDirectionActive={this.isDirectionActive}
           openDirection={this.openDirection}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -49,7 +49,6 @@
 @media (max-width: 640px) {
   .panel {
     width: 100vw;
-    height: 50%;
     position: absolute;
     display: flex;
     flex-direction: column;
@@ -67,7 +66,6 @@
 
     &.maximized {
       border-radius: 0;
-      height: calc(100% - #{$top_bar_height});
 
       // a "fake" background area added above the panel itself,
       // allowing height transitions without changing paddings and preventing "jumps"
@@ -91,8 +89,6 @@
     }
 
     &.minimized {
-      height: 50px;
-
       .minimizedTitle {
         text-align: center;
       }


### PR DESCRIPTION
## Description
Compute panel's height purely in JS, by determining the necessary height to display no more than a specific React `ref` + a slight margin (20px)

## Why
A poi panel would take too much space on a mobile screen if we keep the default height to be `50%` of the screen.

## Screenshots
![Peek 2020-07-30 16-52](https://user-images.githubusercontent.com/2981774/88937908-05528980-d285-11ea-9127-95b8be3e848a.gif)
