### PR TITLE
Manage search input content with history state

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -136,7 +136,7 @@ const Suggest = ({
         inputNode.value = getInputValue(item);
         close();
         if (onSelect) {
-          onSelect(item);
+          onSelect(item, { query: inputNode.value });
         }
       }}
       onClear={onClear}

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -15,11 +15,12 @@ const SUGGEST_MAX_ITEMS = geocoderConfig.maxItems;
 const SUGGEST_USE_FOCUS = geocoderConfig.useFocus;
 const SUGGEST_FOCUS_MIN_ZOOM = 11;
 
-export const selectItem = (selectedItem, { replaceUrl = false, fromQueryParams } = {}) => {
+export const selectItem = (selectedItem, { query, replaceUrl = false, fromQueryParams } = {}) => {
   if (selectedItem instanceof Poi) {
     window.app.navigateTo(`/place/${toUrl(selectedItem)}`, {
       poi: selectedItem,
       centerMap: true,
+      query,
     }, { replace: replaceUrl });
   } else if (selectedItem instanceof Category) {
     window.app.navigateTo(`/places/?type=${selectedItem.name}`,

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -8,6 +8,7 @@ import ServicePanel from './service/ServicePanel';
 import CategoryPanel from 'src/panel/category/CategoryPanel';
 import DirectionPanel from 'src/panel/direction/DirectionPanel';
 import Telemetry from 'src/libs/telemetry';
+import CategoryService from 'src/adapters/category_service';
 import { parseQueryString, getCurrentUrl } from 'src/libs/url_utils';
 import { fire } from 'src/libs/customEvents';
 import { isNullOrEmpty } from 'src/libs/object';
@@ -59,6 +60,19 @@ export default class PanelManager extends React.Component {
         fire('remove_category_markers');
         fire('remove_event_markers');
       }
+    }
+
+    this.updateSearchBarContent(options);
+  }
+
+  updateSearchBarContent({ poiFilters = {} }) {
+    const { category, query } = poiFilters;
+    if (category) {
+      SearchInput.setInputValue(CategoryService.getCategoryByName(category)?.getInputValue());
+    } else if (query) {
+      SearchInput.setInputValue(query);
+    } else {
+      SearchInput.setInputValue('');
     }
   }
 

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -65,10 +65,12 @@ export default class PanelManager extends React.Component {
     this.updateSearchBarContent(options);
   }
 
-  updateSearchBarContent({ poiFilters = {} }) {
-    const { category, query } = poiFilters;
-    if (category) {
-      SearchInput.setInputValue(CategoryService.getCategoryByName(category)?.getInputValue());
+  updateSearchBarContent({ poiFilters = {}, query }) {
+    if (poiFilters.category) {
+      const categoryLabel = CategoryService.getCategoryByName(poiFilters.category)?.getInputValue();
+      SearchInput.setInputValue(categoryLabel);
+    } else if (poiFilters.query) {
+      SearchInput.setInputValue(poiFilters.query);
     } else if (query) {
       SearchInput.setInputValue(query);
     } else {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -7,10 +7,8 @@ import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
 import CategoryPanelHeader from './CategoryPanelHeader';
 import Telemetry from 'src/libs/telemetry';
-import SearchInput from 'src/ui_components/search_input';
 import nconf from '@qwant/nconf-getter';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
-import CategoryService from 'src/adapters/category_service';
 import { getVisibleBbox } from 'src/panel/layouts';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import { boundsFromFlatArray, parseBboxString, boundsToString } from 'src/libs/bounds';
@@ -35,13 +33,13 @@ export default class CategoryPanel extends React.Component {
   }
 
   componentDidMount() {
-    this.updateSearchBarContent();
+    this.sendTelemetry();
     this.mapMoveHandler = listen('map_moveend', this.fetchData);
     window.execOnMapLoaded(() => { this.fitMap(); });
   }
 
   componentDidUpdate(prevProps) {
-    this.updateSearchBarContent(prevProps);
+    this.sendTelemetry(prevProps);
 
     const panelContent = document.querySelector('.panel-content');
     if (panelContent) {
@@ -56,23 +54,14 @@ export default class CategoryPanel extends React.Component {
     }
   }
 
-  updateSearchBarContent(prevProps) {
-    const { category, query } = this.props.poiFilters;
-    if (category) {
-      if (category !== prevProps?.poiFilters?.category) {
-        Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
-      }
-      const value = CategoryService.getCategoryByName(category)?.getInputValue();
-      if (value) {
-        SearchInput.setInputValue(value);
-      }
-    } else if (query) {
-      SearchInput.setInputValue(query);
+  sendTelemetry(prevProps) {
+    const { category } = this.props.poiFilters;
+    if (category && category !== prevProps?.poiFilters?.category) {
+      Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
     }
   }
 
   componentWillUnmount() {
-    SearchInput.setInputValue('');
     unListen(this.mapMoveHandler);
   }
 

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -13,7 +13,6 @@ import { isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
 import { buildQueryString } from 'src/libs/url_utils';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import Poi from 'src/adapters/poi/poi.js';
-import SearchInput from 'src/ui_components/search_input';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import Store from '../../adapters/store';
 import PoiItem from 'src/components/PoiItem';
@@ -86,7 +85,6 @@ export default class PoiPanel extends React.Component {
     fire('move_mobile_bottom_ui', 0);
     fire('clean_marker');
     fire('mobile_direction_button_visibility', true);
-    SearchInput.setInputValue('');
   }
 
   loadPois = () => {

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -80,7 +80,7 @@ export default class SearchInput {
     const results = await fetchSuggests(query, { withCategories: true });
     if (results && results.length > 0) {
       const firstResult = results[0];
-      selectItem(firstResult, { replaceUrl: true, fromQueryParams });
+      selectItem(firstResult, { query, replaceUrl: true, fromQueryParams });
       window.__searchInput.searchInputHandle.blur();
     }
   }


### PR DESCRIPTION
## Description
- Make the category label persistent in the main search input, when going from a POI list to a single POI of the list.
- Remove it when the user exits exit the category (ex: closing it explicitely, clicking elsewhere on the map, opening another feature, etc.)

To achieve that, instead of managing the content at the individual component level (`PoiPanel` and `CategoryPanel`), we do it at the same level as the router.
The logic is that content is dependant on the app navigation state (`poiFilters`, pushed as part of the history state of the POI list and a single POI). So if we update it at each route change, it will always be up-to-date with the application state, including when navigating back/forward.

This also makes the code cleaner, regrouping imperative manipulations of this search input in a single component.

