### PR TITLE
Manage all addresses through <Address> component

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -20,7 +20,7 @@ const PoiItem = ({ poi,
   const Address = () =>
     poi.subClassName !== 'latlon' && address.label
       ? <div className="u-text--subtitle poiItem-address">
-        <MultilineAddress address={address}/>
+        <MultilineAddress address={address} omitCountry={poi.type !== 'admin'} />
       </div>
       : null
   ;

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -5,7 +5,7 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
-import MultilineAddress from 'src/components/ui/MultilineAddress';
+import MultilineAddress from 'src/components/ui/Address';
 
 const PoiItem = ({ poi,
   withOpeningHours,

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -18,7 +18,7 @@ const PoiItem = ({ poi,
   const address = poi.address || {};
 
   const Address = () =>
-    poi.subClassName !== 'latlon' && address.label
+    poi.subClassName !== 'latlon'
       ? <div className="u-text--subtitle poiItem-address">
         <MultilineAddress address={address} omitCountry={poi.type !== 'admin'} />
       </div>

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -4,13 +4,13 @@ import OpeningHour from 'src/components/OpeningHour';
 import OsmSchedule from 'src/adapters/osm_schedule';
 import nconf from '@qwant/nconf-getter';
 import PoiTitle from 'src/components/PoiTitle';
+import Address from 'src/components/ui/Address';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
 const PoiPopup = ({ poi }) => {
   const reviews = poi.blocksByType && poi.blocksByType.grades;
   const openingHours = poi.blocksByType && poi.blocksByType.opening_hours;
-  const address = poi.address && poi.address.label;
 
   let displayedInfo = null;
   if (reviews) {
@@ -19,8 +19,8 @@ const PoiPopup = ({ poi }) => {
     displayedInfo = <OpeningHour
       schedule={new OsmSchedule(openingHours)}
     />;
-  } else if (address) {
-    displayedInfo = <span className="poi_popup__address">{address}</span>;
+  } else if (poi.address) {
+    displayedInfo = <Address address={poi.address} inline omitCountry />;
   }
 
   return <div className="poi_popup">

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -16,7 +16,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
       return <div className="poiTitle">
         <div className="u-text--subtitle u-italic u-mb-4">{ _('Close to', 'poi')}</div>
         <h2 className="poiTitle-main u-text--smallTitle u-mb-4">
-          <Address address={address}/>
+          <Address address={address} omitCountry />
         </h2>
         <div className="poiTitle-position">{latLon}</div>
       </div>;

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import { capitalizeFirst } from 'src/libs/string';
-import MultilineAddress from 'src/components/ui/MultilineAddress';
+import Address from 'src/components/ui/Address';
 
 const PoiTitle = ({ poi, withAlternativeName }) => {
   const { name, localName, subClassName, address } = poi;
@@ -16,7 +16,7 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
       return <div className="poiTitle">
         <div className="u-text--subtitle u-italic u-mb-4">{ _('Close to', 'poi')}</div>
         <h2 className="poiTitle-main u-text--smallTitle u-mb-4">
-          <MultilineAddress address={address}/>
+          <Address address={address}/>
         </h2>
         <div className="poiTitle-position">{latLon}</div>
       </div>;

--- a/src/components/ui/Address.jsx
+++ b/src/components/ui/Address.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { toArray } from 'src/libs/address';
 
-const MultilineAddress = ({ address }) =>
+const Address = ({ address }) =>
   <div>
     {toArray(address).map((item, index) => <div key={index}>{item}</div>)}
   </div>;
 
-MultilineAddress.propTypes = {
+Address.propTypes = {
   address: PropTypes.object.isRequired,
 };
 
-export default MultilineAddress;
+export default Address;

--- a/src/components/ui/Address.jsx
+++ b/src/components/ui/Address.jsx
@@ -28,7 +28,7 @@ function toArray(address, { omitStreet, omitCountry } = {}) {
     .filter(i => i); // Filter out any undefined value
 }
 
-const Address = ({ address, inline, omitStreet, omitCountry }) => {
+const Address = ({ address = {}, inline, omitStreet, omitCountry }) => {
   const parts = toArray(address, { omitStreet, omitCountry });
   return inline
     ? parts.join(', ')

--- a/src/components/ui/Address.jsx
+++ b/src/components/ui/Address.jsx
@@ -1,14 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { toArray } from 'src/libs/address';
 
-const Address = ({ address }) =>
-  <div>
-    {toArray(address).map((item, index) => <div key={index}>{item}</div>)}
-  </div>;
+/**
+ * Filter an address and return an array with the relevant items
+ * @param {*} address - an address object
+ */
+function toArray(address, omitStreet) {
+  if (!address.street) {
+    return [
+      address.suburb,
+      address.cityDistrict,
+      address.city,
+      address.stateDistrict,
+      address.state,
+      address.countryRegion,
+      address.country,
+    ]
+      .filter(i => i)
+      .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]); // remove consecutive duplicated name
+  }
+
+  const cityAndPostcode = address.postcode && address.city
+    ? address.postcode + ' ' + address.city
+    : address.city;
+
+  return [!omitStreet && address.street, cityAndPostcode, address.country]
+    .filter(i => i); // Filter out any undefined value
+}
+
+const Address = ({ address, inline, omitStreet }) => {
+  const parts = toArray(address, omitStreet);
+  return inline
+    ? parts.join(', ')
+    : <div>
+      {toArray(address).map((item, index) => <div key={index}>{item}</div>)}
+    </div>;
+};
 
 Address.propTypes = {
   address: PropTypes.object.isRequired,
+  inline: PropTypes.bool,
+  omitStreet: PropTypes.bool,
 };
 
 export default Address;

--- a/src/components/ui/Address.jsx
+++ b/src/components/ui/Address.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
  * Filter an address and return an array with the relevant items
  * @param {*} address - an address object
  */
-function toArray(address, omitStreet) {
+function toArray(address, { omitStreet, omitCountry } = {}) {
   if (!address.street) {
     return [
       address.suburb,
@@ -14,7 +14,7 @@ function toArray(address, omitStreet) {
       address.stateDistrict,
       address.state,
       address.countryRegion,
-      address.country,
+      !omitCountry && address.country,
     ]
       .filter(i => i)
       .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]); // remove consecutive duplicated name
@@ -24,16 +24,16 @@ function toArray(address, omitStreet) {
     ? address.postcode + ' ' + address.city
     : address.city;
 
-  return [!omitStreet && address.street, cityAndPostcode, address.country]
+  return [!omitStreet && address.street, cityAndPostcode, !omitCountry && address.country]
     .filter(i => i); // Filter out any undefined value
 }
 
-const Address = ({ address, inline, omitStreet }) => {
-  const parts = toArray(address, omitStreet);
+const Address = ({ address, inline, omitStreet, omitCountry }) => {
+  const parts = toArray(address, { omitStreet, omitCountry });
   return inline
     ? parts.join(', ')
     : <div>
-      {toArray(address).map((item, index) => <div key={index}>{item}</div>)}
+      {parts.map((item, index) => <div key={index}>{item}</div>)}
     </div>;
 };
 
@@ -41,6 +41,7 @@ Address.propTypes = {
   address: PropTypes.object.isRequired,
   inline: PropTypes.bool,
   omitStreet: PropTypes.bool,
+  omitCountry: PropTypes.bool,
 };
 
 export default Address;

--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -4,7 +4,7 @@ import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geo
 import IconManager from '../../adapters/icon_manager';
 import Category from 'src/adapters/category';
 import Intention from 'src/adapters/intention';
-import { format as formatAddress } from '../../libs/address';
+import Address from 'src/components/ui/Address';
 
 const ItemLabels = ({ firstLabel, secondLabel }) =>
   <div className="autocomplete_suggestion__labels">
@@ -53,7 +53,11 @@ const PoiItem = ({ poi }) => {
   const icon = IconManager.get({ className, subClassName, type });
   const streetAddress = poi.alternativeName // fallback to alternativeName for older favorites
     ? poi.alternativeName
-    : formatAddress(poi.address);
+    : <Address
+      address={poi.address}
+      omitStreet={type === 'house' || type === 'street'}
+      inline
+    />;
 
   return (
     <div className="autocomplete_suggestion">

--- a/src/libs/address.js
+++ b/src/libs/address.js
@@ -1,44 +1,6 @@
 import IdunnPoi from '../adapters/poi/idunn_poi';
 
 /**
- * Filter an address and return an array with the relevant items
- * @param {*} address - an address object
- */
-export function toArray(address) {
-
-  if (!address) {return [];}
-
-  if (!address.street) {
-    return [
-      address.suburb,
-      address.cityDistrict,
-      address.city,
-      address.stateDistrict,
-      address.state,
-      address.countryRegion,
-      address.country,
-    ]
-      .filter(i => i)
-      .filter((item, pos, arr) => pos === 0 || item !== arr[pos - 1]); // remove consecutive duplicated name
-  }
-
-  const cityAndPostcode = address.postcode && address.city
-    ? address.postcode + ' ' + address.city
-    : address.city;
-
-  return [address.street, cityAndPostcode, address.country]
-    .filter(i => i); // Filter out any undefined value
-}
-/**
- * Format an address given an address object (name, city, country, label, and other regions)
- * @param {*} address - an address object
- * @param string separator - how items are joined
- */
-export function format(address, separator = ', ') {
-  return toArray(address).join(separator);
-}
-
-/**
  * Fetch an address from idunn given a raw poi
  * @param {*} poi - the poi to fetch address for
  */

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -12,6 +12,7 @@ import RecyclingBlock from './blocks/Recycling';
 import WikiBlock from './blocks/Wiki';
 import Block from 'src/panel/poi/blocks/Block';
 import Divider from 'src/components/ui/Divider';
+import Address from 'src/components/ui/Address';
 
 export default class PoiBlockContainer extends React.Component {
   static propTypes = {
@@ -56,7 +57,7 @@ export default class PoiBlockContainer extends React.Component {
           icon="map-pin"
           title={_('address')}
         >
-          {this.props.poi.address.label}
+          <Address inline address={this.props.poi.address} />
         </Block>
       }
       {imagesBlock && imagesBlock.images.length > 1 &&

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -275,11 +275,11 @@ test('check template', async () => {
   });
   /* street */
   expect(lines[0][0]).toEqualCaseInsensitive('037');
-  expect(lines[0][1]).toEqualCaseInsensitive('037, Ferriere, Italia');
+  expect(lines[0][1]).toEqualCaseInsensitive('Ferriere, Italia');
 
   /* house */
   expect(lines[1][0]).toEqualCaseInsensitive('37 Rue Robert');
-  expect(lines[1][1]).toEqualCaseInsensitive('37 Rue Robert, Nîmes, France');
+  expect(lines[1][1]).toEqualCaseInsensitive('Nîmes, France');
 
   /* poi */
   expect(lines[2][0]).toEqualCaseInsensitive('maga');

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -45,7 +45,7 @@ test('load a poi from url', async () => {
     };
   });
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris\nFrance/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
 });
 
 test('load a poi from url and click on directions', async () => {
@@ -67,7 +67,7 @@ test('load a poi from url with simple id', async () => {
     };
   });
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris\nFrance/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
 });
 
 test('load a poi from url on mobile', async () => {
@@ -82,7 +82,7 @@ test('load a poi from url on mobile', async () => {
     address: document.querySelector('.poiItem-address').innerText,
   }));
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris\nFrance/);
+  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
   expect(await exists(page, '.openingHour--closed')).toBeTruthy();
 });
 

--- a/tests/units/address.js
+++ b/tests/units/address.js
@@ -1,30 +1,6 @@
-import {
-  format,
-  normalize,
-} from '../../src/libs/address';
+import { normalize } from '../../src/libs/address';
 
 describe('Address utils', () => {
-  test('format', () => {
-    const cases = [
-      {
-        address: { street: 'street', city: 'city', country: 'country' },
-        expected: 'street, city, country',
-      },
-      {
-        address: { country: 'city' },
-        expected: 'city',
-      },
-      {
-        address: { country: 'country' },
-        expected: 'country',
-      },
-    ];
-
-    cases.forEach(({ address, expected }) => {
-      expect(format(address)).toEqual(expected);
-    });
-  });
-
   test('normalize', () => {
     const casesIdunn = [
       {


### PR DESCRIPTION
## Description
Rename the existing `<MultilineAddress>` component to simply `<Address>`, and improve it so it can manage all the cases throughout the app where we display addresses. Give it some props to adapt to special cases but still in a unified way:
 - `inline`, to format the address as a comma-separated string instead of multiple lines
 - `omitStreet`, to format the address without the street part (used to avoid some repetitions in suggest dropdown)
 - `omitCountry`, to format the address without the country part (used to simplify the addresses in the PoiPanel)

This `<Address>` component can be modified later if we proceed with smarter formatting of addresses, especially wrt. i18n.

## Why
 - Consistency, factorization
 - Better display of addresses depending on the context

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-08-07 à 15 27 56](https://user-images.githubusercontent.com/243653/89650633-09089080-d8c3-11ea-9130-891c5caf988e.png)|![Capture d’écran 2020-08-07 à 15 26 19](https://user-images.githubusercontent.com/243653/89650662-10c83500-d8c3-11ea-95c4-0a4fa800a0fa.png)|
|![Capture d’écran de 2020-08-07 15-28-10](https://user-images.githubusercontent.com/243653/89650684-1756ac80-d8c3-11ea-9e61-f4378a61e7d2.png)|![Capture d’écran de 2020-08-07 15-26-33](https://user-images.githubusercontent.com/243653/89650691-1b82ca00-d8c3-11ea-8fdf-a57c7429122a.png)|
|![Capture d’écran de 2020-08-07 15-28-01](https://user-images.githubusercontent.com/243653/89650710-20477e00-d8c3-11ea-8b17-9200d8573035.png)|![Capture d’écran de 2020-08-07 15-33-37](https://user-images.githubusercontent.com/243653/89650949-761c2600-d8c3-11ea-9573-aed4585aec03.png)|
