### PR TITLE
[Telemetry] Track usage of geoloc for directions

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -24,6 +24,7 @@ module.exports = {
     'itinerary_mode_publictransport',
     'itinerary_route_select',
     'itinerary_route_toggle_details',
+    'itinerary_point_geolocation',
     /* Poi */
     'poi_category_open',
     'poi_backtofavorite',

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -8,6 +8,7 @@ import Error from 'src/adapters/error';
 import { fire } from 'src/libs/customEvents';
 import { fetchSuggests } from 'src/libs/suggest';
 import { DeviceContext } from 'src/libs/device';
+import Telemetry from 'src/libs/telemetry';
 
 class DirectionInput extends React.Component {
   static propTypes = {
@@ -56,6 +57,8 @@ class DirectionInput extends React.Component {
 
   selectItem = async selectedPoi => {
     if (selectedPoi instanceof NavigatorGeolocalisationPoi) {
+      Telemetry.add(Telemetry.ITINERARY_POINT_GEOLOCATION);
+
       this.setState({ readOnly: true });
 
       try {


### PR DESCRIPTION
## Description
Define and send new event `itinerary_point_geolocation` when the user uses "My position" in the context of entering direction points.

## Why
It's on the list of new events we wanted to track but I forgot to add it in the [previous PR](https://github.com/QwantResearch/erdapfel/pull/793).