### PR TITLE
Fix direction results overflow

### DIFF
--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -116,7 +116,7 @@ export default class RouteResult extends React.Component {
       </div>;
     }
 
-    return <div>
+    return <>
       <div className={classnames('itinerary_result', {
         'itinerary_result--publicTransport': this.props.vehicle === 'publicTransport',
       })}>
@@ -145,6 +145,6 @@ export default class RouteResult extends React.Component {
           Combigo
         </a>
       </div>}
-    </div>;
+    </>;
   }
 }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -3,6 +3,8 @@
   background-size: 100% 5px;
 
   .panel-content {
+    display: flex;
+    flex-direction: column;
     overflow-y: visible;
   }
 }
@@ -213,11 +215,6 @@ input:valid:focus ~ .itinerary__field__clear {
 
 .itinerary_result {
   overflow: auto;
-  max-height: calc(100vh - 290px);
-
-  &--publicTransport {
-    max-height: calc(100vh - 330px);
-  }
 }
 
 .itinerary_leg {


### PR DESCRIPTION
## Description
Fix direction results overflow miscalculations by removing calculations in favor of a flex layout.

Before: 
![before](https://user-images.githubusercontent.com/2981774/92403082-0783ef80-f131-11ea-8a53-f4f83b968913.png)

After:
![after](https://user-images.githubusercontent.com/2981774/92403150-26828180-f131-11ea-8abe-27313a034a1e.png)
