### PR TITLE
Unfocus input search on submit by keyboard

### DIFF
--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -83,7 +83,6 @@ const SuggestsDropdown = ({
 
       if (key === 'Enter') {
         if (highlighted !== null) {
-          e.preventDefault();
           onSelect(suggestItems[highlighted]);
         }
       }


### PR DESCRIPTION
## Description
Unfocus the main input search after validation in the following case:
 - typing something
 - highlighting an item in the suggestion dropdown 
 - selecting this item with the enter Key

## Why
All the other ways of validating a search blur the, there's no reason this path should have a different result. 