### PR TITLE
Fix POI panel handle changing height on dragging

### DIFF
--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -100,6 +100,10 @@ $bottom-margin: 40px;
       }
     }
 
+    .panel-drawer {
+      flex-shrink: 0;
+    }
+
     .panel-handle {
       width: 40px;
       height: 5px;


### PR DESCRIPTION
## Description
Tiny fix for a tiny visual bug: when dragging the POI with the panel handle, the panel content is slightly moved up some pixels. It's because the element used as handle shrinks when the full content gets added in the POI panel.

## Screencasts
*(Don't focus on the missing map scale and buttons, this is another bug)*
|Before|After|
|---|---|
|![shrink](https://user-images.githubusercontent.com/243653/94459118-308b2380-01b7-11eb-8cc0-b2e37af3308a.gif)|![no-shrink](https://user-images.githubusercontent.com/243653/94459135-34b74100-01b7-11eb-82f7-eace9aeb15e5.gif)|

