### PR TITLE
Additional categories, used by intention detection only

### DIFF
--- a/config/categories.yml
+++ b/config/categories.yml
@@ -83,3 +83,13 @@
   matcher:
     regex: "fitness|muscu(lation)?|salle de muscu(lation)?"
   icon: basketball
+
+# Only categories with 'icon' are visible as action buttons.
+# Below are the categories that are only accessible
+# via queries (with detected intention) or URL
+- label: _('recycling')
+  name: recycling
+- label: _('station')
+  name: station
+- label: _('parking lot')
+  name: parking

--- a/src/components/CategoryList.jsx
+++ b/src/components/CategoryList.jsx
@@ -11,6 +11,7 @@ const handleCategoryClick = category => {
 const CategoryList = ({ className, limit = Number.MAX_VALUE }) =>
   <div className={className}>
     {CategoryService.getCategories()
+      .filter(c => c.iconName)
       .slice(0, limit)
       .map(category => <MainActionButton
         key={category.name}

--- a/src/components/CategoryList.jsx
+++ b/src/components/CategoryList.jsx
@@ -11,7 +11,7 @@ const handleCategoryClick = category => {
 const CategoryList = ({ className, limit = Number.MAX_VALUE }) =>
   <div className={className}>
     {CategoryService.getCategories()
-      .filter(c => c.iconName)
+      .filter(c => c.iconName) // ignore categories used on detected intention only
       .slice(0, limit)
       .map(category => <MainActionButton
         key={category.name}


### PR DESCRIPTION
## Description
Following https://github.com/QwantResearch/idunn/pull/166, this PR defines more categories to be used in "intentions" returned by the search results.

These new categories have no icon or color, as they don't appear as action button anywhere.  

Let me know if you find this `.filter()` mechanism too implicit. Maybe we could define 2 separate lists of categories with categories buttons on one hand, and searched-only categories on the other hand ?

