### PR TITLE
QMAPS-1723 make the panel close button bigger on mobile

### DIFF
--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -58,6 +58,8 @@
 
     &-close {
       color: $primary_text;
+      height: 50px;
+      width: 35px;
     }
 
     &--white {


### PR DESCRIPTION
## Description
Make the panel close button bigger on mobile (35x50px)

## Why
Misclicks on the upper half of the button often provoke a panel minimization instead of closing it
25x25px is too small for touch inputs

## Screenshots
before:
![image](https://user-images.githubusercontent.com/1225909/93315577-818c3680-f80b-11ea-8043-4c20eca39906.png)

after:
![image](https://user-images.githubusercontent.com/1225909/93317697-12641180-f80e-11ea-8730-695d5be639da.png)

