### PR TITLE
menu: Fix icon image name used for search button

### DIFF
--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -93,7 +93,7 @@ export default class Menu extends React.Component {
               >
                 <img
                   className="menu__panel__action__icon"
-                  src="./statics/images/magnifier.svg" alt=""
+                  src="./statics/images/magnifier-dark.svg" alt=""
                 />
                 <span>{_('Search', 'menu')}</span>
               </button>


### PR DESCRIPTION
## Description
Following #755, the name of the .svg used in the menu entry was modified
