### PR TITLE
Use GPU when dragging panel

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -137,8 +137,6 @@ class Panel extends React.Component {
     this.startClientYOffset = this.startClientY - rect.top;
     this.startHeight = window.innerHeight - rect.top;
 
-    this.removeListeners();
-
     if (event.type === 'touchstart') {
       // Workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1123304
       document.addEventListener('touchmove', this.move, { passive: false });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -297,7 +297,7 @@ export default class DirectionPanel extends React.Component {
             {!activePreviewRoute && form}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel className="directionResult_panel" resizable marginTop={160}>
+            <Panel resizable marginTop={160} >
               {result}
             </Panel>}
           {activePreviewRoute &&

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -242,6 +242,7 @@ export default class PoiPanel extends React.Component {
         <Panel
           white
           resizable
+          fitContent
           className={classnames('poi_panel', {
             'poi_panel--empty-header':
             !isFromPagesJaunes(poi) &&

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -66,8 +66,7 @@ $bottom-margin: 40px;
 @media (max-width: 640px) {
   .panel {
     width: 100vw;
-    height: 50%;
-    position: absolute;
+    position: fixed;
     background: #f4f6fa;
     border-radius: 12px 12px 0 0;
     bottom: 0;
@@ -81,7 +80,7 @@ $bottom-margin: 40px;
     }
 
     &:not(.panel--holding) {
-      transition: height 0.2s ease-in-out;
+      transition: transform 0.2s ease-in-out;
 
       &.maximized {
         box-shadow: none;
@@ -90,15 +89,12 @@ $bottom-margin: 40px;
 
     &.maximized {
       border-radius: 0;
-      height: calc(100% - #{$top_bar_height});
-
       .panel-content {
         overflow: auto;
       }
     }
 
     &.minimized {
-      height: 50px;
       .panel-drawer {
         min-height: 50px;
       }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -699,23 +699,6 @@ button.direction_shortcut {
     background-color: transparent;
   }
 
-  .panel.directionResult_panel {
-    height: auto;
-
-    &:not(.panel--holding) {
-      max-height: 50%;
-    }
-
-    &.maximized {
-      height: calc(100% - 160px);
-      max-height: none;
-
-      .panel-drawer {
-        padding-top: 9px;
-      }
-    }
-  }
-
   .itinerary_result .itemList-item {
     overflow: hidden;
   }


### PR DESCRIPTION
## Description
Improve panel swipe performance using `translate3d`.
Please note, I feel like the "ending animation" is not as smooth  as when dragging the panel manually however, but it is restored as we previously missed them.

## Why
- Panel now feels more "native". Performance is comparable with our greatest competitor product on firefox/chromium.
- Chromium 85 needs a workaround to get a smooth "touchmove" event in our use case, by setting `{ passive: false }`. We should be able to remove this workaround soon.
