### PR TITLE
[POI List] Fix review scores

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -11,6 +11,7 @@ const PoiItem = ({ poi,
   withImage,
   withAlternativeName,
   className,
+  inList,
   ...rest
 }) => {
   const reviews = poi.blocksByType?.grades;
@@ -18,7 +19,7 @@ const PoiItem = ({ poi,
   const Reviews = () =>
     reviews
       ? <span className="poiItem-reviews">
-        <ReviewScore reviews={reviews} poi={poi} inList />
+        <ReviewScore reviews={reviews} poi={poi} inList={inList} />
       </span>
       : null
   ;

--- a/src/panel/category/PoiItemList.jsx
+++ b/src/panel/category/PoiItemList.jsx
@@ -13,7 +13,7 @@ const PoiItems = ({
       onMouseOver={() => { highlightMarker(poi, true); }}
       onMouseOut={() => { highlightMarker(poi, false); }}
     >
-      <PoiItem poi={poi} withOpeningHours withImage />
+      <PoiItem poi={poi} withOpeningHours withImage inList />
     </Item>)}
   </ItemList>;
 

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -61,6 +61,7 @@
 
     .poiItem {
       padding: 12px 16px;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
When `<ReviewScore>` elements are displayed in the context of a POI List:
 - correctly pass the `inList` 
 - make them unclickable on mobile to avoid triggering the link instead of the POI Item (review links are still clickable on the detailed view)