### PR TITLE
Fix: Favorite poi stored with obsolete format could break MultilineAddress 

### DIFF
--- a/src/adapters/poi/poi_store.js
+++ b/src/adapters/poi/poi_store.js
@@ -2,13 +2,24 @@ import Poi from './poi';
 import Store from '../../adapters/store';
 import Error from '../error';
 import Telemetry from '../../libs/telemetry';
+import { normalize as normalizeAddress } from 'src/libs/address';
 
 const store = new Store();
 export default class PoiStore extends Poi {
+  static new(rawStorePoi) {
+    const poi = Object.assign(new PoiStore(), rawStorePoi);
+    if (poi?.address?.admins) {
+      // The address has been stored with the raw Idunn format
+      // and should be normalized before usage
+      poi.address = normalizeAddress('idunn', poi);
+    }
+    return poi;
+  }
+
   static async get(term) {
     try {
       const matches = await store.getMatches(term);
-      return matches.map(match => Object.assign(new PoiStore(), match));
+      return matches.map(match => PoiStore.new(match));
     } catch (e) {
       Error.sendOnce('poi_store', 'get', 'error getting matching favorites', e);
       return [];
@@ -24,8 +35,6 @@ export default class PoiStore extends Poi {
       Error.sendOnce('poi_store', 'getAll', 'error getting pois', e);
       return [];
     }
-    return storedData.map(poi => {
-      return Object.assign(new PoiStore(), poi);
-    });
+    return storedData.map(poi => PoiStore.new(poi));
   }
 }


### PR DESCRIPTION
## Description
`address` objects stored in local storage should be normalized on loading to be compatible with the new address normalization.

## Why
In previous versions of Erdapfel, favorites used to be saved with the whole `address` object fetched from the Idunn API.
This format could break the `MultilineAddress` component that expects the `address` object to be flat (where all values are strings)

