### PR TITLE
Fix suggestions remaining open when emptying search bar

### DIFF
--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -1,6 +1,5 @@
 
 import { selectItem, fetchSuggests } from 'src/libs/suggest';
-import { isMobileDevice } from 'src/libs/device';
 
 const MAPBOX_RESERVED_KEYS = [
   'ArrowLeft', // ←
@@ -31,19 +30,18 @@ export default class SearchInput {
     window.clearSearch = (e, blur = false) => {
       e.preventDefault(); // Prevent losing focus
       const inputElement = document.querySelector(tagSelector);
-      const isMobile = isMobileDevice();
-      const isActive = document.activeElement.id === inputElement.id;
+      const isInputFocused = document.activeElement === inputElement;
       inputElement.value = '';
       const topBarHandle = document.querySelector('.top_bar');
 
-      if (!isMobile || isMobile && isActive) {
+      if (isInputFocused) {
         // Trigger an input event to refresh Suggest's state
         inputElement.dispatchEvent(new Event('input'));
-      }
 
-      if (blur) {
-        inputElement.blur();
-        topBarHandle.classList.remove('top_bar--search_focus');
+        if (blur) {
+          inputElement.blur();
+          topBarHandle.classList.remove('top_bar--search_focus');
+        }
       }
 
       topBarHandle.classList.remove('top_bar--search_filled');


### PR DESCRIPTION
## Description
Fixes a bug appearing after https://github.com/QwantResearch/erdapfel/pull/755.

On desktop, when clicking the X button of the bar when it is unfocused and filled (ex: with the name of the POI selected and currently displayed), the search input was correctly emptied and we correctly return to the start screen, but the suggestion dropdown was still displayed, hiding the service panel as they are both mutually exclusive.

The cause is, on desktop we always triggered an event on the search input to refresh the content of the suggestion dropdown with the new input content (empty string). But doing that when the input isn't focused will display the dropdown.

This is a good example of the kind of inconsistent state we are getting with our current implementation of the search input… It would be good to bring the input search to React so all these state combinations can be safely managed in a centralized way, instead of using false events and imperative code to make blocks communicate.