### PR TITLE
QMAPS-line-endings: let Git pull/push src files in Linux line format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*  text=auto


### PR DESCRIPTION
## Description
Avoid Windows from converting line endings in CRLF for erdapfel source files

## Why
When pulling / switching branches, my IDE on Windows kept complaining that all my js/jsx files were in CR/LF.
To fix this, I followed the instructions here: https://stackoverflow.com/a/13154031
One of them consisted in having this .gitattributes file
It works fine now.
This file may help future other Windows contributors, so I propose to push it.

