### PR TITLE
QMAPS-1703 add information subtitle in poi panel when applicable

### DIFF
--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -43,6 +43,17 @@ export default class PoiBlockContainer extends React.Component {
       {displayCovidInfo &&
         <CovidBlock block={covidBlock} countryCode={this.props.poi.address.country_code} />}
       <Divider />
+      {
+        (
+          (this.props.poi.address && this.props.poi.subClassName !== 'latlon')
+          || websiteBlock
+          || informationBlock
+          || phoneBlock
+          || hourBlock
+          || recyclingBlock
+          || contactBlock
+        ) && <h3 className="u-text--smallTitle">{_('Information')}</h3>
+      }
       {this.props.poi.address && this.props.poi.subClassName !== 'latlon' &&
         <Block className="block-address" icon="map-pin" title={_('address')}>
           <Address inline address={this.props.poi.address} omitCountry />


### PR DESCRIPTION
## Description
If at least one piece of information is displayed, add an "information" subtitle
NB: this should be translated as "Informations" in french.

## Screenshots
City / Hotel (subtitle):
![image](https://user-images.githubusercontent.com/1225909/91960062-b7a8c100-ed09-11ea-9c37-a37019576fbf.png)
![image](https://user-images.githubusercontent.com/1225909/91960096-c4c5b000-ed09-11ea-9d3c-066024712fe0.png)

LatLon poi (no subtitle):
![image](https://user-images.githubusercontent.com/1225909/91960170-d9a24380-ed09-11ea-800f-a7dfb00315d0.png)

