### PR TITLE
Add label styling to POI marker layer

### DIFF
--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -14,13 +14,14 @@ export const filteredPoisStyle = {
     'text-allow-overlap': false,
     'text-ignore-placement': false,
     'text-optional': true,
-    'text-anchor': 'top',
-    'text-radial-offset': 0.25,
+    'text-variable-anchor': ['top', 'bottom-left', 'bottom-right'],
+    'text-offset': [1.5, 0.5],
+    'text-justify': 'auto',
   },
   paint: {
     'text-color': ['case', ['==', ['feature-state', 'selected'], true], '#900014', '#0c0c0e'],
     'text-halo-color': 'white',
     'text-halo-width': 1,
-    'text-translate': [0, 4],
+    'text-translate': [0, -2],
   },
 };

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -7,5 +7,20 @@ export const filteredPoisStyle = {
     'icon-ignore-placement': true,
     'icon-size': 0.5,
     'icon-anchor': 'bottom',
+
+    'text-font': [ 'Noto Sans Bold' ],
+    'text-size': 10,
+    'text-field': '{name}',
+    'text-allow-overlap': false,
+    'text-ignore-placement': false,
+    'text-optional': true,
+    'text-anchor': 'top',
+    'text-radial-offset': 0.25,
+  },
+  paint: {
+    'text-color': ['case', ['==', ['feature-state', 'selected'], true], '#900014', '#0c0c0e'],
+    'text-halo-color': 'white',
+    'text-halo-width': 1,
+    'text-translate': [0, 4],
   },
 };

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -30,6 +30,7 @@ export default class SceneCategory {
       element: createIcon({ disablePointerEvents: true, className: 'marker--category' }),
       anchor: 'bottom',
     });
+    this.selectedPoi = null;
     this.selectedMarker = new Marker({
       element: createIcon({ className: 'marker--category' }),
       anchor: 'bottom',
@@ -122,9 +123,9 @@ export default class SceneCategory {
   }
 
   removeCategoryMarkers = () => {
+    this.selectPoiMarker(null);
     this.map.setLayoutProperty(DYNAMIC_POIS_LAYER, 'visibility', 'none');
     this.hoveredMarker.remove();
-    this.selectedMarker.remove();
     this.setOsmPoisVisibility(true);
   }
 
@@ -145,12 +146,25 @@ export default class SceneCategory {
   }
 
   selectPoiMarker = poi => {
+    if (this.selectedPoi === poi) {
+      return;
+    }
+    if (this.selectedPoi) {
+      this.map.setFeatureState(
+        { id: this.selectedPoi.id, source: DYNAMIC_POIS_LAYER },
+        { selected: false });
+    }
     if (poi) {
+      this.selectedPoi = poi;
       this.selectedMarker
         .setLngLat(poi.latLon)
         .addTo(this.map);
+      this.map.setFeatureState(
+        { id: poi.id, source: DYNAMIC_POIS_LAYER },
+        { selected: true });
     } else {
       this.selectedMarker.remove();
+      this.selectedPoi = null;
     }
   }
 }


### PR DESCRIPTION
## Description
Add labels on category POI map markers. 
Also implement their selected state (red text instead of black).

![Capture d’écran de 2020-09-28 11-48-23](https://user-images.githubusercontent.com/243653/94417591-8bedef00-0180-11eb-8168-08200c5d25f5.png)


I used [text-variable-anchor](https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-symbol-text-variable-anchor) so the label is allowed to be moved on the sides of the icon to fit without collisions, but there are still some overlapping with other icons :/ Mapbox doesn't always chose to move the label where it could possibly avoid things. After many tries I think it's related to Mapbox implementation and we can't obtain much better for now.
I suggest we move on with this state, as it's still globally ok and an improvement over no label at all.