### PR TITLE
[Fix] Don't minimize panel when using back link

### DIFF
--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -147,7 +147,8 @@ export default class PoiPanel extends React.Component {
     });
   }
 
-  backToFavorite = () => {
+  backToFavorite = e => {
+    e.stopPropagation();
     Telemetry.add(Telemetry.POI_BACKTOFAVORITE);
     window.app.navigateTo('/favs');
   }
@@ -170,7 +171,8 @@ export default class PoiPanel extends React.Component {
     window.app.navigateTo('/');
   }
 
-  backToList = () => {
+  backToList = e => {
+    e.stopPropagation();
     const { poiFilters } = this.props;
     const queryObject = {};
     const mappingParams = {


### PR DESCRIPTION
## Description
Fix, follow up to https://github.com/QwantResearch/erdapfel/pull/749.

When using the "back to list" link on POI lists, the event was propagated and also triggered the panel to be minimized.
Stop event propagation to prevent this behavior.