### PR TITLE
"top image" no longer needs to be filtered in ImagesBlock

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -28,7 +28,7 @@ export default class IdunnPoi extends Poi {
       this.blocksByType = Object.assign({}, ...this.blocks.map(b => ({ [b.type]: b })));
       const imagesBlock = this.blocksByType.images;
       if (imagesBlock && imagesBlock.images.length > 0) {
-        this.topImageUrl = imagesBlock.images[0].url;
+        this.titleImageUrl = imagesBlock.images[0].url;
       }
     }
 

--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -65,10 +65,10 @@ export default class PoiBlockContainer extends React.Component {
       {informationBlock && <InformationBlock block={informationBlock} />}
       {recyclingBlock && <RecyclingBlock block={recyclingBlock} />}
       {contactBlock && <ContactBlock block={contactBlock} />}
-      {imagesBlock && imagesBlock.images.length > 1 &&
+      {imagesBlock &&
         <>
           <Divider />
-          <ImagesBlock block={imagesBlock} poi={this.props.poi} />
+          <ImagesBlock block={imagesBlock} />
         </>
       }
     </div>;

--- a/src/panel/poi/PoiTitleImage.jsx
+++ b/src/panel/poi/PoiTitleImage.jsx
@@ -5,10 +5,10 @@ import { toCssUrl } from 'src/libs/url_utils';
 const defaultIcon = { iconClass: 'marker2', color: '#444648' };
 
 const PoiTitleImage = ({ poi, iconOnly }) => {
-  if (poi.topImageUrl && !iconOnly) {
+  if (poi.titleImageUrl && !iconOnly) {
     return <div
       className="poiTitleImage poiTitleImage--image"
-      style={{ backgroundImage: toCssUrl(poi.topImageUrl) }}
+      style={{ backgroundImage: toCssUrl(poi.titleImageUrl) }}
     />;
   }
 

--- a/src/panel/poi/blocks/Images.jsx
+++ b/src/panel/poi/blocks/Images.jsx
@@ -4,9 +4,8 @@ import { toCssUrl } from 'src/libs/url_utils';
 
 const ImagesBlock = ({
   block,
-  poi,
 }) => {
-  const images = block.images.filter(img => img.url !== poi.topImageUrl).slice(0, 3);
+  const images = block.images.slice(0, 3);
   if (!images || images.length === 0) {
     return null;
   }


### PR DESCRIPTION
## Description
After a recent redesign, the `topImageUrl` is no longer used in the title component, and can be dislayed in the imagesBlock.
The `topImageUrl` is also renamed to `titleImageUrl` for clarity.

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/4726554/92244435-3301a280-eec3-11ea-929a-b80ed40be846.png)|![image](https://user-images.githubusercontent.com/4726554/92244277-fafa5f80-eec2-11ea-982f-6efb9b448e2a.png)|
