### PR TITLE
[Fix] Focus search input only for real characters

### DIFF
--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -65,7 +65,9 @@ export default class SearchInput {
       if (MAPBOX_RESERVED_KEYS.find(key => key === e.key)) {
         return;
       }
-      if (!e.shiftKey && !e.ctrlKey && e.key !== 'Enter' && !e.altKey) {
+      // KeyboardEvent.key is either the printed character representation or a standard value for specials keys
+      // See https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values
+      if (e.key.length === 1) {
         if (document.activeElement
           && document.activeElement.tagName !== 'INPUT'
           && window.__searchInput.isEnabled) {


### PR DESCRIPTION
## Description
Change the test to determine which key typed anywhere on the website can trigger the focus on the main search input.  
Instead of excluding some (not enough) special keys, test that the key corresponds to a real printable character, and ignore all other keys.
The test for a real printable character can be made using the `key` property of a KeyboardEvent, which is a string with these values:
 - the Unicode printed representation of the key pressed, if it exists (so its length should equal 1. There may be special cases where it's not true, like if you imagine a Keyboard able to enter Emojis, but I think we can safely ignore them)
 - a standardized multi-char string otherwise: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values

So we trigger the focus only when the `key` length is 1.

## Why
The current test isn't restrictive enough, so many commonly used special keys set the focus on the field:
 - Esc
 - AltGr
 - Cmd (MacOS)
 - Windows key (Windows)
 - 'F*' Function keys
 - PageDown/Up,
 - etc.