### PR TITLE
Refactor Panel navigation with new design

### DIFF
--- a/src/components/ui/Divider.jsx
+++ b/src/components/ui/Divider.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import cx from 'classnames';
 
-const Divider = ({ paddingTop = 20, paddingBottom = 20 }) =>
+const Divider = ({ className, paddingTop = 20, paddingBottom = 20 }) =>
   <div
-    className="divider"
+    className={cx('divider', className)}
     style={{
       padding: `${paddingTop}px 0 ${paddingBottom}px 0`,
     }}

--- a/src/components/ui/Flex.jsx
+++ b/src/components/ui/Flex.jsx
@@ -28,7 +28,7 @@ const Flex = forwardRef(({
 Flex.displayName = 'Flex';
 Flex.propTypes = {
   justifyContent: PropTypes.oneOf(['center', 'space-between']),
-  alignItems: PropTypes.oneOf(['center']),
+  alignItems: PropTypes.oneOf(['center', 'flex-start']),
 };
 
 export default Flex;

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import { fire } from 'src/libs/customEvents';
 import { DeviceContext } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext';
-import Flex from 'src/components/ui/Flex';
 
 const getEventClientY = event => event.changedTouches
   ? event.changedTouches[0].clientY
@@ -39,7 +38,6 @@ function getTargetSize(previousSize, startHeight, endHeight, maxSize) {
 class Panel extends React.Component {
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
-    title: PropTypes.node,
     minimizedTitle: PropTypes.node,
     resizable: PropTypes.bool,
     size: PropTypes.string,
@@ -192,8 +190,8 @@ class Panel extends React.Component {
 
   render() {
     const {
-      children, title, minimizedTitle,
-      resizable, className, white, size, renderNav } = this.props;
+      children, minimizedTitle,
+      resizable, className, white, size, renderHeader } = this.props;
     const { currentHeight, holding } = this.state;
 
     return (
@@ -209,19 +207,17 @@ class Panel extends React.Component {
             onTransitionEnd={() => this.updateMobileMapUI()}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
-            {(isMobile || title) && <Flex
-              justifyContent="space-between"
-              className={classnames(
-                'panel-header',
-                { 'panel-resizeHandle': resizable && isMobile }
-              )}
-              onClick={this.handleHeaderClick}
-            >
-              {resizable && isMobile && size === 'minimized' && minimizedTitle
-                ? <span className="minimizedTitle">{minimizedTitle}</span>
-                : title}
-            </Flex>}
-            {renderNav}
+            {isMobile &&
+              <div
+                className="panel-header"
+                onClick={() => this.handleHeaderClick()}
+              >
+                {resizable && isMobile && <div className="panel-resizeHandle"/>}
+                {resizable && isMobile && size === 'minimized' && minimizedTitle
+                && <span className="minimizedTitle u-text--subtitle">{minimizedTitle}</span>}
+              </div>
+            }
+            {size !== 'minimized' && renderHeader}
             <div
               className="panel-content"
               ref={this.panelContentRef}

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -209,10 +209,10 @@ class Panel extends React.Component {
           >
             {isMobile &&
               <div
-                className="panel-header"
+                className="panel-drawer"
                 onClick={() => this.handleHeaderClick()}
               >
-                {resizable && isMobile && <div className="panel-resizeHandle"/>}
+                {resizable && isMobile && <div className="panel-handle"/>}
                 {resizable && isMobile && size === 'minimized' && minimizedTitle
                 && <span className="minimizedTitle u-text--subtitle">{minimizedTitle}</span>}
               </div>

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -212,7 +212,7 @@ class Panel extends React.Component {
                 className="panel-drawer"
                 onClick={() => this.handleHeaderClick()}
               >
-                {<div className="panel-handle"/>}
+                <div className="panel-handle"/>
                 {size === 'minimized' && minimizedTitle
                 && <span className="minimizedTitle u-text--subtitle">{minimizedTitle}</span>}
               </div>

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -1,3 +1,4 @@
+/* globals _ */
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -191,7 +192,7 @@ class Panel extends React.Component {
   render() {
     const {
       children, minimizedTitle,
-      resizable, className, white, size, renderHeader } = this.props;
+      resizable, className, white, size, renderHeader, onClose } = this.props;
     const { currentHeight, holding } = this.state;
 
     return (
@@ -207,6 +208,15 @@ class Panel extends React.Component {
             onTransitionEnd={() => this.updateMobileMapUI()}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
+            {onClose &&
+              <button
+                className="panel-close"
+                title={_('Close')}
+                onClick={onClose}
+              >
+                <i className="icon-x" />
+              </button>
+            }
             {isMobile && resizable &&
               <div
                 className="panel-drawer"

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -1,4 +1,3 @@
-/* global _ */
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -46,7 +45,6 @@ class Panel extends React.Component {
     size: PropTypes.string,
     setSize: PropTypes.func,
     marginTop: PropTypes.number,
-    close: PropTypes.func,
     className: PropTypes.string,
     white: PropTypes.bool,
   }
@@ -195,7 +193,7 @@ class Panel extends React.Component {
   render() {
     const {
       children, title, minimizedTitle,
-      resizable, close, className, white, size } = this.props;
+      resizable, className, white, size, renderNav } = this.props;
     const { currentHeight, holding } = this.state;
 
     return (
@@ -211,27 +209,19 @@ class Panel extends React.Component {
             onTransitionEnd={() => this.updateMobileMapUI()}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
-            <Flex
+            {(isMobile || title) && <Flex
               justifyContent="space-between"
               className={classnames(
                 'panel-header',
                 { 'panel-resizeHandle': resizable && isMobile }
               )}
-              onClick={() => isMobile && this.handleHeaderClick()}
+              onClick={this.handleHeaderClick}
             >
               {resizable && isMobile && size === 'minimized' && minimizedTitle
                 ? <span className="minimizedTitle">{minimizedTitle}</span>
                 : title}
-              {close &&
-              <Flex
-                justifyContent="center"
-                className="panel-close"
-                title={_('Close')}
-                onClick={e => {e.stopPropagation(); close(e);}}
-              >
-                <i className="icon-x" />
-              </Flex>}
-            </Flex>
+            </Flex>}
+            {renderNav}
             <div
               className="panel-content"
               ref={this.panelContentRef}

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -217,7 +217,7 @@ class Panel extends React.Component {
                 && <span className="minimizedTitle u-text--subtitle">{minimizedTitle}</span>}
               </div>
             }
-            {size !== 'minimized' && renderHeader}
+            {size !== 'minimized' && <div className="panel-header">{renderHeader}</div>}
             <div
               className="panel-content"
               ref={this.panelContentRef}

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -207,13 +207,13 @@ class Panel extends React.Component {
             onTransitionEnd={() => this.updateMobileMapUI()}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
-            {isMobile &&
+            {isMobile && resizable &&
               <div
                 className="panel-drawer"
                 onClick={() => this.handleHeaderClick()}
               >
-                {resizable && isMobile && <div className="panel-handle"/>}
-                {resizable && isMobile && size === 'minimized' && minimizedTitle
+                {<div className="panel-handle"/>}
+                {size === 'minimized' && minimizedTitle
                 && <span className="minimizedTitle u-text--subtitle">{minimizedTitle}</span>}
               </div>
             }

--- a/src/components/ui/PanelNav.jsx
+++ b/src/components/ui/PanelNav.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Button, Flex, Divider } from '.';
+
+const PanelNav = ({ onGoBack, goBackText }) =>
+  <div className="panelNav">
+    <Flex className="panelNav-content" justifyContent="space-between">
+      <Button
+        icon="arrow-left"
+        variant="tertiary"
+        onClick={onGoBack}
+      >
+        {goBackText}
+      </Button>
+    </Flex>
+
+    <Divider
+      paddingTop={0}
+      paddingBottom={0}
+    />
+  </div>
+;
+
+export default PanelNav;

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -1,4 +1,5 @@
 import Button from './Button';
+import Divider from './Divider';
 import ShareMenu from './ShareMenu';
 import Flex from './Flex';
 import { ItemList, Item } from './ItemList';
@@ -9,9 +10,11 @@ import Panel from './Panel';
 import PlaceholderText from './PlaceholderText';
 import Suggest from './Suggest';
 import Text from './Text';
+import PanelNav from './PanelNav';
 
 export {
   Button,
+  Divider,
   ShareMenu,
   Flex,
   ItemList,
@@ -23,4 +26,5 @@ export {
   PlaceholderText,
   Suggest,
   Text,
+  PanelNav,
 };

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -125,10 +125,6 @@ export default class CategoryPanel extends React.Component {
     fire('save_location');
   };
 
-  close = () => {
-    window.app.navigateTo('/');
-  }
-
   selectPoi = poi => {
     const { poiFilters } = this.props;
     const { pois } = this.state;
@@ -165,7 +161,6 @@ export default class CategoryPanel extends React.Component {
       resizable
       renderHeader={<CategoryPanelHeader dataSource={dataSource} loading={initialLoading} />}
       minimizedTitle={_('Show results', 'categories')}
-      close={this.close}
       className="category__panel"
     >
       {panelContent}

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -163,7 +163,7 @@ export default class CategoryPanel extends React.Component {
 
     return <Panel
       resizable
-      title={<CategoryPanelHeader dataSource={dataSource} loading={initialLoading} />}
+      renderHeader={<CategoryPanelHeader dataSource={dataSource} loading={initialLoading} />}
       minimizedTitle={_('Show results', 'categories')}
       close={this.close}
       className="category__panel"

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -312,8 +312,18 @@ export default class DirectionPanel extends React.Component {
             <MobileRoadMapPreview steps={getAllSteps(activePreviewRoute)} />}
         </Fragment>
         : <Panel
-          renderHeader={title}
-          close={this.onClose}
+          renderHeader={(
+            <div>
+              {title}
+              <div
+                className="direction-close"
+                title={_('Close')}
+                onClick={this.onClose}
+              >
+                <i className="icon-x" />
+              </div>
+            </div>
+          )}
           className="direction_panel"
         >
           {form}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -312,16 +312,10 @@ export default class DirectionPanel extends React.Component {
             <MobileRoadMapPreview steps={getAllSteps(activePreviewRoute)} />}
         </Fragment>
         : <Panel
+          onClose={this.onClose}
           renderHeader={(
             <div>
               {title}
-              <div
-                className="direction-close"
-                title={_('Close')}
-                onClick={this.onClose}
-              >
-                <i className="icon-x" />
-              </div>
             </div>
           )}
           className="direction_panel"

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -312,7 +312,7 @@ export default class DirectionPanel extends React.Component {
             <MobileRoadMapPreview steps={getAllSteps(activePreviewRoute)} />}
         </Fragment>
         : <Panel
-          title={title}
+          renderHeader={title}
           close={this.onClose}
           className="direction_panel"
         >

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -50,16 +50,16 @@ export default class FavoritesPanel extends React.Component {
 
     const { favoritePois, isLoggedIn } = this.state;
 
-    const header = <React.Fragment>
+    const header = <div className="u-text--smallTitle u-mt-8 u-center">
       {favoritePois.length === 0
         ? _('Favorite places', 'favorite panel')
         : _('My favorites', 'favorite panel')}
       {isLoggedIn && <div className="icon-masq_dark favorite_panel__masq_icon" />}
-    </React.Fragment>;
+    </div>;
 
     return <Panel
       resizable
-      title={header}
+      renderHeader={header}
       minimizedTitle={_('Show favorites', 'favorite panel')}
       close={this.close}
       className="favorite_panel"

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -50,7 +50,7 @@ export default class FavoritesPanel extends React.Component {
 
     const { favoritePois, isLoggedIn } = this.state;
 
-    const header = <div className="u-text--smallTitle u-mt-8 u-center">
+    const header = <div className="favorite-header u-text--smallTitle u-center">
       {favoritePois.length === 0
         ? _('Favorite places', 'favorite panel')
         : _('My favorites', 'favorite panel')}

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -61,7 +61,7 @@ export default class FavoritesPanel extends React.Component {
       resizable
       renderHeader={header}
       minimizedTitle={_('Show favorites', 'favorite panel')}
-      close={this.close}
+      onClose={this.close}
       className="favorite_panel"
     >
       <FavoriteItems favorites={favoritePois} removeFavorite={this.removeFav} />

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -6,7 +6,6 @@ import Telemetry from 'src/libs/telemetry';
 import nconf from '@qwant/nconf-getter';
 import ActionButtons from './ActionButtons';
 import PoiBlockContainer from './PoiBlockContainer';
-import Panel from 'src/components/ui/Panel';
 import OsmContribution from 'src/components/OsmContribution';
 import CategoryList from 'src/components/CategoryList';
 import { isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
@@ -17,8 +16,8 @@ import { fire, listen, unListen } from 'src/libs/customEvents';
 import Store from '../../adapters/store';
 import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
-import Flex from 'src/components/ui/Flex';
 import { DeviceContext } from 'src/libs/device';
+import { Flex, Panel, PanelNav } from 'src/components/ui';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -230,52 +229,49 @@ export default class PoiPanel extends React.Component {
       return null;
     }
 
-    let backAction = null;
-    if (isFromFavorite) {
-      backAction = {
-        callback: this.backToFavorite,
-        text: _('Back to favorites'),
-      };
-    } else if (poiFilters.category || poiFilters.query) {
-      backAction = {
-        callback: this.backToList,
-        text: _('Back to list'),
-      };
-    } else {
-      backAction = {
-        callback: this.closeAction,
-        text: '',
-      };
-    }
-
-    const header = backAction && backAction.text.length > 0 &&
-      <Flex inline className="poi_panel__back_to_list" onClick={backAction.callback}>
-        <i className="poi_panel__back icon-arrow-left" />
-        <span className="poi_panel__back_text">{backAction.text}</span>
-      </Flex>;
+    const backAction = poiFilters.category || poiFilters.query
+      ? this.backToList
+      : isFromFavorite
+        ? this.backToFavorite
+        : this.closeAction;
 
     return <DeviceContext.Consumer>
       {isMobile =>
         <Panel
           white
           resizable
-          title={!isMobile ? header : null}
-          close={isMobile ? backAction.callback : this.closeAction}
           className={classnames('poi_panel', {
             'poi_panel--empty-header':
             !isFromPagesJaunes(poi) &&
             !isFromFavorite &&
             (!poiFilters || !poiFilters.category),
-          } )}
+          })}
+          renderNav={!isMobile && backAction !== this.closeAction &&
+            <PanelNav
+              isMobile={isMobile}
+              onGoBack={backAction}
+              goBackText={_('Display all results')}
+            />
+          }
         >
           <div className="poi_panel__content">
-            <PoiItem
-              poi={poi}
-              className="u-mb-20"
-              withAlternativeName
-              withOpeningHours
-              onClick={this.center}
-            />
+            <Flex alignItems="flex-start">
+              <PoiItem
+                poi={poi}
+                className="u-mb-20 poi-panel-poiItem"
+                withAlternativeName
+                withOpeningHours
+                onClick={this.center}
+              />
+
+              <button
+                className="poi-panel-close"
+                title={_('Close')}
+                onClick={isMobile ? backAction : this.closeAction}
+              >
+                <i className="icon-x" />
+              </button>
+            </Flex>
             <div className="u-mb-8">
               <ActionButtons
                 poi={poi}

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -246,7 +246,7 @@ export default class PoiPanel extends React.Component {
             !isFromFavorite &&
             (!poiFilters || !poiFilters.category),
           })}
-          renderNav={!isMobile && backAction !== this.closeAction &&
+          renderHeader={!isMobile && backAction !== this.closeAction &&
             <PanelNav
               isMobile={isMobile}
               onGoBack={backAction}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -18,6 +18,7 @@ $bottom-margin: 40;
   flex-direction: column;
 
   &-drawer {
+    height: 20px;
     pointer-events: all;
     -moz-user-select: none;
     -webkit-user-select: none;

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -13,7 +13,7 @@
   background-color: white;
   width: $panel_width;
 
-  &-header {
+  &-drawer {
     pointer-events: all;
     -moz-user-select: none;
     -webkit-user-select: none;
@@ -78,12 +78,12 @@
 
     &.minimized {
       height: 50px;
-      .panel-header {
+      .panel-drawer {
         min-height: 50px;
       }
     }
 
-    .panel-resizeHandle {
+    .panel-handle {
       width: 40px;
       height: 5px;
       margin: 4px auto;

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -31,14 +31,16 @@ $bottom-margin: 40;
   }
 
   &-close {
-    cursor: pointer;
+    position: absolute;
+    top: 8px;
+    right: 16px;
     transition: background-color .1s;
     border-radius: 50%;
     font-size: 20px;
     height: 24px;
     width: 24px;
     color: $secondary_text;
-    margin-left: auto;
+    cursor: pointer;
 
     &:hover {
       color: $primary_text;

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -14,12 +14,14 @@
   width: $panel_width;
 
   &-header {
-    padding: 0 15px;
-    min-height: 30px;
-    color: #5c6f84;
-    span {
-      width: 100%;
-    }
+    pointer-events: all;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    cursor: -webkit-grab;
+    cursor: grab;
+    text-align: center;
   }
 
   &-close {
@@ -35,13 +37,6 @@
     &:hover {
       color: $primary_text;
     }
-  }
-
-  &-content {
-    // 172 = top UI margin + top bar height + top bar margin + panel header + bottom UI margin
-    max-height: calc(100vh - 172px);
-    overflow-y: auto;
-    scrollbar-width: thin;
   }
 }
 
@@ -83,40 +78,17 @@
 
     &.minimized {
       height: 50px;
-
-      .minimizedTitle {
-        text-align: center;
+      .panel-header {
+        min-height: 50px;
       }
-    }
-
-    &-content {
-      max-height: none;
-      height: 100%;
-      overflow: hidden;
     }
 
     .panel-resizeHandle {
-      pointer-events: all;
-      -moz-user-select: none;
-      -webkit-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-      width: 100%;
-      cursor: -webkit-grab;
-      cursor: grab;
-      position: relative;
-
-      &:before {
-        content: "";
-        position: absolute;
-        top: 8px;
-        left: 50%;
-        width: 40px;
-        height: 5px;
-        transform: translateX(-50%);
-        border-radius: 2.5px;
-        background-color: #e0e1e6;
-      }
+      width: 40px;
+      height: 5px;
+      margin: 4px auto;
+      border-radius: 2.5px;
+      background-color: #e0e1e6;
     }
   }
 }

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -1,3 +1,5 @@
+$bottom-margin: 40;
+
 .panel-hidden {
   .panel:not(.direction_panel) {
     display: none;
@@ -12,6 +14,8 @@
   @include panel_radius();
   background-color: white;
   width: $panel_width;
+  display: flex;
+  flex-direction: column;
 
   &-drawer {
     pointer-events: all;
@@ -40,13 +44,26 @@
   }
 }
 
+@media (min-width: 641px) {
+  .panel {
+    max-height: calc(100vh - (92px + 40px)); // 92px is panel.getBoundingClientRect().top
+
+    &-header {
+      flex-shrink: 0;
+    }
+
+    &-content {
+      overflow-y: auto;
+    }
+  }
+
+}
+
 @media (max-width: 640px) {
   .panel {
     width: 100vw;
     height: 50%;
     position: absolute;
-    display: flex;
-    flex-direction: column;
     background: #f4f6fa;
     border-radius: 12px 12px 0 0;
     bottom: 0;

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -18,6 +18,7 @@ $bottom-margin: 40;
   flex-direction: column;
 
   &-drawer {
+    min-height: 20px;
     height: 20px;
     pointer-events: all;
     -moz-user-select: none;

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -15,7 +15,7 @@
 
   &-header {
     padding: 0 15px;
-    min-height: 40px;
+    min-height: 30px;
     color: #5c6f84;
     span {
       width: 100%;
@@ -91,7 +91,7 @@
 
     &-content {
       max-height: none;
-      height: calc(100% - 50px);
+      height: 100%;
       overflow: hidden;
     }
 
@@ -101,14 +101,13 @@
       -webkit-user-select: none;
       -ms-user-select: none;
       user-select: none;
-      min-height: 50px;
       width: 100%;
       cursor: -webkit-grab;
       cursor: grab;
       position: relative;
 
       &:before {
-        content: '';
+        content: "";
         position: absolute;
         top: 8px;
         left: 50%;

--- a/src/scss/includes/components/panelNav.scss
+++ b/src/scss/includes/components/panelNav.scss
@@ -1,0 +1,10 @@
+.panelNav {
+  background-color: $background;
+  height: 50px;
+  width: 100%;
+
+  &-content {
+    padding: 0 20px;
+    height: 100%;
+  }
+}

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -12,7 +12,6 @@
 .itinerary_title {
   text-align: center;
   width: 100%;
-  padding: 8px 0;
 }
 
 .itinerary__field__clear {
@@ -601,6 +600,12 @@ button.direction_shortcut {
 
 .direction_panel_mobile .autocomplete_suggestions {
   @include long_shadow();
+}
+
+@media (min-width: 641px) {
+  .itinerary_title {
+    margin-top: 8px;
+  }
 }
 
 /* Mobile */

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -9,6 +9,19 @@
   }
 }
 
+.direction-close {
+  position: absolute;
+  top: 8px;
+  right: 16px;
+  font-size: 20px;
+  color: $secondary_text;
+
+  :hover {
+    color: $grey-black;
+    cursor: pointer;
+  }
+}
+
 .itinerary_title {
   text-align: center;
   width: 100%;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -12,6 +12,7 @@
 .itinerary_title {
   text-align: center;
   width: 100%;
+  padding: 8px 0;
 }
 
 .itinerary__field__clear {
@@ -700,21 +701,15 @@ button.direction_shortcut {
       max-height: 50%;
     }
 
-    .panel-header {
-      min-height: 24px;
-    }
-
     &.maximized {
       height: calc(100% - 160px);
       max-height: none;
 
       .panel-header {
         padding-top: 9px;
-        height: auto;
       }
     }
   }
-
 
   .itinerary_result .itemList-item {
     overflow: hidden;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -9,19 +9,6 @@
   }
 }
 
-.direction-close {
-  position: absolute;
-  top: 8px;
-  right: 16px;
-  font-size: 20px;
-  color: $secondary_text;
-
-  :hover {
-    color: $grey-black;
-    cursor: pointer;
-  }
-}
-
 .itinerary_title {
   text-align: center;
   width: 100%;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -705,7 +705,7 @@ button.direction_shortcut {
       height: calc(100% - 160px);
       max-height: none;
 
-      .panel-header {
+      .panel-drawer {
         padding-top: 9px;
       }
     }

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -43,6 +43,10 @@
 }
 
 @media (max-width: 640px) {
+  .category__panel__pj {
+    height: 20px;
+  }
+
   .category__panel {
     position: absolute;
     width: 100vw;

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -6,6 +6,8 @@
 
 .category__panel__pj {
   width: 100%;
+  height: 50px;
+  padding: 0 20px;
   display: flex;
   line-height: 18px;
   align-items: center;

--- a/src/scss/includes/panels/favorite_panel.scss
+++ b/src/scss/includes/panels/favorite_panel.scss
@@ -1,5 +1,12 @@
 $MASQ_BANNER_HEIGHT: 93px;
 
+
+@media (min-width: 641px){
+  .favorite-header {
+    margin: 8px 0;
+  }
+}
+
 .favorite_panel__show_list {
   display: none;
 }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -219,7 +219,7 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   .poi_panel.panel {
     &.default, &.minimized {
       height: auto;
-      .panel-header {
+      .panel-drawer {
         min-height: inherit;
       }
     }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -11,6 +11,8 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   }
 
   &-close {
+    height: 35px;
+    width: 35px;
     margin-left: auto;
     font-size: 22px;
     cursor: pointer;

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -219,6 +219,9 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   .poi_panel.panel {
     &.default, &.minimized {
       height: auto;
+      .panel-header {
+        min-height: inherit;
+      }
     }
   }
 

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -3,19 +3,23 @@
 $BLOCK_PADDING: 24px;
 $BLOCK_ICON_FONT_SIZE: 16px;
 
-.poi_panel--empty-header {
-  .panel-header {
-    border-bottom: none;
+.poi-panel {
+  overflow-y: hidden;
+
+  &-poiItem {
+    flex-grow: 1;
   }
 
-  .poi_panel__content {
-    padding-top: 0;
+  &-close {
+    margin-left: auto;
+    font-size: 22px;
+    cursor: pointer;
   }
 }
 
 .poi_panel__content {
   animation: appear 600ms forwards;
-  padding: 0 30px 10px 30px;
+  padding: 20px 30px 10px 30px;
   position: relative;
 }
 
@@ -24,25 +28,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   100% {opacity: 1; }
 }
 
-.poi_panel__back {
-  display: inline-block;
-  width: 20px;
-  color: $primary_text;
-}
-
-.poi_panel__back_text {
-  padding-left: 5px;
-  margin-right: 6px;
-}
-
-.poi_panel__back.icon-arrow-left {
-  font-size: 22px;
-  margin-top: -2px;
-}
-
-.poi_panel__back_to_list:hover {
-  color: $secondary_text;
-}
 .poi_panel__info__hour__circle {
   width: 6px;
   height: 6px;
@@ -220,14 +205,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
 .marker-anywhere {
   top: -15px;
-}
-
-.poi_panel__back_to_list {
-  cursor: pointer;
-  color: $secondary_text;
-  &:hover {
-    color: $primary_text;
-  }
 }
 
 .poi_panel__pj_logo {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -16,6 +16,9 @@ $BLOCK_ICON_FONT_SIZE: 16px;
     margin-left: auto;
     font-size: 22px;
     cursor: pointer;
+    position: relative;
+    top: -5px;
+    right: -5px;
   }
 }
 
@@ -214,6 +217,11 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 }
 
 @media (max-width: 640px) {
+
+  .poi-panel-close {
+    right: 0;
+  }
+
   .poi_panel__content {
     padding: 0 12px 12px;
   }

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -5,10 +5,6 @@
   @include card_shadow();
   @include card_radius();
   padding: 20px 14px 12px;
-
-  .panel-header {
-    display: none;
-  }
 }
 
 .service_panel__categories,
@@ -36,23 +32,6 @@
     hr {
       border-top: 1px solid #e0e1e6;
       margin-bottom: 20px;
-    }
-
-    .panel-header {
-      display: flex;
-      justify-content: center;
-      color: $grey-semi-darkness;
-    }
-  }
-
-  .service_panel:not(.minimized) {
-    .panel-resizeHandle {
-      height: 30px;
-      min-height: auto;
-    }
-
-    .panel-content {
-      height: calc(100% - 30px);
     }
   }
 

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -9,3 +9,4 @@
 @import "./components/poiItem";
 @import "./components/divider";
 @import "./components/block";
+@import "./components/panelNav";

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -68,10 +68,6 @@
   font-weight: bold;
 }
 
-.u-mt-8 {
-  margin-top: 8px;
-}
-
 .u-ml-4 {
   margin-left: 4px;
 }

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -68,6 +68,10 @@
   font-weight: bold;
 }
 
+.u-mt-8 {
+  margin-top: 8px;
+}
+
 .u-ml-4 {
   margin-left: 4px;
 }

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -229,7 +229,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   expect(await exists(page, '.poiTitle')).toBeTruthy();
   expect(await exists(page, '.poi_panel')).toBeTruthy();
   await page.click('.poi_panel__actions .poi_panel__action__favorite');
-  await page.click('.poi_panel .panel-close');
+  await page.click('.poi-panel-close');
   // we check that the first favorite item is our poi
   await toggleFavoritePanel(page);
   let fav = await getFavorites(page);
@@ -244,7 +244,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   expect(await exists(page, '.poi_panel')).toBeTruthy();
 
   await page.click('.poi_panel__actions .poi_panel__action__favorite');
-  await page.click('.poi_panel .panel-close');
+  await page.click('.poi-panel-close');
   // it should disappear from the favorites
   await toggleFavoritePanel(page);
   fav = await getFavorites(page);


### PR DESCRIPTION
## Description
- Fix close button position/design
- Now, components using `Panel` can use `renderHeader` to render a header on top of the panel.
- Add `PanelNav` component on desktop to pass as a `renderHeader` props to Panel
- Removed obsolete `title` prop from Panel.
- Remove obsolete `close` prop from Panel.
- Simpler Panel drawer/header style, no absolute positioning anymore.
- styles cleanup

## Screenshots
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/2981774/93577981-02c70300-f99d-11ea-904d-b0b40e19d783.png)|![image](https://user-images.githubusercontent.com/2981774/93578021-14100f80-f99d-11ea-8a2d-291a532f2f4f.png)|
|![image](https://user-images.githubusercontent.com/2981774/93578144-3f92fa00-f99d-11ea-8b18-e1587f2cc55a.png) | ![image](https://user-images.githubusercontent.com/2981774/93578164-47529e80-f99d-11ea-99ea-ffaf8dcb30c0.png)|
![image](https://user-images.githubusercontent.com/2981774/93578521-b9c37e80-f99d-11ea-8977-ef9b98e777a6.png)|![image](https://user-images.githubusercontent.com/2981774/93578425-9d274680-f99d-11ea-8a1c-24b89bd6daf2.png)|

Please note : On the bottom-left screenshot, there is no close button anymore. The close action can still be done from the search bar, which should be the targetted UX behavior. If you think it's too early to remove this button, let me know :)