### PR TITLE
[Panel] Simplify touch event handling and fix on iOS

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -215,7 +215,6 @@ class Panel extends React.Component {
                 'panel-header',
                 { 'panel-resizeHandle': resizable && isMobile }
               )}
-              ref={element => this.handleElement = element}
               onClick={() => isMobile && this.handleHeaderClick()}
             >
               {resizable && isMobile && size === 'minimized' && minimizedTitle

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -106,7 +106,7 @@ class Panel extends React.Component {
     document.removeEventListener('mousemove', this.move);
   }
 
-  holdResizer = event => {
+  startResize = event => {
     this.startHeight = this.panelDOMElement.offsetHeight;
     this.startClientY = getEventClientY(event.nativeEvent);
 
@@ -183,8 +183,8 @@ class Panel extends React.Component {
 
   getEventHandlers() {
     return {
-      onMouseDown: this.holdResizer,
-      onTouchStart: this.holdResizer,
+      onMouseDown: this.startResize,
+      onTouchStart: this.startResize,
       onMouseUp: this.stopResize,
       onTouchEnd: this.stopResize,
     };

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -182,7 +182,9 @@ class Panel extends React.Component {
       window.innerHeight - this.props.marginTop,
     );
 
-    this.props.setSize(newSize);
+    if (newSize !== this.props.size) {
+      this.props.setSize(newSize);
+    }
     this.setState({ holding: false, currentHeight: null });
   }
 

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -16,7 +16,7 @@ const SWIPE_THRESHOLD_PX = 50;
 // Pixel threshold from the bottom or top of the viewport to span to min or max
 const MIN_MAX_THRESHOLD_PX = 75;
 
-function getTargetSize(previousSize, moveDuration, startHeight, endHeight, maxSize) {
+function getTargetSize(previousSize, startHeight, endHeight, maxSize) {
   let size = previousSize;
   const heightDelta = startHeight - endHeight;
   if (Math.abs(heightDelta) < SWIPE_THRESHOLD_PX) {
@@ -115,7 +115,6 @@ class Panel extends React.Component {
     // event.preventDefault();
     this.startHeight = this.panelDOMElement.offsetHeight;
     this.startClientY = getEventClientY(event.nativeEvent);
-    this.interactionStarted = event.timeStamp;
 
     this.removeListeners();
 
@@ -176,7 +175,6 @@ class Panel extends React.Component {
 
     const newSize = getTargetSize(
       this.props.size,
-      event.timeStamp - this.interactionStarted,
       this.startHeight,
       this.state.currentHeight,
       window.innerHeight - this.props.marginTop,


### PR DESCRIPTION
## Description
This PR simplifies parts of the `<Panel>` component related to user gestures on mobile.

The root reason was several bugs, especially a big one on iOS which prevented most user interaction on the POI Panel. While debugging, it appears that Safari event manager seemed sometimes confused by React re-renders happening between the `touchstart` and `touchend` event. This lead to the [normal event firing chain](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent#Event_order) being interrupted, so `click` event at the end was never called, and interactive elements inside the panel didn't respond.

The simplification consists mainly of two parts:

**1. avoid unnecessary state/props update**
- don't update the height state on `touchstart`, just init some vars and attach listeners. Updating the state on `touchmove` if the user starts a dragging move is enough.
- don't update the height state/props on `touchend` if nothing actually changed.

As a result, if the user only performed a "click" action in the panel content, the panel state won't change at all and the normal event chain won't be disturbed.
We also spare some React update cycles, which can benefit perceived performance.

**2. simplify the event handlers**
As another result of the event chain being complete, we don't need to manage separately the case of clicks on the panel header. The dragging handlers can be attached to the whole panel, and the click handler on the header is enough.
This allows us to remove the code which distinguished both cases using the `forceResize` var. This makes the event handling code far easier to follow.

Another related simplification would be to stop listening to `mouse*` events for the drag interactions. `touch*` should be enough theoretically. But let's do it separately only if we are sure.

## Why
 - Fixing an important issue with iOS which prevented buttons and links to be clicked inside the panel in some situations 
 - Overall simplification of this component, which is the main UI building block of our app