### PR TITLE
Fix: Localized link names were not used in MenuItem

### DIFF
--- a/src/panel/menu/MenuItem.jsx
+++ b/src/panel/menu/MenuItem.jsx
@@ -19,7 +19,7 @@ const MenuItem = ({ menuItem: { uri, sectionName, links, icon } }) => <div>
       className="menu__panel__link"
       href={link.uri} rel="noopener noreferrer" target="_blank"
     >
-      {link.name}
+      {_(link.name)}
     </a>)}
   </div>}
 </div>;


### PR DESCRIPTION
## Description
Menu items are described in constants.yml, with a pseudo-call to `_()` to be parsed by gettext on build.
So that these items are effectively translated, the component needs to call `_()` again on the translation key imported from the constants file. This (arguably confusing) mechanism is already used for `_(sectionName)` a few lines above.

