### PR TITLE
QMAPS-1648 update the X icon's style

### DIFF
--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -33,7 +33,6 @@
     margin-left: auto;
 
     &:hover {
-      background: $background_hover;
       color: $primary_text;
     }
   }
@@ -56,6 +55,10 @@
     background: #f4f6fa;
     border-radius: 12px 12px 0 0;
     bottom: 0;
+
+    &-close {
+      color: $primary_text;
+    }
 
     &--white {
       background: white;


### PR DESCRIPTION
## Description

The X icon that closes a panel now has the following style:

- #0c0c0e on mobile
- #59595f on desktop / #0c0c0e on hover / no background circle on hover

Notes for @bbecquet / C.Ziegler:
- The X icon that empties a search field wasn't modified (to discuss: is it ok like that?)
- The X icon that closes the burger menu wasn't modified (to discuss: it is white. Will it stay white after Masq is removed?)
- I didn't make a separate "x-icon" component (yet), I don't think it belongs to this ticket which only asked for a little redesign.
If it's still necessary to create a component, may we do it in another ticket?


![image](https://user-images.githubusercontent.com/1225909/90652428-5a5b3d00-e23e-11ea-97ea-a558b257a965.png)
![image](https://user-images.githubusercontent.com/1225909/90652495-6a731c80-e23e-11ea-8d15-233fb6862b5c.png)

