### PR TITLE
Add a margin between category and address in POI

### DIFF
--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -36,7 +36,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
   const subclass = capitalizeFirst(poiSubClass(subClassName));
 
   // Location / address
-  return <div className="poiTitle">
+  return <div className="poiTitle u-mb-8">
     <h2 className="poiTitle-main u-text--smallTitle">{title || subclass}</h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
       {alternative}


### PR DESCRIPTION
## Description
Add a vertical space between the POI title (name and category) and its address, for readability.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-08-04 à 16 38 30](https://user-images.githubusercontent.com/243653/89307566-86d55d80-d671-11ea-9ef7-ed9344c95335.png)|![Capture d’écran 2020-08-04 à 16 37 58](https://user-images.githubusercontent.com/243653/89307590-8e950200-d671-11ea-9ce8-957a64db6b7d.png)|
