### PR TITLE
[Fix] Disappearing POI panel elements on desktop

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -51,7 +51,7 @@ export default class PanelManager extends React.Component {
     window.times.appRendered = Date.now();
 
     listen('map_user_interaction', () => {
-      if (this.state.ActivePanel === PoiPanel) {
+      if (this.state.ActivePanel === PoiPanel && isMobileDevice()) {
         this.setState({ panelSize: 'minimized' });
       }
     });

--- a/src/scss/includes/components/poiItem.scss
+++ b/src/scss/includes/components/poiItem.scss
@@ -30,8 +30,4 @@
     display: flex;
     align-items: center;
   }
-
-  .minimized:not(.panel--holding) & {
-    margin-bottom: 0;
-  }
 }

--- a/src/scss/includes/openingHour.scss
+++ b/src/scss/includes/openingHour.scss
@@ -2,8 +2,4 @@
   margin: 0;
   display: flex;
   align-items: center;
-
-  .minimized:not(.panel--holding) & {
-    display: none;
-  }
 }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -78,10 +78,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   .poi_panel__action__direction {
     flex-grow: 1;
   }
-
-  .minimized:not(.panel--holding) & {
-    display: none;
-  }
 }
 
 .poi_panel__store_status__toggle:after {
@@ -258,6 +254,19 @@ $BLOCK_ICON_FONT_SIZE: 16px;
     }
   }
 
+  .poi_panel.minimized:not(.panel--holding) {
+    .poiItem {
+      margin-bottom: 0;
+
+      .openingHour {
+        display: none;
+      }
+    }
+
+    .poi_panel__actions {
+      display: none;
+    }
+  }
 }
 
 @import "./covid";


### PR DESCRIPTION
## Description
Fix a bug when, on desktop, some elements of the POI panel (buttons and opening hours) disappear when the user interacts with the map… They are actually the elements that should disappear only on mobile when minimizing the panel.

There are 2 reasons for the price of 1 :slightly_smiling_face: :
 - In https://github.com/QwantResearch/erdapfel/pull/749 we set the panel size to `minimized` even on desktop, where as it's a mobile-only feature, 
 - In https://github.com/QwantResearch/erdapfel/pull/776 we forgot to apply the hiding rules on mobile-only media query

Fix these root causes, and also move all CSS rules related to this UI feature to `poi_panel.scss` instead of scattering them across all concerned elements. That way they are easier to manage.
