### PR TITLE
intentions: Ignore intention about unknown category

### DIFF
--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -61,7 +61,9 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
       });
       const bragiResponse = { pois };
       if (intentions) {
-        bragiResponse.intentions = intentions.map(intention => new Intention(intention));
+        bragiResponse.intentions = intentions
+          .map(intention => new Intention(intention))
+          .filter(intention => intention.isValid());
       }
       bragiCache[cacheKey] = bragiResponse;
       resolve(bragiResponse);

--- a/src/adapters/intention.js
+++ b/src/adapters/intention.js
@@ -9,6 +9,8 @@ export default class Intention {
     this.place = description.place;
   }
 
+  isValid = () => this.category || this.fullTextQuery;
+
   toQueryString = () => buildQueryString({
     q: this.fullTextQuery,
     type: this.category?.name,


### PR DESCRIPTION
## Why
This is a no-op for now, as frontend (erdapfel) and backend (idunn) applications are supposed to share the same list of categories.
But it will make easier for us to extend the list gradually, on the backend first, without breaking the application.
