### PR TITLE
[PoC] React server-side rendering: first step

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/bin/SSR/reactSSR.js
+++ b/bin/SSR/reactSSR.js
@@ -1,0 +1,16 @@
+/* globals module */
+
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import TopBar from '../../src/components/TopBar.jsx';
+
+module.exports = function(html, { i18n, config }) {
+  const topBar = ReactDOMServer.renderToString(
+    <TopBar i18n={i18n} config={config} />
+  );
+
+  return html.replace(
+    '<div class="top_bar"></div>',
+    `<div class="top_bar">${topBar}</div>`
+  );
+};

--- a/bin/app.js
+++ b/bin/app.js
@@ -11,6 +11,7 @@ const fakePbf = require('./middlewares/fake_pbf/index');
 const compression = require('compression');
 const mapStyle = require('./middlewares/map_style');
 const getReqSerializer = require('./serializers/request');
+const reactSSR = require('./SSR/reactSSR');
 
 const app = express();
 const promRegistry = new promClient.Registry();
@@ -116,7 +117,14 @@ function App(config) {
       appConfig = JSON.parse(JSON.stringify(config));
       appConfig.burgerMenu.enabled = false;
     }
-    res.render('index', { config: appConfig });
+    res.render('index', { config: appConfig }, (_err, html) => {
+      res.send(reactSSR(html, {
+        config: appConfig,
+        i18n: {
+          _: res.locals._,
+        },
+      }));
+    });
   });
 
   if (config.server.acceptPostedLogs) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,8 @@
 /* globals require */
 
+require('@babel/register');
+require('@babel/polyfill');
+
 require('dotenv').config();
 const configBuilt = require('@qwant/nconf-builder');
 const App = require('./app');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3117,6 +3117,31 @@
         }
       }
     },
