### PR TITLE
[Telemetry] Add missing event tracing for itinerary feature

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -22,6 +22,8 @@ module.exports = {
     'itinerary_mode_walking',
     'itinerary_mode_cycling',
     'itinerary_mode_publictransport',
+    'itinerary_route_select',
+    'itinerary_route_toggle_details',
     /* Poi */
     'poi_category_open',
     'poi_backtofavorite',

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -209,6 +209,7 @@ export default class DirectionPanel extends React.Component {
     if (this.state.activePreviewRoute) {
       this.setState({ activePreviewRoute: null });
     } else {
+      Telemetry.add(Telemetry.ITINERARY_CLOSE);
       window.app.navigateTo('/');
     }
   }

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import { Item, ItemList } from 'src/components/ui/ItemList';
 import PlaceholderText from 'src/components/ui/PlaceholderText';
 import { fire, listen } from 'src/libs/customEvents';
+import Telemetry from 'src/libs/telemetry';
 
 export default class RouteResult extends React.Component {
   static propTypes = {
@@ -44,6 +45,7 @@ export default class RouteResult extends React.Component {
     if (routeId === this.state.activeRouteId) {
       return;
     }
+    Telemetry.add(Telemetry.ITINERARY_ROUTE_SELECT);
     fire('set_main_route', { routeId, fitView: true });
     this.setState({ activeRouteId: routeId });
   }
@@ -56,6 +58,7 @@ export default class RouteResult extends React.Component {
   }
 
   toggleRouteDetails = routeId => {
+    Telemetry.add(Telemetry.ITINERARY_ROUTE_TOGGLE_DETAILS);
     if (this.state.activeRouteId === routeId) {
       this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
     } else {


### PR DESCRIPTION
## Description
Adds 3 telemetry events for the itinerary features.
One of them (`itinerary_close`) was already declared as valid but never thrown. Two others were added.