### PR TITLE
[ESLint] No 'async' without 'await'

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -95,7 +95,8 @@
         "object-curly-spacing": ["error", "always"],
         "object-shorthand": "error",
         "react/prop-types": 0,
-        "jsx-quotes": ["error", "prefer-double"]
+        "jsx-quotes": ["error", "prefer-double"],
+        "require-await": "error"
     },
     "overrides": [
         {

--- a/bin/middlewares/og_meta.js
+++ b/bin/middlewares/og_meta.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
     );
   }
 
-  async function getPoi(poiId, locale) {
+  function getPoi(poiId, locale) {
     let id = poiId;
     const atPos = poiId.indexOf('@');
     if (atPos !== -1) {

--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -33,7 +33,7 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
   }
   /* ajax */
   let suggestsPromise;
-  const queryPromise = new Promise(async (resolve, reject) => {
+  const queryPromise = new Promise((resolve, reject) => {
     const query = {
       'q': term,
       'limit': geocoderConfig.maxItems,

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -55,7 +55,7 @@ PoiPopup.prototype.addListener = function(layer) {
     this.close();
   });
 
-  this.map.on('mouseleave', layer, async () => {
+  this.map.on('mouseleave', layer, () => {
     this.close();
     clearTimeout(this.timeOutHandler);
   });

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -352,7 +352,7 @@ Scene.prototype.addMarker = function(poi) {
   return marker;
 };
 
-Scene.prototype.cleanMarker = async function() {
+Scene.prototype.cleanMarker = function() {
   if (this.currentMarker !== null) {
     this.currentMarker.remove();
     this.currentMarker = null;

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -51,13 +51,13 @@ export default class Store {
       this.abstractStore = this.masqStore;
     }
 
-    this.masqStore.masq.eventTarget.addEventListener('logged_in', async () => {
+    this.masqStore.masq.eventTarget.addEventListener('logged_in', () => {
       // login was successful, use masqStore as abstractStore until signout
       this.abstractStore = this.masqStore;
       this.masqEventTarget.dispatchEvent(new Event('store_logged_in'));
     });
 
-    this.masqStore.masq.eventTarget.addEventListener('signed_out', async () => {
+    this.masqStore.masq.eventTarget.addEventListener('signed_out', () => {
       // signout was successful, use localStore as abstractStore until login
       this.abstractStore = this.localStore;
       this.masqEventTarget.dispatchEvent(new Event('store_logged_out'));

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -85,7 +85,7 @@ const Suggest = ({
       setLastQuery(value);
     };
 
-    const handleKeyDown = async event => {
+    const handleKeyDown = event => {
       if (event.key === 'Esc' || event.key === 'Escape') {
         if (inputNode.value === '' && !isMobile) {
           close();

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -13,7 +13,7 @@ Ajax.post = (url, data, options, headers = {}) => {
   return query(url, data, 'POST', options, headers);
 };
 
-Ajax.getLang = async (url, data = {}, options = {}, headers = {}) => {
+Ajax.getLang = (url, data = {}, options = {}, headers = {}) => {
   data.lang = window.getLang().code;
   return Ajax.get(url, data, options, headers);
 };

--- a/src/libs/async_file_loader.js
+++ b/src/libs/async_file_loader.js
@@ -1,5 +1,5 @@
 
-async function AsyncFileLoader(uri) {
+function AsyncFileLoader(uri) {
   return new Promise(resolve => {
     const sc = document.createElement('script');
     sc.onload = resolve;

--- a/src/libs/geolocation.js
+++ b/src/libs/geolocation.js
@@ -8,7 +8,7 @@ const geolocationPermissions = {
 };
 
 export default class GeolocationCheck {
-  static async checkPrompt(successCallback = () => {}) {
+  static checkPrompt(successCallback = () => {}) {
     if (!window.navigator.permissions) {
       // Some browsers (Safari, etc) do not implement Permissions API
       return successCallback();

--- a/src/libs/import_masq.js
+++ b/src/libs/import_masq.js
@@ -1,3 +1,3 @@
-export default async function importMasq() {
+export default function importMasq() {
   return import(/* webpackChunkName: "masq-lib" */ 'masq-lib');
 }

--- a/src/libs/local_store.js
+++ b/src/libs/local_store.js
@@ -8,7 +8,7 @@ export default class LocalStore {
     this.storeName = 'local_store';
   }
 
-  async getAllPois() {
+  getAllPois() {
     let localStorageKeys = [];
     try {
       localStorageKeys = Object.keys(localStorage);
@@ -38,11 +38,11 @@ export default class LocalStore {
     return this.set(`qmaps_v${version}_last_location`, loc);
   }
 
-  async has(k) {
-    return Boolean(await this.get(k));
+  has(k) {
+    return Boolean(this.get(k));
   }
 
-  async get(k) {
+  get(k) {
     try {
       return JSON.parse(localStorage.getItem(k));
     } catch (e) {
@@ -51,7 +51,7 @@ export default class LocalStore {
     }
   }
 
-  async set(k, v) {
+  set(k, v) {
     try {
       localStorage.setItem(k, JSON.stringify(v));
     } catch (e) {
@@ -59,7 +59,7 @@ export default class LocalStore {
     }
   }
 
-  async clear() {
+  clear() {
     try {
       localStorage.clear();
     } catch (e) {
@@ -67,7 +67,7 @@ export default class LocalStore {
     }
   }
 
-  async del(k) {
+  del(k) {
     try {
       localStorage.removeItem(k);
     } catch (e) {

--- a/src/libs/masq.js
+++ b/src/libs/masq.js
@@ -184,7 +184,7 @@ export default class MasqStore {
     }
   }
 
-  async clear() {
+  clear() {
     handleError('clear', 'masq storage doesn\'t support clear method');
   }
 

--- a/src/libs/telemetry.js
+++ b/src/libs/telemetry.js
@@ -29,7 +29,7 @@ export default class Telemetry {
     }
   }
 
-  static async send(event, extra_data) {
+  static send(event, extra_data) {
     if (!telemetry.enabled) {
       return;
     } else if (typeof event === 'undefined') {

--- a/src/modals/GeolocationModal.jsx
+++ b/src/modals/GeolocationModal.jsx
@@ -56,7 +56,7 @@ listen('open_geolocate_not_activated_modal', () => open('NOT_ACTIVATED', close))
 
 listen('open_geolocate_denied_modal', () => open('DENIED', close));
 
-export async function openAndWaitForClose() {
+export function openAndWaitForClose() {
   return new Promise(resolve => {
     open('PENDING', () => {
       close();

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -79,7 +79,7 @@ export default class PanelManager extends React.Component {
       });
     });
 
-    router.addRoute('POI', '/place/(.*)', async (poiUrl, options = {}) => {
+    router.addRoute('POI', '/place/(.*)', (poiUrl, options = {}) => {
       const poiId = poiUrl.split('@')[0];
       this.setState({
         ActivePanel: PoiPanel,

--- a/tests/integration/helpers/autocomplete.js
+++ b/tests/integration/helpers/autocomplete.js
@@ -42,7 +42,7 @@ export default class AutocompleteHelper {
     }, SUGGEST_SELECTOR);
   }
 
-  async getSearchInputValue() {
+  getSearchInputValue() {
     return getInputValue(this.page, SEARCH_INPUT_SELECTOR);
   }
 }

--- a/tests/integration/server_close.js
+++ b/tests/integration/server_close.js
@@ -1,3 +1,3 @@
-module.exports = async function() {
+module.exports = function() {
   global.appServer.close();
 };

--- a/tests/integration/tests/server.js
+++ b/tests/integration/tests/server.js
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 let server;
 
-beforeAll(async () => {
+beforeAll(() => {
   server = request(APP_URL);
 });
 


### PR DESCRIPTION
## Description
Following discussion [here](https://github.com/QwantResearch/erdapfel/pull/733#discussion_r466225601), add an ESLint rule to prevent declaring functions as `async` when it's not needed i.e. they don't include the `await` instruction.
Apply the rule to clean the current codebase.

## Why
Useless and can lead to false assumptions when reading the code.