### PR TITLE
QMAPS-1639 reduce mobile placeholder to 14px and don't hide it on screens under 360px

### DIFF
--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -279,6 +279,10 @@ input[type="search"] {
     padding-right: 12px;
   }
 
+  .search_form__input::placeholder {
+    font-size: 14px;
+  }
+
   .search_form__wrapper {
     padding: 0 9px 0 12px;
   }
@@ -302,23 +306,5 @@ input[type="search"] {
 
   .search_form__return {
     width: 34px;
-  }
-}
-
-@media (max-width: 359px) {
-  .search_form__input {
-    &::placeholder {
-      color: transparent;
-    }
-
-    &::-webkit-input-placeholder {
-      color:transparent;
-    }
-    &::-moz-placeholder {
-      color:transparent;
-    }
-    &:-ms-input-placeholder {
-      color:transparent;
-    }
   }
 }


### PR DESCRIPTION
## Description
- Stop hiding field placeholder on screens below 360px wide
- Reduce the placeholder font size to 14px on mobile only
- Itinerary fields are unchanged (already 14px font-size)

## Screenshots

![image](https://user-images.githubusercontent.com/1225909/90637041-c2545800-e22b-11ea-81b5-a82f2a06e41e.png)

