### PR TITLE
Compact version of the ReviewScore component for in-list display

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -19,7 +19,7 @@ const PoiItem = ({ poi,
   const Reviews = () =>
     reviews
       ? <span className="poiItem-reviews">
-        <ReviewScore reviews={reviews} poi={poi} inList={inList} />
+        <ReviewScore reviews={reviews} poi={poi} inList={inList} compact={inList} />
       </span>
       : null
   ;

--- a/src/components/ReviewScore.jsx
+++ b/src/components/ReviewScore.jsx
@@ -17,7 +17,12 @@ function logGradesClick(poi, inList) {
   }
 }
 
-const ReviewScore = ({ poi, reviews: { global_grade, total_grades_count, url }, inList }) =>
+const ReviewScore = ({
+  poi,
+  reviews: { global_grade, total_grades_count, url },
+  inList,
+  compact,
+}) =>
   <a className="reviewScore" rel="noopener noreferrer" href={url}
     onClick={e => {
       e.stopPropagation();
@@ -25,12 +30,16 @@ const ReviewScore = ({ poi, reviews: { global_grade, total_grades_count, url }, 
     }}
   >
     <span className="reviewScore-stars">
-      {[1, 2, 3, 4, 5].map(k =>
-        <span key={k} className={k > global_grade ? 'icon-icon_star' : 'icon-icon_star-filled'} />
-      )}
+      {compact
+        ? <span className="icon-icon_star-filled" />
+        : [1, 2, 3, 4, 5].map(k =>
+          <span key={k} className={k > global_grade ? 'icon-icon_star' : 'icon-icon_star-filled'} />
+        )}
     </span>
+    <span className="reviewScore-score">{global_grade}</span>
     <span className="reviewScore-count">
-      ({total_grades_count}) {_('on PagesJaunes', 'reviews')}
+      ({total_grades_count})
+      {!compact && ' ' + _('on PagesJaunes', 'reviews')}
     </span>
   </a>;
 

--- a/src/scss/includes/reviewScore.scss
+++ b/src/scss/includes/reviewScore.scss
@@ -16,7 +16,8 @@
     }
   }
 
-  .icon-icon_star-filled {
+  .icon-icon_star-filled,
+  &-score {
     color: $action-blue-base;
   }
 


### PR DESCRIPTION
## Description
Add a `compact` prop to the `<ReviewScore>` component, to display it optionally as single star, without the source mentioned. Used in the POI list result in the new design.
Also always displays the score, according to the designs.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_places__type=restaurant(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/91579861-88323700-e94c-11ea-907d-cca51420157b.png)|![localhost_3000_place_admin_osm_relation_7444@Paris_75000-75116(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/91579893-93856280-e94c-11ea-8eb9-0e7e63522641.png)|
|![localhost_3000_places__type=restaurant(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/243653/91580164-f7a82680-e94c-11ea-8e4c-27296fed14b7.png)|![localhost_3000_place_pj_50537893@LE_KHELKOM(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/91580178-fe369e00-e94c-11ea-836f-f23222eb0f3c.png)|
