### PR TITLE
Fix 'null' strings on symbol layer for POIs with no name

### DIFF
--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -10,7 +10,7 @@ export const filteredPoisStyle = {
 
     'text-font': [ 'Noto Sans Bold' ],
     'text-size': 10,
-    'text-field': '{name}',
+    'text-field': ['get', 'name'],
     'text-allow-overlap': false,
     'text-ignore-placement': false,
     'text-optional': true,


### PR DESCRIPTION
## Description
Fix POIs with no name displayed with a "null" label on the symbol layer.
For that, use the Mapbox-GL `['get', 'name']` expression instead of the "token syntax" `{'name'}`, which seems to do a `toString` under the hood.

*Note: this brace-based syntax is undocumented and actually appears to be deprecated https://github.com/mapbox/mapbox-gl-js/pull/6216. We should probably replace it by expressions everywhere in our style, but let's discuss that separately.*

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-09-29 à 10 14 17](https://user-images.githubusercontent.com/243653/94531327-b604e700-023c-11eb-877b-345b410472a1.png)|![Capture d’écran 2020-09-29 à 10 13 50](https://user-images.githubusercontent.com/243653/94531310-ae454280-023c-11eb-9a83-87670f0e4f3a.png)|

