### PR TITLE
Fix appearance of Wikipedia block

### DIFF
--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -40,16 +40,13 @@ export default class PoiBlockContainer extends React.Component {
 
     return <div className="poi_panel__info">
       {wikipedia && <WikiBlock block={wikipedia} />}
+      {displayCovidInfo &&
+        <CovidBlock block={covidBlock} countryCode={this.props.poi.address.country_code} />}
+      <Divider />
       {this.props.poi.address && this.props.poi.subClassName !== 'latlon' &&
         <Block className="block-address" icon="map-pin" title={_('address')}>
           <Address inline address={this.props.poi.address} omitCountry />
         </Block>
-      }
-      {displayCovidInfo &&
-        <>
-          <CovidBlock block={covidBlock} countryCode={this.props.poi.address.country_code} />
-          <Divider />
-        </>
       }
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {informationBlock && <InformationBlock block={informationBlock} />}

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -19,7 +19,6 @@ import Store from '../../adapters/store';
 import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
 import Flex from 'src/components/ui/Flex';
-import Divider from 'src/components/ui/Divider';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -249,7 +248,6 @@ export default class PoiPanel extends React.Component {
         />
       </div>
       {(!isMobile || panelSize === 'maximized') && <div className="poi_panel__fullContent">
-        <Divider paddingTop={12} paddingBottom={10} />
         <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
         {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
           <h3 className="u-text--smallTitle">

--- a/src/panel/poi/blocks/Wiki.jsx
+++ b/src/panel/poi/blocks/Wiki.jsx
@@ -1,25 +1,18 @@
 /* global _ */
 import React from 'react';
-import Flex from 'src/components/ui/Flex';
 
 const WikiBlock = ({
   block,
 }) => {
   return <div className="poi_panel__info__wiki">
-    { block.description &&
-      <p className="poi_panel__description__ellipsis">
-        { block.description }
-      </p> }
-    <br/>
-    { block.url && <Flex justifyContent="center">
-      <a
-        rel="noopener noreferrer"
-        target="_blank"
-        href={ block.url }
-      >
-        <span>{_('Read more on Wikipedia')}</span>
-      </a>
-    </Flex>}
+    { block.description && <p>{block.description}</p> }
+    { block.url && <a
+      rel="noopener noreferrer"
+      target="_blank"
+      href={ block.url }
+    >
+      {_('Read more on Wikipedia')}
+    </a>}
   </div>;
 };
 

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -103,6 +103,15 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
 .poi_panel__info__wiki {
   margin-top: 20px;
+  position: relative;
+
+  a {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    padding-left: 48px;
+    background: linear-gradient(to right, transparent 0, white 48px, white 100%);
+  }
 }
 
 .poi_panel__pictures_tiles {
@@ -218,10 +227,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 @media (max-width: 640px) {
   .poi_panel__content {
     padding: 0 12px 12px;
-  }
-
-  .poi_panel__description__ellipsis {
-    width: 100%;
   }
 
   .poi_panel.panel {


### PR DESCRIPTION
## Description
Modify the Wikipedia info block of the POI panel (as well as some margins and separators) so it matches more closely the design and takes less space.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-08-21 à 17 48 33](https://user-images.githubusercontent.com/243653/90910106-1bacba80-e3d7-11ea-943c-ced8adba7b41.png)|![Capture d’écran 2020-08-21 à 17 47 34](https://user-images.githubusercontent.com/243653/90910119-210a0500-e3d7-11ea-900e-34cf6af5b86a.png)|
|![Capture d’écran 2020-08-21 à 17 49 27](https://user-images.githubusercontent.com/243653/90910136-26674f80-e3d7-11ea-9153-e087bfbe5351.png)|![Capture d’écran 2020-08-21 à 17 49 49](https://user-images.githubusercontent.com/243653/90910142-2b2c0380-e3d7-11ea-85bc-90d641759d9f.png)|
