### PR TITLE
Progressive focus: send zoom level with autocomplete queries

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -29,6 +29,7 @@ services:
     maxItems: 7
     useFocus: true
     focusPrecision: '0.1' # lat/lon degrees
+    focusZoomPrecision: '1.0'
     useNlu: false
   idunn:
     url: override_by_environment

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -30,6 +30,7 @@ services:
     useFocus: true
     focusPrecision: '0.1' # lat/lon degrees
     focusZoomPrecision: '1.0'
+    focusMinZoom: 11
     useNlu: false
   idunn:
     url: override_by_environment

--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -7,6 +7,7 @@ import Intention from './intention';
 const serviceConfigs = nconf.get().services;
 const geocoderConfig = serviceConfigs.geocoder;
 const geocoderFocusPrecision = geocoderConfig.focusPrecision;
+const geocoderFocusZoomPrecision = geocoderConfig.focusZoomPrecision;
 
 const bragiCache = {};
 
@@ -17,11 +18,12 @@ function roundWithPrecision(value, precision, digits = 3) {
 
 export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}) {
   let cacheKey = term;
-  let { lat, lon } = focus;
+  let { lat, lon, zoom } = focus;
   if (lat !== undefined && lon !== undefined) {
     lat = roundWithPrecision(lat, geocoderFocusPrecision);
     lon = roundWithPrecision(lon, geocoderFocusPrecision);
-    cacheKey += `;${lat};${lon}`;
+    zoom = roundWithPrecision(zoom, geocoderFocusZoomPrecision);
+    cacheKey += `;${lat};${lon};${zoom}`;
   }
   /* cache */
   if (cacheKey in bragiCache) {
@@ -41,6 +43,7 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
     if (lat !== undefined && lon !== undefined) {
       query.lat = lat;
       query.lon = lon;
+      query.zoom = zoom;
     }
     if (geocoderConfig.useLang) {
       query.lang = window.getLang().code;
@@ -55,7 +58,7 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
           term,
           index + 1, // ranking
           query.lang,
-          { lat, lon, zoom: focus.zoom }
+          { lat, lon, zoom }
         );
         return new BragiPoi(feature, queryContext);
       });

--- a/src/adapters/query_context.js
+++ b/src/adapters/query_context.js
@@ -11,7 +11,7 @@ export default class QueryContext {
     this.ranking = ranking;
     this.lang = lang;
     // `position` field is supposed to contain `lon`, `lat` and `zoom`.
-    this.position = position;
+    this.position = position || {};
   }
 
   static toHeaders(queryContext) {

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -3,10 +3,10 @@ import { getGeocoderSuggestions } from 'src/adapters/geocoder';
 import CategoryService from './category_service';
 
 // @TODO: Improvement: don't access directly to window.map
-function getFocus(focusMinZoom) {
-  const zoom = window.map && window.map.mb && window.map.mb.getZoom();
-  if (zoom >= focusMinZoom) {
+function getFocus() {
+  if (window?.map?.mb) {
     const { lat, lng: lon } = window.map.mb.getCenter();
+    const zoom = window.map.mb.getZoom();
     return { lat, lon, zoom };
   }
   return {};
@@ -15,7 +15,6 @@ function getFocus(focusMinZoom) {
 export function suggestResults(term, {
   withCategories,
   useFocus,
-  focusMinZoom = 11,
   maxFavorites = 2,
   maxItems = 10,
 } = {}) {
@@ -27,7 +26,7 @@ export function suggestResults(term, {
   } else {
     promise = new Promise(async (resolve, reject) => {
       geocoderPromise = getGeocoderSuggestions(term, {
-        focus: useFocus ? getFocus(focusMinZoom) : {},
+        focus: useFocus ? getFocus() : {},
         useNlu: withCategories,
       });
       const favoritePromise = PoiStore.get(term);

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -12,8 +12,6 @@ import { suggestResults } from 'src/adapters/suggest_sources';
 
 const geocoderConfig = nconf.get().services.geocoder;
 const SUGGEST_MAX_ITEMS = geocoderConfig.maxItems;
-const SUGGEST_USE_FOCUS = geocoderConfig.useFocus;
-const SUGGEST_FOCUS_MIN_ZOOM = 11;
 
 export const selectItem = (selectedItem, { query, replaceUrl = false, fromQueryParams } = {}) => {
   if (selectedItem instanceof Poi) {
@@ -63,11 +61,10 @@ export const getInputValue = item => {
 
 export const fetchSuggests = (query, options = {}) =>
   suggestResults(query, {
-    withCategories: options.withCategories || false,
-    useFocus: options.useFocus || SUGGEST_USE_FOCUS,
-    focusMinZoom: options.focusMinZoom || SUGGEST_FOCUS_MIN_ZOOM,
-    maxItems: options.maxItems || SUGGEST_MAX_ITEMS,
-    maxFavorites: options.maxFavorites || !query ? 5 : 2,
+    withCategories: options.withCategories ?? false,
+    useFocus: options.useFocus ?? true,
+    maxItems: options.maxItems ?? SUGGEST_MAX_ITEMS,
+    maxFavorites: options.maxFavorites ?? (!query ? 5 : 2),
   });
 
 export const modifyList = (items, withGeoloc, query) => {

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -87,7 +87,10 @@ export default class SearchInput {
 
   static async executeSearch(query, { fromQueryParams } = {}) {
     window.__searchInput.searchInputHandle.value = query;
-    const results = await fetchSuggests(query, { withCategories: true });
+    const results = await fetchSuggests(query, {
+      withCategories: true,
+      useFocus: !fromQueryParams, // Ignore map position for a query passed in URL
+    });
 
     selectItem(
       results[0] || null,


### PR DESCRIPTION
## Description

Pass the zoom option to Idunn in order to allow a refinement of the focus mode. Currently, only the coordinates are passed when the zoom level is at least 11 which only allows for focus with a rather big scale.

This is the integration of changes in Idunn from https://github.com/QwantResearch/idunn/pull/162

---

**Update** by @amatissart:
This PR has been updated with a new setting `focusMinZoom` (default value: 11).  
The default behavior is unchanged, but it's now possible to allow focused search for lower zooms in the deploy configuration.