### PR TITLE
Fix touchmove on minimized panel: 'document' can't receive events after target has been removed

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -57,6 +57,7 @@ export default class Panel extends React.Component {
   constructor(props) {
     super(props);
     this.moveHandler = null;
+    this.moveTarget = null;
     this.panelContentRef = React.createRef();
     this.state = {
       holding: false,
@@ -102,12 +103,13 @@ export default class Panel extends React.Component {
   }
 
   removeListeners() {
-    if (!this.moveHandler) {
+    if (!this.moveHandler || !this.moveTarget) {
       return;
     }
-    document.removeEventListener('touchmove', this.moveHandler);
-    document.removeEventListener('mousemove', this.moveHandler);
+    this.moveTarget.removeEventListener('touchmove', this.moveHandler);
+    this.moveTarget.removeEventListener('mousemove', this.moveHandler);
     this.moveHandler = null;
+    this.moveTarget = null;
   }
 
   holdResizer = (event, forceResize = false) => {
@@ -119,10 +121,13 @@ export default class Panel extends React.Component {
     this.removeListeners();
 
     this.moveHandler = event => this.move(event, forceResize);
+    this.moveTarget = event.target;
+    // It is important to attach the move handler to the current target (instead of `document`)
+    // in order to keep receiving the events, even if the target is removed from the DOM.
     if (event.type === 'touchstart') {
-      document.addEventListener('touchmove', this.moveHandler);
+      this.moveTarget.addEventListener('touchmove', this.moveHandler);
     } else {
-      document.addEventListener('mousemove', this.moveHandler);
+      this.moveTarget.addEventListener('mousemove', this.moveHandler);
     }
 
     this.setState(previousState => ({


### PR DESCRIPTION
## Description
This PR suggests to attach the move handler to the target where the touchstart/mousestart event has been trigger (instead of `document`)
This is necessary keep receiving the events, even if the target is removed from the DOM.

## Why
The Panel component renders a `<span className="minimizedTitle">` in the minimized state only.
When this <span> is the target of touchmove/mousemove events, it is then removed (`size` is set to 'default') and the events
can't bubble up to the document, where touchmove/mousemove handlers are attached.

This should fix a bug where a mouse/touch drag from the minimized state could start a resize action and leave the panel in an intermediate state before the move ends.