### PR TITLE
QMAPS-1649 search field redesign

### DIFF
--- a/public/images/magnifier-blue.svg
+++ b/public/images/magnifier-blue.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="21px" height="20px" viewBox="0 0 21 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.2 (67145) - http://www.bohemiancoding.com/sketch -->
+    <title>Mask</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M19.7,18.3 L15.2,13.8 C16.3,12.4 17,10.5 17,8.5 C17,3.8 13.2,0 8.5,0 C3.8,0 0,3.8 0,8.5 C0,13.2 3.8,17 8.5,17 C10.5,17 12.3,16.3 13.8,15.2 L18.3,19.7 C18.5,19.9 18.8,20 19,20 C19.2,20 19.5,19.9 19.7,19.7 C20.1,19.3 20.1,18.7 19.7,18.3 Z M2,8.5 C2,4.9 4.9,2 8.5,2 C12.1,2 15,4.9 15,8.5 C15,10.3 14.3,11.9 13.1,13.1 C13.1,13.1 13.1,13.1 13.1,13.1 C13.1,13.1 13.1,13.1 13.1,13.1 C11.9,14.3 10.3,15 8.5,15 C4.9,15 2,12.1 2,8.5 Z" id="path-1"></path>
+    </defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Components/Qwant/Layout/Main-search/Active" transform="translate(-677.000000, -24.000000)">
+            <g id="Components/Main-search/Active">
+                <g id="Icons/24x24/search" transform="translate(677.933975, 24.000000)">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <use id="Mask" fill="#1a6aff" fill-rule="nonzero" xlink:href="#path-1"></use>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/public/images/magnifier-dark.svg
+++ b/public/images/magnifier-dark.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="21px" height="20px" viewBox="0 0 21 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.2 (67145) - http://www.bohemiancoding.com/sketch -->
+    <title>Mask</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M19.7,18.3 L15.2,13.8 C16.3,12.4 17,10.5 17,8.5 C17,3.8 13.2,0 8.5,0 C3.8,0 0,3.8 0,8.5 C0,13.2 3.8,17 8.5,17 C10.5,17 12.3,16.3 13.8,15.2 L18.3,19.7 C18.5,19.9 18.8,20 19,20 C19.2,20 19.5,19.9 19.7,19.7 C20.1,19.3 20.1,18.7 19.7,18.3 Z M2,8.5 C2,4.9 4.9,2 8.5,2 C12.1,2 15,4.9 15,8.5 C15,10.3 14.3,11.9 13.1,13.1 C13.1,13.1 13.1,13.1 13.1,13.1 C13.1,13.1 13.1,13.1 13.1,13.1 C11.9,14.3 10.3,15 8.5,15 C4.9,15 2,12.1 2,8.5 Z" id="path-1"></path>
+    </defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Components/Qwant/Layout/Main-search/Active" transform="translate(-677.000000, -24.000000)">
+            <g id="Components/Main-search/Active">
+                <g id="Icons/24x24/search" transform="translate(677.933975, 24.000000)">
+                    <mask id="mask-2" fill="white">
+                        <use xlink:href="#path-1"></use>
+                    </mask>
+                    <use id="Mask" fill="#59595F" fill-rule="nonzero" xlink:href="#path-1"></use>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/public/images/magnifier-light.svg
+++ b/public/images/magnifier-light.svg
@@ -13,7 +13,7 @@
                     <mask id="mask-2" fill="white">
                         <use xlink:href="#path-1"></use>
                     </mask>
