### PR TITLE
[Panel] Avoid re-renders of Panel content while resizing

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -234,7 +234,9 @@ class Panel extends React.Component {
               className="panel-content"
               ref={this.panelContentRef}
             >
-              {typeof children === 'function' ? children({ size, isMobile }) : children}
+              <PanelContent size={size} isMobile={isMobile}>
+                {children}
+              </PanelContent>
             </div>
           </div>
         }
@@ -242,6 +244,15 @@ class Panel extends React.Component {
     );
   }
 }
+
+// Use React.memo to skip re-renders
+// and keep the same inner DOM during the panel manual resizes
+const PanelContent = React.memo(({ children, size, isMobile }) =>
+  typeof children === 'function'
+    ? children({ size, isMobile })
+    : children
+);
+PanelContent.displayName = 'PanelContent';
 
 const PanelWrapper = props => {
   const { size, setSize } = useContext(PanelContext);

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -117,6 +117,8 @@ class Panel extends React.Component {
     } else {
       document.addEventListener('mousemove', this.move);
     }
+
+    this.setState({ currentHeight: this.startHeight });
   }
 
   /**


### PR DESCRIPTION
## Description
Follow-up to https://github.com/QwantResearch/erdapfel/pull/758
Explicitely avoid re-renders of the Panel inner-content when it's being resized.
For that, wrap the inner content in `React.memo` (see https://reactjs.org/docs/react-api.html#reactmemo), which ensures the content won't be re-rendered at all if the props haven't changed.

## Why
Fixing a remaining bug on touch interactions, which occured because some `touchend` events were never fired. Ensuring the DOM won't change under the user's finger during resize means the touch event cycle (touchstart => touchmove => touchend) will be complete.

This may also improve the fluidity of the panel resize on some devices, as far less operations will be done.
