### PR TITLE
[POI panel] Dynamic height based on content

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -252,7 +252,7 @@ export default class Panel extends React.Component {
               ref={this.panelContentRef}
               {...(isMobile && resizeHandlers)}
             >
-              {typeof children === 'function' ? children(size) : children}
+              {typeof children === 'function' ? children(size, isMobile) : children}
             </div>
           </div>
         }

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -38,7 +38,7 @@ function getTargetSize(previousSize, moveDuration, startHeight, endHeight, maxSi
 
 export default class Panel extends React.Component {
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
     title: PropTypes.node,
     minimizedTitle: PropTypes.node,
     resizable: PropTypes.bool,
@@ -252,7 +252,7 @@ export default class Panel extends React.Component {
               ref={this.panelContentRef}
               {...(isMobile && resizeHandlers)}
             >
-              {children}
+              {typeof children === 'function' ? children(size) : children}
             </div>
           </div>
         }

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -252,7 +252,7 @@ export default class Panel extends React.Component {
               ref={this.panelContentRef}
               {...(isMobile && resizeHandlers)}
             >
-              {typeof children === 'function' ? children(size, isMobile) : children}
+              {typeof children === 'function' ? children({ size, isMobile }) : children}
             </div>
           </div>
         }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -224,7 +224,7 @@ export default class PoiPanel extends React.Component {
     }
   }
 
-  renderContent = (poi, panelSize, isMobile) => {
+  renderContent = (poi, { size: panelSize, isMobile }) => {
     if (isMobile && panelSize === 'minimized') {
       return <div className="poi_panel__content">
         <PoiTitle poi={poi} withAlternativeName />
@@ -299,7 +299,7 @@ export default class PoiPanel extends React.Component {
           (!poiFilters || !poiFilters.category),
       } )}
     >
-      {(panelSize, isMobile) => this.renderContent(poi, panelSize, isMobile)}
+      {panelOptions => this.renderContent(poi, panelOptions)}
     </Panel>;
   }
 }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -20,6 +20,7 @@ import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
 import Flex from 'src/components/ui/Flex';
 import Divider from 'src/components/ui/Divider';
+import PoiTitle from 'src/components/PoiTitle';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -223,6 +224,37 @@ export default class PoiPanel extends React.Component {
     }
   }
 
+  renderContent = (poi, panelSize, isMobile) => {
+    if (isMobile && panelSize === 'minimized') {
+      return <div className="poi_panel__content">
+        <PoiTitle poi={poi} withAlternativeName />
+      </div>;
+    }
+
+    return <div className="poi_panel__content">
+      <PoiItem poi={poi} withAlternativeName className="u-mb-24" onClick={this.center} />
+      <ActionButtons
+        poi={poi}
+        isDirectionActive={this.isDirectionActive}
+        openDirection={this.openDirection}
+        onClickPhoneNumber={this.onClickPhoneNumber}
+        isPoiInFavorite={this.state.isPoiInFavorite}
+        toggleStorePoi={this.toggleStorePoi}
+      />
+      {(!isMobile || panelSize === 'maximized') && <div className="poi_panel__fullContent">
+        <Divider paddingBottom={10}/>
+        <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
+        {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
+          <h3 className="u-text--smallTitle">
+            {_('Search around this place', 'poi')}
+          </h3>
+          <CategoryList />
+        </div>}
+        {isFromOSM(poi) && <OsmContribution poi={poi} />}
+      </div>}
+    </div>;
+  }
+
   render() {
     const { poiFilters, isFromFavorite } = this.props;
     const poi = this.getBestPoi();
@@ -267,31 +299,7 @@ export default class PoiPanel extends React.Component {
           (!poiFilters || !poiFilters.category),
       } )}
     >
-      {panelSize =>
-        <div className="poi_panel__content">
-          <PoiItem poi={poi} withAlternativeName className="u-mb-24" onClick={this.center} />
-          <ActionButtons
-            poi={poi}
-            isDirectionActive={this.isDirectionActive}
-            openDirection={this.openDirection}
-            onClickPhoneNumber={this.onClickPhoneNumber}
-            isPoiInFavorite={this.state.isPoiInFavorite}
-            toggleStorePoi={this.toggleStorePoi}
-          />
-          {panelSize === 'maximized' && <>
-            <Divider paddingBottom={10}/>
-            <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
-            {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
-              <h3 className="u-text--smallTitle">
-                {_('Search around this place', 'poi')}
-              </h3>
-              <CategoryList />
-            </div>}
-            {isFromOSM(poi) && <OsmContribution poi={poi} />}
-            </>
-          }
-        </div>
-      }
+      {(panelSize, isMobile) => this.renderContent(poi, panelSize, isMobile)}
     </Panel>;
   }
 }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -267,26 +267,31 @@ export default class PoiPanel extends React.Component {
           (!poiFilters || !poiFilters.category),
       } )}
     >
