### PR TITLE
Simplify Telemetry API

### DIFF
--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -35,7 +35,7 @@ export default class SceneCategory {
       previousMarker.classList.remove('active');
     }
     if (poi.meta && poi.meta.source) {
-      Telemetry.add('open', 'poi', poi.meta.source,
+      Telemetry.sendPoiEvent(poi, 'open',
         Telemetry.buildInteractionData({
           id: poi.id,
           source: poi.meta.source,

--- a/src/components/ReviewScore.jsx
+++ b/src/components/ReviewScore.jsx
@@ -5,7 +5,7 @@ import Telemetry from 'src/libs/telemetry';
 function logGradesClick(poi, inList) {
   const grades = poi.blocksByType.grades;
   if (grades && grades.url) {
-    Telemetry.add('reviews', 'poi', poi.meta.source,
+    Telemetry.sendPoiEvent(poi, 'reviews',
       Telemetry.buildInteractionData({
         id: poi.id,
         source: poi.meta.source,

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -28,8 +28,6 @@ export const selectItem = (selectedItem, { query, replaceUrl = false, fromQueryP
   } else if (selectedItem instanceof Intention) {
     Telemetry.add(
       Telemetry.SUGGEST_SELECTION,
-      null,
-      null,
       {
         item: 'intention',
         category: selectedItem.category ? selectedItem.category.name : null,

--- a/src/libs/telemetry.js
+++ b/src/libs/telemetry.js
@@ -18,19 +18,6 @@ telemetryModule.events.forEach(event => {
   events[event.toUpperCase()] = event;
 });
 
-function add(event, type, source, data) {
-  if (event) {
-    if (type && source) {
-      const event_const_name = `${(type + '_' + source + '_' + event).toUpperCase()}`;
-      event = events[event_const_name];
-    }
-
-    return send(event, data);
-  }
-
-  Error.send('telemetry', 'add', 'telemetry event mismatch configuration', {});
-}
-
 function addOnce(event) {
   if (uniqEventList.indexOf(event) === -1) {
     uniqEventList.push(event);
@@ -38,7 +25,7 @@ function addOnce(event) {
   }
 }
 
-function send(event, extra_data) {
+function add(event, extra_data) {
   if (!telemetry.enabled) {
     return;
   }
@@ -76,9 +63,15 @@ function buildInteractionData({ source, template, id, zone, element, category })
   };
 }
 
+function sendPoiEvent(poi, event, data) {
+  const eventName = `poi_${poi.meta?.source}_${event}`.toUpperCase();
+  return add(events[eventName], data);
+}
+
 export default {
   add,
   addOnce,
   buildInteractionData,
+  sendPoiEvent,
   ...events,
 };

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -39,7 +39,7 @@ export default class PanelManager extends React.Component {
     const initialRoute = this.initRouter();
     this.initTopBar();
 
-    Telemetry.add(Telemetry.APP_START, null, null, {
+    Telemetry.add(Telemetry.APP_START, {
       'language': window.getLang(),
       'is_mobile': isMobileDevice(),
       'url_pathname': initialUrlPathName,

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -20,7 +20,7 @@ export default class App {
     SearchInput.initSearchInput('#search');
     listen('map_loaded', () => {
       window.times.mapLoaded = Date.now();
-      Telemetry.add(Telemetry.PERF_MAP_FIRST_RENDER, null, null, {
+      Telemetry.add(Telemetry.PERF_MAP_FIRST_RENDER, {
         app_render: window.times.appRendered - window.times.init,
         mapbox_init: window.times.initMapBox - window.times.init,
         map_first_render: window.times.mapLoaded - window.times.initMapBox,

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -57,7 +57,7 @@ export default class CategoryPanel extends React.Component {
   sendTelemetry(prevProps) {
     const { category } = this.props.poiFilters;
     if (category && category !== prevProps?.poiFilters?.category) {
-      Telemetry.add(Telemetry.POI_CATEGORY_OPEN, null, null, { category });
+      Telemetry.add(Telemetry.POI_CATEGORY_OPEN, { category });
     }
   }
 

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -27,7 +27,7 @@ export default class DirectionPanel extends React.Component {
   constructor(props) {
     super(props);
 
-    Telemetry.add(Telemetry.ITINERARY_OPEN, null, null,
+    Telemetry.add(Telemetry.ITINERARY_OPEN,
       props.poi && Telemetry.buildInteractionData({
         id: props.poi.id,
         source: props.poi.meta ? props.poi.meta.source : props.poi.name,

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -157,7 +157,7 @@ export default class PoiPanel extends React.Component {
 
   center = () => {
     const poi = this.getBestPoi();
-    Telemetry.add('go', 'poi', poi.meta && poi.meta.source);
+    Telemetry.sendPoiEvent(poi, 'go');
     fire('fit_map', poi);
   }
 
@@ -198,7 +198,7 @@ export default class PoiPanel extends React.Component {
     const poi = this.getBestPoi();
     const source = poi.meta && poi.meta.source;
     if (source) {
-      Telemetry.add('phone', 'poi', source,
+      Telemetry.sendPoiEvent(poi, 'phone',
         Telemetry.buildInteractionData({
           id: poi.id,
           source,
@@ -212,9 +212,7 @@ export default class PoiPanel extends React.Component {
 
   toggleStorePoi = () => {
     const poi = this.state.fullPoi;
-    if (poi.meta && poi.meta.source) {
-      Telemetry.add('favorite', 'poi', poi.meta.source);
-    }
+    Telemetry.sendPoiEvent(poi, 'favorite');
     if (this.state.isPoiInFavorite) {
       store.del(poi);
     } else {

--- a/src/panel/poi/blocks/Website.jsx
+++ b/src/panel/poi/blocks/Website.jsx
@@ -16,7 +16,7 @@ export default class WebsiteBlock extends React.Component {
     super(props);
 
     this.clickWebsite = () => {
-      Telemetry.add('website', 'poi', this.props.poi.meta.source,
+      Telemetry.sendPoiEvent(this.props.poi, 'website',
         Telemetry.buildInteractionData(
           {
             'id': this.props.poi.id,


### PR DESCRIPTION
## Description
Simplify telemetry API by:
 - introducing a special method to send a POI-related event, so it doesn't require to extract explicitely the source each time
 - remove two args from the generic `add` method, which were used only by POIs, so non-POI events don't require two `null` parameters.

## Why
Clean things up before introducing a bunch of new events