+    "@babel/register": {
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.11.5.tgz",
+      "integrity": "sha512-CAml0ioKX+kOAvBQDHa/+t1fgOt3qkTIz0TrRtRAT6XY0m5qYZXR85k6/sLCNPMGhYDlCFHCYuU0ybTJbvlC6w==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.19",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.16"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "@babel/runtime": {
       "version": "7.9.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/plugin-transform-template-literals": "^7.8.0",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-react": "^7.9.0",
+    "@babel/register": "^7.11.5",
     "@babel/runtime": "^7.9.0",
     "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
     "@qwant/config-sanitizer-loader": "file:local_modules/config-sanitizer-loader",

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const TopBar = ({ i18n, config }) => {
+  const _ = i18n._;
+
+  return <>
+    <form onSubmit="return false" noValidate className="search_form"
+      data-flag-text={config.app.versionFlag}
+    >
+      <div className="search_form__logo" />
+      <div id="react_menu__container" />
+      <div className="search_form__wrapper empty">
+        <div
+          className="search_form__return icon-arrow-left"
+          onMouseDown="clearSearch(event, true)"
+        />
+        <input
+          id="search" className="search_form__input"
+          type="search" spellCheck="false" required autoComplete="off"
+          placeholder={_('Search on Qwant Maps')}
+        />
+        <button
+          id="clear_button_mobile" className="search_form__clear icon-x"
+          type="button"
+          onMouseDown="clearSearch(event)" />
+        <input
+          className="search_form__action"
+          type="submit" value="" title={_('Search')}
+          onClick="submitSearch()"
+        />
+      </div>
+      {config.direction.enabled && <>
+        <button
+          className="search_form__direction_shortcut"
+          title={_('Directions', 'top bar')} />
+        <button
+          id="clear_button_desktop" className="search_form__clear icon-x"
+          type="button"
+          onMouseDown="clearSearch(event)" />
+      </>}
+    </form>
+    <div className="search_form__result" />
+  </>;
+};
+
+export default TopBar;

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -10,23 +10,25 @@ const TopBar = ({ i18n, config }) => {
       <div className="search_form__logo" />
       <div id="react_menu__container" />
       <div className="search_form__wrapper empty">
-        <div
-          className="search_form__return icon-arrow-left"
-          onMouseDown="clearSearch(event, true)"
-        />
+        <div className="search_form__return icon-arrow-left" />
         <input
-          id="search" className="search_form__input"
-          type="search" spellCheck="false" required autoComplete="off"
+          id="search"
+          className="search_form__input"
+          type="search"
+          spellCheck="false"
+          required
+          autoComplete="off"
           placeholder={_('Search on Qwant Maps')}
         />
         <button
-          id="clear_button_mobile" className="search_form__clear icon-x"
-          type="button"
-          onMouseDown="clearSearch(event)" />
+          id="clear_button_mobile"
+          className="search_form__clear icon-x"
+          type="button" />
         <input
           className="search_form__action"
-          type="submit" value="" title={_('Search')}
-          onClick="submitSearch()"
+          type="submit"
+          value=""
+          title={_('Search')}
         />
       </div>
       {config.direction.enabled && <>
@@ -36,7 +38,7 @@ const TopBar = ({ i18n, config }) => {
         <button
           id="clear_button_desktop" className="search_form__clear icon-x"
           type="button"
-          onMouseDown="clearSearch(event)" />
+        />
       </>}
     </form>
     <div className="search_form__result" />

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -50,7 +50,8 @@ export default class SearchInput {
       window.app.navigateTo('/');
     };
 
-    window.submitSearch = () => {
+    window.submitSearch = e => {
+      e.preventDefault();
       Telemetry.add(Telemetry.SUGGEST_SUBMIT);
       if (window.__searchInput.searchInputHandle.value.length > 0) {
         this.executeSearch(window.__searchInput.searchInputHandle.value);

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,3 +1,6 @@
+require('@babel/register');
+require('@babel/polyfill');
+
 const config = require('./integration/test_config');
 
 module.exports = {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -38,7 +38,14 @@
     <div id="react_root"></div>
     <div class="react_modal__container"></div>
     <div class="top_bar"></div>
-    <script>window.times = {init : Date.now()}</script>
+    <script>
+      window.times = { init : Date.now() };
+      // Temp: global functions attached to SSRed TopBar, until we use hydration
+      document.querySelector('.search_form__return').onmousedown = event => clearSearch(event, true);
+      document.querySelector('#clear_button_desktop').onmousedown = event => clearSearch(event);
+      document.querySelector('#clear_button_mobile').onmousedown = event => clearSearch(event);
+      document.querySelector('.search_form__action').onclick = event => submitSearch(event);
+    </script>
     <script src="./statics/build/javascript/bundle.js"></script>
     <noscript><%= _('JavaScript is required to view this application.') %></noscript>
   </body>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,26 +37,7 @@
     <div id="scene_container" class="map_container"></div>
     <div id="react_root"></div>
     <div class="react_modal__container"></div>
-    <div class="top_bar">
-      <form onsubmit="return false" novalidate class="search_form"
-        <% if(config.app.versionFlag) { %>
-          data-flag-text="<%= config.app.versionFlag %>"
-        <% } %> >
-        <div class="search_form__logo"></div>
-        <div id="react_menu__container"></div>
-        <div class="search_form__wrapper empty">
-          <div class="search_form__return icon-arrow-left" onmousedown="clearSearch(event, true)"></div>
-          <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
-          <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
-          <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">
-        </div>
-        <% if(config.direction.enabled) { %>
-        <button class="search_form__direction_shortcut" title="<%= _('Directions', 'top bar') %>"></button>
-        <button id="clear_button_desktop" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)"></button>
-        <% } %>
-      </form>
-      <div class="search_form__result"></div>
-    </div>
+    <div class="top_bar"></div>
     <script>window.times = {init : Date.now()}</script>
     <script src="./statics/build/javascript/bundle.js"></script>
     <noscript><%= _('JavaScript is required to view this application.') %></noscript>


### PR DESCRIPTION
## Description
A quick PoC to lay the first bricks of server-side rendering of React components.

There are many goals for that (first load perf, crawlability, etc.), but the first would be to simplify our top bar/main search implementation by moving in to a React component. The target is to have one render tree with shared state, instead of using DOM selections and global functions to make React and static HTML communicate. Hopefully we'll reduce overall complexity, ease top bar maintenance and avoid frequent bugs concerning the search.

SSR is not trivial to set-up from scratch and there are many gotchas, so it's better if we go slowly :slightly_smiling_face: 
This PR is a basis so we can discuss the process and explain all details. It includes only the very first steps:
 1. ensure React can be used on the server (In practice, this means mainly using Babel on the server code too so JSX is recognized)
 2. define a new step when serving the index page, so we can render React components to strings and inject them in the HTML template. Also pass necessary bits (i18n and config).
 3. define a new `TopBar.jsx` component and render it in place of the current static markup
 4. ensure event listeners mapped to global functions are working

That's it. It doesn't do anything more for now, that's pure server-side rendering with no client counterparts. The same as the current implementation, except with React instead of HTML. Fun stuff and real benefits will come later, but it needs these first step to be well understood first.