-      <div className="poi_panel__content">
-        <PoiItem poi={poi} withAlternativeName className="u-mb-24" onClick={this.center} />
-        <ActionButtons
-          poi={poi}
-          isDirectionActive={this.isDirectionActive}
-          openDirection={this.openDirection}
-          onClickPhoneNumber={this.onClickPhoneNumber}
-          isPoiInFavorite={this.state.isPoiInFavorite}
-          toggleStorePoi={this.toggleStorePoi}
-        />
-        <Divider paddingBottom={10}/>
-        <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
-        {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
-          <h3 className="u-text--smallTitle">
-            {_('Search around this place', 'poi')}
-          </h3>
-          <CategoryList />
-        </div>}
-        {isFromOSM(poi) && <OsmContribution poi={poi} />}
-      </div>
+      {panelSize =>
+        <div className="poi_panel__content">
+          <PoiItem poi={poi} withAlternativeName className="u-mb-24" onClick={this.center} />
+          <ActionButtons
+            poi={poi}
+            isDirectionActive={this.isDirectionActive}
+            openDirection={this.openDirection}
+            onClickPhoneNumber={this.onClickPhoneNumber}
+            isPoiInFavorite={this.state.isPoiInFavorite}
+            toggleStorePoi={this.toggleStorePoi}
+          />
+          {panelSize === 'maximized' && <>
+            <Divider paddingBottom={10}/>
+            <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
+            {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
+              <h3 className="u-text--smallTitle">
+                {_('Search around this place', 'poi')}
+              </h3>
+              <CategoryList />
+            </div>}
+            {isFromOSM(poi) && <OsmContribution poi={poi} />}
+            </>
+          }
+        </div>
+      }
     </Panel>;
   }
 }

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -69,22 +69,6 @@
       border-radius: 0;
       height: calc(100% - #{$top_bar_height});
 
-      // a "fake" background area added above the panel itself,
-      // allowing height transitions without changing paddings and preventing "jumps"
-      &::before {
-        content: '';
-        display: block;
-        width: 100%;
-        height: $top_bar_height;
-        background-color: #f4f6fa;
-        position: absolute;
-        top: -$top_bar_height;
-      }
-
-      &.panel--white::before {
-        background-color: white;
-      }
-
       .panel-content {
         overflow: auto;
       }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -224,6 +224,16 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   .poi_panel__description__ellipsis {
     width: 100%;
   }
+
+  .poi_panel.panel {
+    &.default, &.minimized {
+      height: auto;
+    }
+  }
+
+  .poi_panel__fullContent {
+    animation: appear 600ms;
+  }
 }
 
 @import "./covid";

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -83,7 +83,6 @@ test('load a poi from url on mobile', async () => {
   }));
   expect(title).toMatch(/Musée d'Orsay/);
   expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
-  expect(await exists(page, '.openingHour--closed')).toBeTruthy();
 });
 
 test('load a poi already in my favorite from url', async () => {


### PR DESCRIPTION
## Description
Alternative to https://github.com/QwantResearch/erdapfel/pull/722, based on DOM changes instead of explicit JS size computation.

### Principle
If provided with a function as `children` prop, the `<Panel>` component can transmit its size (`default`, `minimized` or `maximized`) so the calling component can decide what to render depending on the panel size. This allows to hide the content that doesn't need to be displayed in `default` or `minimized` sizes.
The POI panel is also given `auto` height instead of fixed height. That way, the height adapts automatically to the content, even if it changes asynchronously (ressource loading, etc.).

### TODO

 - [x] **Fix a bug**: https://github.com/QwantResearch/erdapfel/pull/718 apparently introduced a bug on panel resize (all of them, not just POI).
When coming from 'minized' state, a mouse/touch drag to the left or right starts a resize action but stops right there, leaving the panel in an intermediate state. This conflicts with the current PR behavior, maybe hiding other problems with it, so this should be fixed first.
**=> simple fix: https://github.com/QwantResearch/erdapfel/pull/741**

 - [ ] **Display full content early**: currently, when going from `default` size to `maximized`, the panel displays extra POI info only when the panel is released, leaving a misleading white space during the resize. We could compute the target size of the Panel (the one "towards" which it's currently being resized) during the resize and give it to the children so we could fill the panel with content early.
**=> changing the panel content dynamically causes the bug mentioned above. Let's deal with it separately.**

 - [ ] **Restore CSS transitions**: using `height: auto;` for `default` and `minized` sizes makes CSS height transitions from and to them impossible, as they need numerical values. We can keep the computed size as start value, but there may be no easy way for target value.
**=> there is no major feature break with the loss of these transitions. Let's deal with it separately**
