### PR TITLE
[Perfs] Measure and send map initialization metrics

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -57,5 +57,7 @@ module.exports = {
     /* Covid-19 */
     'covid_caresteouvert_link',
     'covid_caresteouvert_contribute',
+    /* Perfs */
+    'perf_map_first_render',
   ],
 };

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -50,6 +50,8 @@ Scene.prototype.setupInitialPosition = async function(locationHash) {
 };
 
 Scene.prototype.initMapBox = function() {
+  window.times.initMapBox = Date.now();
+
   setRTLTextPlugin(
     `${baseUrl}statics/build/javascript/map_plugins/mapbox-gl-rtl-text.js`,
     error => {

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -15,7 +15,6 @@ import { isNullOrEmpty } from 'src/libs/object';
 import { isMobileDevice } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext.js';
 
-const performanceEnabled = nconf.get().performance.enabled;
 const directionConf = nconf.get().direction;
 
 const directSearchRouteName = 'Direct search query';
@@ -48,9 +47,7 @@ export default class PanelManager extends React.Component {
       'url_client': initialQueryParams['client'] || null,
     });
 
-    if (performanceEnabled) {
-      window.times.appRendered = Date.now();
-    }
+    window.times.appRendered = Date.now();
 
     listen('map_user_interaction', () => {
       if (this.state.ActivePanel === PoiPanel) {

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -6,6 +6,7 @@ import Router from 'src/proxies/app_router';
 import { parseMapHash, joinPath, getCurrentUrl } from 'src/libs/url_utils';
 import { listen } from 'src/libs/customEvents';
 import RootComponent from './RootComponent';
+import Telemetry from 'src/libs/telemetry';
 
 const burgerMenuEnabled = nconf.get().burgerMenu.enabled;
 
@@ -17,7 +18,13 @@ export default class App {
   constructor() {
     this.initMap();
     SearchInput.initSearchInput('#search');
-    listen('map_loaded', () => { window.times.mapLoaded = Date.now(); });
+    listen('map_loaded', () => {
+      window.times.mapLoaded = Date.now();
+      Telemetry.add(Telemetry.PERF_MAP_FIRST_RENDER, null, null, {
+        mapbox_init: window.times.initMapBox - window.times.init,
+        map_first_render: window.times.mapLoaded - window.times.initMapBox,
+      });
+    });
 
     this.router = new Router(window.baseUrl);
 

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -21,6 +21,7 @@ export default class App {
     listen('map_loaded', () => {
       window.times.mapLoaded = Date.now();
       Telemetry.add(Telemetry.PERF_MAP_FIRST_RENDER, null, null, {
+        app_render: window.times.appRendered - window.times.init,
         mapbox_init: window.times.initMapBox - window.times.init,
         map_first_render: window.times.mapLoaded - window.times.initMapBox,
       });

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -7,7 +7,6 @@ import { parseMapHash, joinPath, getCurrentUrl } from 'src/libs/url_utils';
 import { listen } from 'src/libs/customEvents';
 import RootComponent from './RootComponent';
 
-const performanceEnabled = nconf.get().performance.enabled;
 const burgerMenuEnabled = nconf.get().burgerMenu.enabled;
 
 if (!burgerMenuEnabled) {
@@ -18,9 +17,7 @@ export default class App {
   constructor() {
     this.initMap();
     SearchInput.initSearchInput('#search');
-    if (performanceEnabled) {
-      listen('map_loaded', () => { window.times.mapLoaded = Date.now(); });
-    }
+    listen('map_loaded', () => { window.times.mapLoaded = Date.now(); });
 
     this.router = new Router(window.baseUrl);
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -55,9 +55,7 @@
       </form>
       <div class="search_form__result"></div>
     </div>
-    <% if(config.performance.enabled) { %>
-      <script>window.times = {init : Date.now()}</script>
-    <% } %>
+    <script>window.times = {init : Date.now()}</script>
     <script src="./statics/build/javascript/bundle.js"></script>
     <noscript><%= _('JavaScript is required to view this application.') %></noscript>
   </body>


### PR DESCRIPTION
## Description
Always measure the times taken for MapBox-GL initialization and for the first map render, and transmit these metrics to the telemetry server with a new event.

## Why
Study the application startup bottleneck. 