### PR TITLE
[POI panel] Redesign mobile minimized and default content

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -5,7 +5,6 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
-import MultilineAddress from 'src/components/ui/Address';
 
 const PoiItem = ({ poi,
   withOpeningHours,
@@ -15,15 +14,6 @@ const PoiItem = ({ poi,
   ...rest
 }) => {
   const reviews = poi.blocksByType?.grades;
-  const address = poi.address || {};
-
-  const Address = () =>
-    poi.subClassName !== 'latlon'
-      ? <div className="u-text--subtitle poiItem-address">
-        <MultilineAddress address={address} omitCountry={poi.type !== 'admin'} />
-      </div>
-      : null
-  ;
 
   const Reviews = () =>
     reviews
@@ -45,7 +35,6 @@ const PoiItem = ({ poi,
   return <div className={classnames('poiItem', className)} {...rest}>
     <div className="poiItem-left">
       <PoiTitle poi={poi} withAlternativeName={withAlternativeName} />
-      <Address />
       <Reviews />
       <OpenStatus />
     </div>

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 
 const PoiItem = ({ poi,
   withOpeningHours,
-  withImage = true,
+  withImage,
   withAlternativeName,
   className,
   ...rest
@@ -28,13 +28,14 @@ const PoiItem = ({ poi,
       ? <OpeningHour
         withIcon
         schedule={new OsmSchedule(poi.blocksByType.opening_hours)}
-        showNextOpenOnly={true}
       />
       : null;
 
   return <div className={classnames('poiItem', className)} {...rest}>
     <div className="poiItem-left">
-      <PoiTitle poi={poi} withAlternativeName={withAlternativeName} />
+      <div className="u-mb-4">
+        <PoiTitle poi={poi} withAlternativeName={withAlternativeName} />
+      </div>
       <Reviews />
       <OpenStatus />
     </div>

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -36,8 +36,8 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
   const subclass = capitalizeFirst(poiSubClass(subClassName));
 
   // Location / address
-  return <div className="poiTitle u-mb-8">
-    <h2 className="poiTitle-main u-text--smallTitle">{title || subclass}</h2>
+  return <div className="poiTitle">
+    <h2 className="poiTitle-main u-text--heading6">{title || subclass}</h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
       {alternative}
     </div>}

--- a/src/components/ReviewScore.jsx
+++ b/src/components/ReviewScore.jsx
@@ -29,7 +29,7 @@ const ReviewScore = ({ poi, reviews: { global_grade, total_grades_count, url }, 
         <span key={k} className={k > global_grade ? 'icon-icon_star' : 'icon-icon_star-filled'} />
       )}
     </span>
-    <span className="u-text--caption reviewScore-count">
+    <span className="reviewScore-count">
       ({total_grades_count}) {_('on PagesJaunes', 'reviews')}
     </span>
   </a>;

--- a/src/panel/category/PoiItemList.jsx
+++ b/src/panel/category/PoiItemList.jsx
@@ -13,7 +13,7 @@ const PoiItems = ({
       onMouseOver={() => { highlightMarker(poi, true); }}
       onMouseOut={() => { highlightMarker(poi, false); }}
     >
-      <PoiItem poi={poi} withOpeningHours />
+      <PoiItem poi={poi} withOpeningHours withImage />
     </Item>)}
   </ItemList>;
 

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -21,10 +21,10 @@ export default class PoiBlockContainer extends React.Component {
   }
 
   render() {
-    if (!this.props.poi || !this.props.poi.blocks || this.props.poi.blocks.length === 0) {
+    if (!this.props.poi) {
       return null;
     }
-    const blocks = this.props.poi.blocks;
+    const blocks = this.props.poi.blocks || [];
     const hourBlock = blocks.find(b => b.type === 'opening_hours');
     const informationBlock = blocks.find(b => b.type === 'information');
     const phoneBlock = blocks.find(b => b.type === 'phone');
@@ -40,6 +40,11 @@ export default class PoiBlockContainer extends React.Component {
 
     return <div className="poi_panel__info">
       {wikipedia && <WikiBlock block={wikipedia} />}
+      {this.props.poi.address && this.props.poi.subClassName !== 'latlon' &&
+        <Block icon="map-pin" title={_('address')}>
+          <Address inline address={this.props.poi.address} omitCountry />
+        </Block>
+      }
       {displayCovidInfo &&
         <>
           <CovidBlock block={covidBlock} countryCode={this.props.poi.address.country_code} />
@@ -52,14 +57,6 @@ export default class PoiBlockContainer extends React.Component {
       {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {recyclingBlock && <RecyclingBlock block={recyclingBlock} />}
       {contactBlock && <ContactBlock block={contactBlock} />}
-      {this.props.poi.address.label &&
-        <Block
-          icon="map-pin"
-          title={_('address')}
-        >
-          <Address inline address={this.props.poi.address} />
-        </Block>
-      }
       {imagesBlock && imagesBlock.images.length > 1 &&
         <>
           <Divider />

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -41,7 +41,7 @@ export default class PoiBlockContainer extends React.Component {
     return <div className="poi_panel__info">
       {wikipedia && <WikiBlock block={wikipedia} />}
       {this.props.poi.address && this.props.poi.subClassName !== 'latlon' &&
-        <Block icon="map-pin" title={_('address')}>
+        <Block className="block-address" icon="map-pin" title={_('address')}>
           <Address inline address={this.props.poi.address} omitCountry />
         </Block>
       }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -20,7 +20,6 @@ import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
 import Flex from 'src/components/ui/Flex';
 import Divider from 'src/components/ui/Divider';
-import PoiTitle from 'src/components/PoiTitle';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -227,22 +226,30 @@ export default class PoiPanel extends React.Component {
   renderContent = (poi, { size: panelSize, isMobile }) => {
     if (isMobile && panelSize === 'minimized') {
       return <div className="poi_panel__content">
-        <PoiTitle poi={poi} withAlternativeName />
+        <PoiItem poi={poi} withAlternativeName />
       </div>;
     }
 
     return <div className="poi_panel__content">
-      <PoiItem poi={poi} withAlternativeName className="u-mb-24" onClick={this.center} />
-      <ActionButtons
+      <PoiItem
         poi={poi}
-        isDirectionActive={this.isDirectionActive}
-        openDirection={this.openDirection}
-        onClickPhoneNumber={this.onClickPhoneNumber}
-        isPoiInFavorite={this.state.isPoiInFavorite}
-        toggleStorePoi={this.toggleStorePoi}
+        withAlternativeName
+        withOpeningHours
+        className="u-mb-20"
+        onClick={this.center}
       />
+      <div className="u-mb-8">
+        <ActionButtons
+          poi={poi}
+          isDirectionActive={this.isDirectionActive}
+          openDirection={this.openDirection}
+          onClickPhoneNumber={this.onClickPhoneNumber}
+          isPoiInFavorite={this.state.isPoiInFavorite}
+          toggleStorePoi={this.toggleStorePoi}
+        />
+      </div>
       {(!isMobile || panelSize === 'maximized') && <div className="poi_panel__fullContent">
-        <Divider paddingBottom={10}/>
+        <Divider paddingTop={12} paddingBottom={10} />
         <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
         {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
           <h3 className="u-text--smallTitle">

--- a/src/panel/poi/blocks/Block.jsx
+++ b/src/panel/poi/blocks/Block.jsx
@@ -6,7 +6,7 @@ const Block = ({ icon, title, children, className }) =>
     <i className={`block-icon icon-${icon}`}/>
     <div className="block-content">
       <div className="u-firstCap u-text--caption u-mb-2">{title}</div>
-      {children}
+      <div className="block-value">{children}</div>
     </div>
   </div>;
 

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -216,9 +216,8 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 }
 
 @media (max-width: 640px) {
-  .poi_panel__content,
-  .poi_panel--empty-header .poi_panel__content {
-    padding: 0 12px 10px 12px;
+  .poi_panel__content {
+    padding: 0 12px 12px;
   }
 
   .poi_panel__description__ellipsis {

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -40,6 +40,13 @@
 
 /* Temporary typo classes, until we use real components */
 
+.u-text--heading6 {
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 22px;
+  letter-spacing: -0.2px;
+}
+
 .u-text--caption {
   font-size: 12px;
   line-height: 16px;
@@ -87,13 +94,4 @@
 
 .u-mb-20 {
   margin-bottom: 20px;
-}
-
-.u-mb-24 {
-  margin-bottom: 24px;
-}
-
-.u-text--label {
-  font-size: 12px;
-  color: $primary_text;
 }

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -38,14 +38,8 @@ test('click on a poi', async () => {
 test('load a poi from url', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poiTitle');
-  const { title, address } = await page.evaluate(() => {
-    return {
-      title: document.querySelector('.poiTitle').innerText,
-      address: document.querySelector('.poiItem-address').innerText,
-    };
-  });
+  const title = await page.evaluate(() => document.querySelector('.poiTitle').innerText);
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
 });
 
 test('load a poi from url and click on directions', async () => {
@@ -60,14 +54,8 @@ test('load a poi from url and click on directions', async () => {
 test('load a poi from url with simple id', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753`);
   await page.waitForSelector('.poiTitle');
-  const { title, address } = await page.evaluate(() => {
-    return {
-      title: document.querySelector('.poiTitle').innerText,
-      address: document.querySelector('.poiItem-address').innerText,
-    };
-  });
+  const title = await page.evaluate(() => document.querySelector('.poiTitle').innerText);
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
 });
 
 test('load a poi from url on mobile', async () => {
@@ -77,12 +65,8 @@ test('load a poi from url on mobile', async () => {
   });
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
   await page.waitForSelector('.poiTitle');
-  const { title, address } = await page.evaluate(() => ({
-    title: document.querySelector('.poiTitle').innerText,
-    address: document.querySelector('.poiItem-address').innerText,
-  }));
+  const title = await page.evaluate(() => document.querySelector('.poiTitle').innerText);
   expect(title).toMatch(/Musée d'Orsay/);
-  expect(address).toMatch(/1 Rue de la Légion d'Honneur\n75007 Paris/);
 });
 
 test('load a poi already in my favorite from url', async () => {
@@ -161,14 +145,16 @@ test('display details about the poi on a poi click', async () => {
   });
   expect(infoTitle.trim()).toEqual('');
 
-  const { contact, contactUrl, phone, website } = await page.evaluate(() => {
+  const { address, contact, contactUrl, phone, website } = await page.evaluate(() => {
     return {
+      address: document.querySelector('.block-address .block-value').innerText,
       contact: document.querySelector('.block-contact-link').innerText,
       contactUrl: document.querySelector('.block-contact-link').href,
       phone: document.querySelector('.block-phone').innerText,
       website: document.querySelector('.block-website').innerText,
     };
   });
+  expect(address).toEqual('1 Rue de la Légion d\'Honneur, 75007 Paris');
   expect(await exists(page, '.poi_panel .openingHour--closed')).toBeTruthy();
   expect(phone).toMatch('01 40 49 48 14');
   expect(website).toMatch('www.musee-orsay.fr');


### PR DESCRIPTION
## Description
New redesign of the POI panel content, for the three different panel sizes on mobile, according to the latest designs.
Except for:
- the title font size => *too big, needs to big discussed*
- the position of reviews, between the title and the POI class => *needs more component refacto, as the title and class are managed as a single component for now*

*Note: as a side effect of these changes, POI items in result lists change too. But this brings them closer to the final design of this part*

## Screenshots
|Before|After|
|---|---|
|![www qwant com_maps_places__type=restaurant(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/90528980-7fcf4480-e173-11ea-86dd-572da882357c.png)|![localhost_3000_place_pj_56927563@Les_Bios_Arts(iPhone 6_7_8 Plus) (2)](https://user-images.githubusercontent.com/243653/90528998-83fb6200-e173-11ea-97b0-0db4afa6002a.png)|
|![www qwant com_maps_place_pj_50015630@Le_Zinc_Du_March%C3%A9(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/90534463-0c7d0100-e17a-11ea-9dd8-76f7c982eaff.png)|![localhost_3000_(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/243653/90534476-10a91e80-e17a-11ea-8996-1f9c13b200cb.png)|
|![www qwant com_maps_place_pj_50015630@Le_Zinc_Du_March%C3%A9(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/90534723-5c5bc800-e17a-11ea-98e2-ec893ab59aca.png)|![localhost_3000_(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/243653/90534719-5bc33180-e17a-11ea-91b3-928368cb92e5.png)|