### PR TITLE
QMAPS-1704 reorder PoI panel blocks and resize icons

### DIFF
--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -48,10 +48,10 @@ export default class PoiBlockContainer extends React.Component {
           <Address inline address={this.props.poi.address} omitCountry />
         </Block>
       }
+      {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
+      {phoneBlock && <PhoneBlock block={phoneBlock} />}
       {websiteBlock && <WebsiteBlock block={websiteBlock} poi={this.props.poi} />}
       {informationBlock && <InformationBlock block={informationBlock} />}
-      {phoneBlock && <PhoneBlock block={phoneBlock} />}
-      {hourBlock && <HourBlock block={hourBlock} covid19enabled={!!displayCovidInfo} />}
       {recyclingBlock && <RecyclingBlock block={recyclingBlock} />}
       {contactBlock && <ContactBlock block={contactBlock} />}
       {imagesBlock && imagesBlock.images.length > 1 &&

--- a/src/scss/includes/components/block.scss
+++ b/src/scss/includes/components/block.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   &-icon {
-    font-size: 24px;
+    font-size: 20px;
     margin-top: 8px;
     margin-right: 12px;
     color: $action-blue-base;


### PR DESCRIPTION
## Description

Order:
- Adresse
- Horaires
- Téléphone
- Site web

Smaller icons


## Screenshots
![image](https://user-images.githubusercontent.com/1225909/91997163-125a1100-ed3a-11ea-9e7a-63de7a45c2d2.png)

