### PR TITLE
Fix input submit blur issue without triggering a search

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -134,6 +134,7 @@ const Suggest = ({
       }}
       onSelect={item => {
         inputNode.value = getInputValue(item);
+        inputNode.blur();
         close();
         if (onSelect) {
           onSelect(item, { query: inputNode.value });

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -83,6 +83,7 @@ const SuggestsDropdown = ({
 
       if (key === 'Enter') {
         if (highlighted !== null) {
+          e.preventDefault(); // prevent search input submit with its current content (highlighted POI name)
           onSelect(suggestItems[highlighted]);
         }
       }


### PR DESCRIPTION
## Description
Follow-up to https://github.com/QwantResearch/erdapfel/pull/760, after @amatissart's [comment](https://github.com/QwantResearch/erdapfel/pull/760#discussion_r482202166)
The `preventDefault` was actually very useful, to not submit the search on `Enter` keypress. As it will be submitted with the POI name of the highlighted item as search term and take the first POI of the result… which may be different from the highlighted item :exploding_head: 

Instead, fix the original bug by always blurring the field when selecting an item.