-                    <use id="Mask" fill="#5C6F84" fill-rule="nonzero" xlink:href="#path-1"></use>
+                    <use id="Mask" fill="#898991" fill-rule="nonzero" xlink:href="#path-1"></use>
                 </g>
             </g>
         </g>

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -83,13 +83,6 @@ const Suggest = ({
       fetchItems(value);
       setIsOpen(true);
       setLastQuery(value);
-      const topBarHandle = document.querySelector('.top_bar');
-      if (value.length > 0) {
-        topBarHandle.classList.add('top_bar--search_filled');
-      }
-      else {
-        topBarHandle.classList.remove('top_bar--search_filled');
-      }
     };
 
     const handleKeyDown = async event => {

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -83,6 +83,13 @@ const Suggest = ({
       fetchItems(value);
       setIsOpen(true);
       setLastQuery(value);
+      const topBarHandle = document.querySelector('.top_bar');
+      if (value.length > 0) {
+        topBarHandle.classList.add('top_bar--search_filled');
+      }
+      else {
+        topBarHandle.classList.remove('top_bar--search_filled');
+      }
     };
 
     const handleKeyDown = async event => {

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -160,13 +160,22 @@ export default class PanelManager extends React.Component {
     const searchInput = document.querySelector('#search');
     const topBarHandle = document.querySelector('.top_bar');
 
-    searchInput.onfocus = () => {
+    searchInput.addEventListener('focus', () => {
       topBarHandle.classList.add('top_bar--search_focus');
-    };
+    });
 
-    searchInput.onblur = () => {
+    searchInput.addEventListener('blur', () => {
       topBarHandle.classList.remove('top_bar--search_focus');
-    };
+    });
+
+    searchInput.addEventListener('input', () => {
+      const value = searchInput.value;
+      if (value.length > 0) {
+        topBarHandle.classList.add('top_bar--search_filled');
+      } else {
+        topBarHandle.classList.remove('top_bar--search_filled');
+      }
+    });
   }
 
   setPanelSize = panelSize => {

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -70,15 +70,20 @@ export default class PanelManager extends React.Component {
   }
 
   updateSearchBarContent({ poiFilters = {}, query }) {
+    const topBarHandle = document.querySelector('.top_bar');
     if (poiFilters.category) {
       const categoryLabel = CategoryService.getCategoryByName(poiFilters.category)?.getInputValue();
       SearchInput.setInputValue(categoryLabel);
+      topBarHandle.classList.add('top_bar--search_filled');
     } else if (poiFilters.query) {
       SearchInput.setInputValue(poiFilters.query);
+      topBarHandle.classList.add('top_bar--search_filled');
     } else if (query) {
       SearchInput.setInputValue(query);
+      topBarHandle.classList.add('top_bar--search_filled');
     } else {
       SearchInput.setInputValue('');
+      topBarHandle.classList.remove('top_bar--search_filled');
     }
   }
 

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -30,7 +30,6 @@ export default class FavoritesPanel extends React.Component {
     });
   }
 
-
   removeFav = async poi => {
     Telemetry.add(Telemetry.FAVORITE_DELETE);
     this.setState(prevState => ({

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -844,8 +844,7 @@ button.direction_shortcut {
     background: $action-blue-base url(../images/direction.svg) center no-repeat;
 
     &:not(:disabled):hover {
-      background: $action-blue-base;
-      color: #fff;
+      background: $action-blue-base url(../images/direction.svg) center no-repeat;
     }
 
     /* Attempt to fix rare layout bug on iOS */

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -1,10 +1,10 @@
 
 #react_menu__container {
   align-self: stretch;
-  width: 42px;
+  width: 40px;
   position: absolute;
   right: 0;
-  top: 25px;
+  top: 24px;
 }
 
 .no-burger #react_menu__container {

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -2,7 +2,9 @@
 #react_menu__container {
   align-self: stretch;
   width: 42px;
-  margin-right: -12px;
+  position: absolute;
+  right: 0;
+  top: 25px;
 }
 
 .no-burger #react_menu__container {

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -1,3 +1,4 @@
+// Form
 .search_form {
   width: 100%;
   height: $top_bar_height;
@@ -23,6 +24,7 @@
   }
 }
 
+// Wrapper around the field and some icons, gets a colored border when the field is focused
 .search_form__wrapper {
   flex-grow: 1;
   flex-shrink: 1;
@@ -37,27 +39,7 @@
   position: relative;
 }
 
-.top_bar--search_focus {
-  .search_form:before {
-    display: none;
-  }
-
-  .search_form__wrapper {
-    background-color: white;
-
-    // Trick to display a gradient border
-    &:before {
-      content: '';
-      position: absolute;
-      top: 0; right: 0; bottom: 0; left: 0;
-      z-index: -1;
-      margin: -1px;
-      border-radius: inherit;
-      background: linear-gradient(to right, #216fff, #af27cc);
-    }
-  }
-}
-
+// Input
 .search_form__input {
   min-width: 0;
   width: 100%;
@@ -77,6 +59,7 @@
   }
 }
 
+// Hover
 .search_form__wrapper:hover {
   .search_form__input:not(:focus)::placeholder {
     opacity: 1;
@@ -98,6 +81,7 @@ input[type="search"] {
   }
 }
 
+// Logo
 .search_form__logo {
   flex-shrink: 0;
   width: 36px;
@@ -107,6 +91,7 @@ input[type="search"] {
   margin-right: 12px;
 }
 
+// Return arrow
 .search_form__return {
   flex-shrink: 0;
   display: none;
@@ -122,6 +107,7 @@ input[type="search"] {
   }
 }
 
+// Magnifying glass
 .search_form__action {
   width: 24px;
   background: url(../images/magnifier.svg) center no-repeat;
@@ -129,61 +115,17 @@ input[type="search"] {
   cursor: pointer;
 }
 
-.top_bar--search_focus.top_bar--search_filled {
-  .search_form__action {
-    background: url(../images/magnifier-blue.svg) center no-repeat;
-    background-size: 16px 16px;
-  }
-}
-
+// Clear X icon
 .search_form__clear {
   height: 60px;
   width: 30px;
   color: $secondary_text;
   cursor: pointer;
   font-size: 16px;
-}
-
-.search_form__clear {
   display: none;
 }
 
-.top_bar--search_filled #clear_button_desktop {
-  display: block;
-}
-
-/*.top_bar--search_focus.top_bar--search_filled .search_form__action {
-  color: $action-blue-base;
-}*/
-
-.search_form__direction_shortcut {
-  margin-right: -12px;
-  width: 48px;
-  height: 48px;
-  background: url(../images/direction-line.svg) center no-repeat;
-  background-size: 24px 24px;
-  cursor: pointer;
-  transition: filter .1s;
-
-  &:hover {
-    filter: brightness(80%);
-  }
-}
-
-.top_bar--search_filled {
-  .search_form__direction_shortcut {
-    display: none;
-  }
-
-  #clear_button_desktop {
-    width: 48px;
-    height: 48px;
-    bagkground-position: 10px center;
-    margin-right: -12px;
-  }
-
-}
-
+// Autocomplete
 .autocomplete_suggestions {
   max-height: calc(100vh - #{$top_bar_height});
   background: $background;
@@ -291,6 +233,68 @@ input[type="search"] {
   cursor: default;
 }
 
+// Directions icon
+.search_form__direction_shortcut {
+  margin-right: -12px;
+  width: 48px;
+  height: 48px;
+  background: url(../images/direction-line.svg) center no-repeat;
+  background-size: 24px 24px;
+  cursor: pointer;
+  transition: filter .1s;
+
+  &:hover {
+    filter: brightness(80%);
+  }
+}
+
+// When the search field is focused (empty or not)
+.top_bar--search_focus {
+
+  // White background
+  .search_form__wrapper {
+    background-color: white;
+
+    // Gradient border trick
+    &:before {
+      content: '';
+      position: absolute;
+      top: 0; right: 0; bottom: 0; left: 0;
+      z-index: -1;
+      margin: -1px;
+      border-radius: inherit;
+      background: linear-gradient(to right, #216fff, #af27cc);
+    }
+  }
+}
+
+// When the search field is focused and filled (focused or not)
+.top_bar--search_filled {
+
+  // Hide directions icon
+  .search_form__direction_shortcut {
+    display: none;
+  }
+
+  // Show desktop clear X icon
+  #clear_button_desktop {
+    width: 48px;
+    height: 48px;
+    bagkground-position: 10px center;
+    margin-right: -12px;
+    display: block;
+  }
+}
+
+// When the search field is focused and filled
+.top_bar--search_focus.top_bar--search_filled {
+  .search_form__action {
+    background: url(../images/magnifier-blue.svg) center no-repeat;
+    background-size: 16px 16px;
+  }
+}
+
+// Mobile
 @media (max-width: 640px) {
   .search_form {
     padding-right: 12px;
@@ -321,32 +325,44 @@ input[type="search"] {
     height: 34px;
   }
 
+  // When the search field is filled
   .top_bar--search_filled {
+
+    // Show mobile clear X button
     #clear_button_mobile {
       display: block;
     }
   }
 
+  // When the search field is focused
   .top_bar--search_focus {
+
+    // Hide the logo
     .search_form__logo {
       display: none;
     }
 
+    // Show return arrow
     .search_form__return {
       display: block;
     }
 
+    // Hide magnifying glass
     .search_form__action {
       display: none;
     }
   }
 
+  // When the field is filled and/or focused
   .top_bar--search_filled,
   .top_bar--search_focus {
+
+    // Hide mobile burger menu
     #react_menu__container {
       display: none;
     }
 
+    // Hide desktop clear X icon
     #clear_button_desktop {
       display: none;
     }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -319,6 +319,19 @@ input[type="search"] {
 
   .search_form__wrapper {
     padding: 0 9px 0 12px;
+    width: calc(100% - 100px);
+    left: 60px;
+    transition: width .25s, left .25s;
+    position: absolute;
+  }
+
+  .search_form__return {
+    display: block;
+    opacity: 0;
+    position: absolute;
+    top: 15px;
+    left: 12px;
+    transition: opacity .25s;
   }
 
   .search_form__action {
@@ -338,6 +351,12 @@ input[type="search"] {
     height: 34px;
   }
 
+  #react_menu__container {
+    opacity: 1;
+    transition: opacity .25s;
+    z-index: -1;
+  }
+
   // When the search field is filled
   .top_bar--search_filled {
 
@@ -352,12 +371,12 @@ input[type="search"] {
 
     // Hide the logo
     .search_form__logo {
-      display: none;
+      //display: none;
     }
 
     // Show return arrow
     .search_form__return {
-      display: block;
+      opacity: 1;
     }
 
     // Hide magnifying glass
@@ -372,12 +391,19 @@ input[type="search"] {
 
     // Hide mobile burger menu
     #react_menu__container {
-      display: none;
+      opacity: 0;
     }
 
     // Hide desktop clear X icon
     #clear_button_desktop {
       display: none;
+    }
+
+    // Make the wrapper full-width and overlap the rest
+    .search_form__wrapper {
+      left: 10px;
+      width: calc(100% - 20px);
+      padding: 0 0 0 40px;
     }
   }
 }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -38,14 +38,6 @@
 }
 
 .top_bar--search_focus {
-  .search_form__logo {
-    display: none;
-  }
-
-  .search_form__return {
-    display: block;
-  }
-
   .search_form:before {
     display: none;
   }
@@ -118,11 +110,11 @@ input[type="search"] {
 .search_form__return {
   flex-shrink: 0;
   display: none;
-  width: 36px;
-  font-size: 32px;
+  width: 20px;
+  font-size: 20px;
   text-align: center;
   color: $grey-black;
-  margin-right: 12px;
+  margin-right: 8px;
   cursor: pointer;
 
   &:hover {
@@ -137,6 +129,13 @@ input[type="search"] {
   cursor: pointer;
 }
 
+.top_bar--search_focus.top_bar--search_filled {
+  .search_form__action {
+    background: url(../images/magnifier-blue.svg) center no-repeat;
+    background-size: 16px 16px;
+  }
+}
+
 .search_form__clear {
   height: 60px;
   width: 30px;
@@ -145,13 +144,17 @@ input[type="search"] {
   font-size: 16px;
 }
 
-.search_form__input:valid ~ .search_form__clear {
+.search_form__clear {
+  display: none;
+}
+
+.top_bar--search_filled #clear_button_desktop {
   display: block;
 }
 
-.search_form__input:invalid ~ .search_form__clear {
-  display: none;
-}
+/*.top_bar--search_focus.top_bar--search_filled .search_form__action {
+  color: $action-blue-base;
+}*/
 
 .search_form__direction_shortcut {
   margin-right: -12px;
@@ -165,6 +168,20 @@ input[type="search"] {
   &:hover {
     filter: brightness(80%);
   }
+}
+
+.top_bar--search_filled {
+  .search_form__direction_shortcut {
+    display: none;
+  }
+
+  #clear_button_desktop {
+    width: 48px;
+    height: 48px;
+    bagkground-position: 10px center;
+    margin-right: -12px;
+  }
+
 }
 
 .autocomplete_suggestions {
@@ -304,7 +321,34 @@ input[type="search"] {
     height: 34px;
   }
 
-  .search_form__return {
-    width: 34px;
+  .top_bar--search_filled {
+    #clear_button_mobile {
+      display: block;
+    }
+  }
+
+  .top_bar--search_focus {
+    .search_form__logo {
+      display: none;
+    }
+
+    .search_form__return {
+      display: block;
+    }
+
+    .search_form__action {
+      display: none;
+    }
+  }
+
+  .top_bar--search_filled,
+  .top_bar--search_focus {
+    #react_menu__container {
+      display: none;
+    }
+
+    #clear_button_desktop {
+      display: none;
+    }
   }
 }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -97,9 +97,13 @@ input[type="search"] {
 // Magnifying glass
 .search_form__action {
   width: 24px;
+  height: 48px;
   background: url(../images/magnifier-light.svg) center no-repeat;
   background-size: 16px 16px;
   cursor: pointer;
+  position: absolute;
+  top: 0;
+  right: 12px;
 }
 
 // Clear X icon

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -3,7 +3,6 @@
   width: 100%;
   height: $top_bar_height;
   position: relative;
-  display: flex;
   align-items: center;
   pointer-events: auto;
   padding: 8px 12px;
@@ -26,28 +25,28 @@
 
 // Wrapper around the field and some icons, gets a colored border when the field is focused
 .search_form__wrapper {
-  flex-grow: 1;
-  flex-shrink: 1;
   height: 48px;
   padding: 0 16px;
   border: none;
   background-color: $surface;
   border-radius: 24px;
   margin: 1px;
-  display: flex;
   align-items: center;
-  position: relative;
+  position: absolute;
+  width: calc(100% - 110px);
+  top: 8px;
+  left: 63px;
 }
 
 // Input
 .search_form__input {
   min-width: 0;
-  width: 100%;
+  width: calc(100% - 30px);
+  height: 48px;
   font-size: 16px;
   font-weight: normal;
   color: #353c52;
   box-shadow: none;
-  align-self: stretch;
 
   &::placeholder {
     color: $secondary_text;
@@ -83,17 +82,15 @@ input[type="search"] {
 
 // Logo
 .search_form__logo {
-  flex-shrink: 0;
   width: 36px;
   height: 36px;
   background: url(../images/qwant-logo.svg) no-repeat;
   background-size: cover;
-  margin-right: 12px;
+  margin-top: 7px;
 }
 
 // Return arrow
 .search_form__return {
-  flex-shrink: 0;
   display: none;
   width: 20px;
   font-size: 20px;
@@ -110,7 +107,7 @@ input[type="search"] {
 // Magnifying glass
 .search_form__action {
   width: 24px;
-  background: url(../images/magnifier.svg) center no-repeat;
+  background: url(../images/magnifier-light.svg) center no-repeat;
   background-size: 16px 16px;
   cursor: pointer;
 }
@@ -190,7 +187,7 @@ input[type="search"] {
 .autocomplete_suggestion--intention {
   .autocomplete-icon {
     height: 30px;
-    background: url(../images/magnifier.svg) center no-repeat;
+    background: url(../images/magnifier-light.svg) center no-repeat;
     color: #353c52;
   }
 }
@@ -235,13 +232,16 @@ input[type="search"] {
 
 // Directions icon
 .search_form__direction_shortcut {
-  margin-right: -12px;
   width: 48px;
   height: 48px;
   background: url(../images/direction-line.svg) center no-repeat;
   background-size: 24px 24px;
   cursor: pointer;
   transition: filter .1s;
+  position: absolute;
+  right: 2px;
+  top: 10px;
+
 
   &:hover {
     filter: brightness(80%);
@@ -268,7 +268,7 @@ input[type="search"] {
   }
 }
 
-// When the search field is focused and filled (focused or not)
+// When the search field is filled (focused or not)
 .top_bar--search_filled {
 
   // Hide directions icon
@@ -281,9 +281,20 @@ input[type="search"] {
     width: 48px;
     height: 48px;
     bagkground-position: 10px center;
-    margin-right: -12px;
     display: block;
+    position: absolute;
+    right: 2px;
+    top: 10px;
+    &:hover::before {
+      color: $grey-black;
+    }
   }
+
+  .search_form__action:hover {
+    background: url(../images/magnifier-blue.svg) center no-repeat;
+    background-size: 16px 16px;
+  }
+
 }
 
 // When the search field is focused and filled
@@ -293,6 +304,8 @@ input[type="search"] {
     background-size: 16px 16px;
   }
 }
+
+
 
 // Mobile
 @media (max-width: 640px) {

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -42,7 +42,7 @@
 .search_form__input {
   min-width: 0;
   width: calc(100% - 30px);
-  height: 48px;
+  height: 46px;
   font-size: 16px;
   font-weight: normal;
   color: #353c52;
@@ -92,16 +92,6 @@ input[type="search"] {
 // Return arrow
 .search_form__return {
   display: none;
-  width: 20px;
-  font-size: 20px;
-  text-align: center;
-  color: $grey-black;
-  margin-right: 8px;
-  cursor: pointer;
-
-  &:hover {
-    color: $primary_text;
-  }
 }
 
 // Magnifying glass
@@ -242,7 +232,6 @@ input[type="search"] {
   right: 2px;
   top: 10px;
 
-
   &:hover {
     filter: brightness(80%);
   }
@@ -313,25 +302,43 @@ input[type="search"] {
     padding-right: 12px;
   }
 
+  .search_form__input {
+    width: calc(100% - 35px);
+    padding: 0 0 0 12px;
+  }
+
   .search_form__input::placeholder {
     font-size: 14px;
   }
 
   .search_form__wrapper {
-    padding: 0 9px 0 12px;
+    padding: 0;
     width: calc(100% - 100px);
     left: 60px;
-    transition: width .25s, left .25s;
+    transition: width .15s, left .15s;
     position: absolute;
   }
 
   .search_form__return {
+    font-size: 20px;
+    text-align: center;
+    color: #0c0c0e;
+    margin-right: 8px;
+    cursor: pointer;
+
     display: block;
     opacity: 0;
     position: absolute;
-    top: 15px;
-    left: 12px;
-    transition: opacity .25s;
+    transition: opacity .15s;
+    top: 0;
+    left: 0;
+    width: 30px;
+    height: 60px;
+    padding: 13px 0 0 12px;
+
+    &:hover {
+      color: $primary_text;
+    }
   }
 
   .search_form__action {
@@ -363,25 +370,19 @@ input[type="search"] {
     // Show mobile clear X button
     #clear_button_mobile {
       display: block;
+      position: absolute;
+      right: 15px;
+      top: 0;
+      height: 50px;
     }
   }
 
-  // When the search field is focused
+  // When the search field is focused (empty or not)
   .top_bar--search_focus {
 
-    // Hide the logo
-    .search_form__logo {
-      //display: none;
-    }
-
-    // Show return arrow
-    .search_form__return {
+    .search_form__input::placeholder {
+      color: $grey-semi-darkness;
       opacity: 1;
-    }
-
-    // Hide magnifying glass
-    .search_form__action {
-      display: none;
     }
   }
 
@@ -403,7 +404,17 @@ input[type="search"] {
     .search_form__wrapper {
       left: 10px;
       width: calc(100% - 20px);
-      padding: 0 0 0 40px;
+      padding: 0 0 0 30px;
+    }
+
+    // Show return arrow
+    .search_form__return {
+      opacity: 1;
+    }
+
+    // Hide magnifying glass
+    .search_form__action {
+      display: none;
     }
   }
 }

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -35,12 +35,13 @@ export default class SearchInput {
       const isActive = document.activeElement.id === inputElement.id;
       inputElement.value = '';
 
-      if (blur) {
-        inputElement.blur();
-      }
       if (!isMobile || isMobile && isActive) {
         // Trigger an input event to refresh Suggest's state
         inputElement.dispatchEvent(new Event('input'));
+      }
+
+      if (blur) {
+        inputElement.blur();
       }
       window.app.navigateTo('/');
     };

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -34,6 +34,7 @@ export default class SearchInput {
       const isMobile = isMobileDevice();
       const isActive = document.activeElement.id === inputElement.id;
       inputElement.value = '';
+      const topBarHandle = document.querySelector('.top_bar');
 
       if (!isMobile || isMobile && isActive) {
         // Trigger an input event to refresh Suggest's state
@@ -42,7 +43,10 @@ export default class SearchInput {
 
       if (blur) {
         inputElement.blur();
+        topBarHandle.classList.remove('top_bar--search_focus');
       }
+
+      topBarHandle.classList.remove('top_bar--search_filled');
       window.app.navigateTo('/');
     };
 

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -34,6 +34,8 @@ export default class SearchInput {
       const isMobile = isMobileDevice();
       const isActive = document.activeElement.id === inputElement.id;
       inputElement.value = '';
+      const topBarHandle = document.querySelector('.top_bar');
+      topBarHandle.classList.remove('top_bar--search_filled');
 
       if (!isMobile || isMobile && isActive) {
         // Trigger an input event to refresh Suggest's state

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -28,7 +28,7 @@ export default class SearchInput {
 
     window.__searchInput = new SearchInput(tagSelector);
 
-    window.clearSearch = e => {
+    window.clearSearch = (e, blur = false) => {
       e.preventDefault(); // Prevent losing focus
       const inputElement = document.querySelector(tagSelector);
       const isMobile = isMobileDevice();
@@ -37,11 +37,13 @@ export default class SearchInput {
       const topBarHandle = document.querySelector('.top_bar');
       topBarHandle.classList.remove('top_bar--search_filled');
 
+      if (blur) {
+        inputElement.blur();
+      }
       if (!isMobile || isMobile && isActive) {
         // Trigger an input event to refresh Suggest's state
         inputElement.dispatchEvent(new Event('input'));
       }
-
       window.app.navigateTo('/');
     };
 

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -34,8 +34,6 @@ export default class SearchInput {
       const isMobile = isMobileDevice();
       const isActive = document.activeElement.id === inputElement.id;
       inputElement.value = '';
-      const topBarHandle = document.querySelector('.top_bar');
-      topBarHandle.classList.remove('top_bar--search_filled');
 
       if (blur) {
         inputElement.blur();

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -32,7 +32,7 @@ test('search and clear', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Hello');
-  expect(await exists(page, '#clear_button')).toBeTruthy();
+  expect(await exists(page, '#clear_button_desktop')).toBeTruthy();
 
   const autocompleteItems = await autocompleteHelper.getSuggestList();
   expect(autocompleteItems.length).toEqual(SUGGEST_MAX_ITEMS);
@@ -40,7 +40,7 @@ test('search and clear', async () => {
   const searchValue = await autocompleteHelper.getSearchInputValue();
   expect(searchValue).toEqual('Hello');
 
-  await page.click('#clear_button');
+  await page.click('#clear_button_desktop');
   const searchValueAfterClear = await autocompleteHelper.getSearchInputValue();
   expect(searchValueAfterClear).toEqual('');
 });
@@ -229,7 +229,7 @@ test('submit key', async () => {
 
   let firstFeatureCenter = mockAutocomplete.features[0].geometry.coordinates;
   expect(center).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
-  await page.click('#clear_button');
+  await page.click('#clear_button_desktop');
 
   /* force specific query */
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=paris/);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,15 +42,16 @@
           data-flag-text="<%= config.app.versionFlag %>"
         <% } %> >
         <div class="search_form__logo"></div>
-        <div class="search_form__return icon-arrow-left"></div>
-        <div class="search_form__wrapper">
+        <div class="search_form__wrapper empty unfocused">
+          <div class="search_form__return icon-arrow-left"></div>
           <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
-          <button id="clear_button" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
+          <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
           <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">
         </div>
         <div id="react_menu__container"></div>
         <% if(config.direction.enabled) { %>
         <button class="search_form__direction_shortcut" title="<%= _('Directions', 'top bar') %>"></button>
+        <button id="clear_button_desktop" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
         <% } %>
       </form>
       <div class="search_form__result"></div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,13 +42,13 @@
           data-flag-text="<%= config.app.versionFlag %>"
         <% } %> >
         <div class="search_form__logo"></div>
+        <div id="react_menu__container"></div>
         <div class="search_form__wrapper empty unfocused">
           <div class="search_form__return icon-arrow-left"></div>
           <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
           <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
           <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">
         </div>
-        <div id="react_menu__container"></div>
         <% if(config.direction.enabled) { %>
         <button class="search_form__direction_shortcut" title="<%= _('Directions', 'top bar') %>"></button>
         <button id="clear_button_desktop" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,8 +43,8 @@
         <% } %> >
         <div class="search_form__logo"></div>
         <div id="react_menu__container"></div>
-        <div class="search_form__wrapper empty unfocused">
-          <div class="search_form__return icon-arrow-left"></div>
+        <div class="search_form__wrapper empty">
+          <div class="search_form__return icon-arrow-left" onmousedown="clearSearch(event, true)"></div>
           <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
           <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
           <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">


### PR DESCRIPTION
## Description
Update the display and behavior of the main search field on mobile and desktop.
For each device, there are 4 views with different colors/icons/sizes:

Unfocused empty
![image](https://user-images.githubusercontent.com/1225909/91823933-44844980-ec3a-11ea-8bb3-f9d210cb43aa.png)
![image](https://user-images.githubusercontent.com/1225909/91823971-4f3ede80-ec3a-11ea-98bc-0842eaf8362f.png)


Focused empty
![image](https://user-images.githubusercontent.com/1225909/91823779-0b4bd980-ec3a-11ea-8d46-de4d676a7248.png)
![image](https://user-images.githubusercontent.com/1225909/91823793-11da5100-ec3a-11ea-9aa1-ac1db2d07749.png)


Unfocused filled

![image](https://user-images.githubusercontent.com/1225909/91823815-1a328c00-ec3a-11ea-98b1-be1f8bc03343.png)
![image](https://user-images.githubusercontent.com/1225909/91823834-20286d00-ec3a-11ea-9eea-bd2651151d16.png)


Focused filled
![image](https://user-images.githubusercontent.com/1225909/91823865-2f0f1f80-ec3a-11ea-86c8-1274c3b2eddf.png)

![image](https://user-images.githubusercontent.com/1225909/91823857-29193e80-ec3a-11ea-9773-84021ef4b239.png)

Besides this redesign:
- the HTML code has changed (reordering of elements)
- the JS code was enhanced to represent the focused and filled states with css classes on the top bar.
- the tests have been fixed.
- the return arrow on mobile now clears the field

Other detail asked by design team but to do in a different ticket:
- Another style for unfocused filled while we're scrolling the suggests on mobile, or while a list item has been selected (in this case the arrow must disappear)
- Gradient on the right of the field when there's too much text: 
![image](https://user-images.githubusercontent.com/1225909/91824648-616d4c80-ec3b-11ea-927a-b545ecb853a1.png)