### PR TITLE
Panel: white as only background color

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -49,7 +49,6 @@ class Panel extends React.Component {
     setSize: PropTypes.func,
     marginTop: PropTypes.number,
     className: PropTypes.string,
-    white: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -248,7 +247,7 @@ class Panel extends React.Component {
   render() {
     const {
       children, minimizedTitle,
-      resizable, className, white, size, renderHeader, onClose } = this.props;
+      resizable, className, size, renderHeader, onClose } = this.props;
     const { translateY, holding } = this.state;
 
     return (
@@ -256,7 +255,6 @@ class Panel extends React.Component {
         {isMobile =>
           <div
             className={classnames('panel', size, className, {
-              'panel--white': white,
               'panel--holding': holding,
             })}
             style={isMobile ?

--- a/src/panel/NoResultPanel.jsx
+++ b/src/panel/NoResultPanel.jsx
@@ -15,10 +15,7 @@ const handleSearchClick = e => {
 
 const NoResultPanel = () => {
   return (
-    <Panel
-      white
-      close={close}
-    >
+    <Panel close={close}>
       <div
         style={{ padding: '0 16px 32px 16px' }}
       >

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -167,7 +167,6 @@ export default class CategoryPanel extends React.Component {
     }
 
     return <Panel
-      white
       resizable
       minimizedTitle={_('Unfold to show the results', 'categories')}
       className={classnames('category__panel', { 'panel--pj': dataSource === sources.pagesjaunes })}

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -240,7 +240,6 @@ export default class PoiPanel extends React.Component {
     return <DeviceContext.Consumer>
       {isMobile =>
         <Panel
-          white
           resizable
           fitContent
           className={classnames('poi_panel', {

--- a/src/panel/service/ServicePanelDesktop.jsx
+++ b/src/panel/service/ServicePanelDesktop.jsx
@@ -7,7 +7,7 @@ const ServicePanelDesktop = () => {
   const [ collapsed, setCollapsed ] = useState(true);
 
   return <Fragment>
-    <Panel className="service_panel u-mb-8" white>
+    <Panel className="service_panel u-mb-8">
       <h3 className="u-text--smallTitle u-mb-12">
         {_('Search around this place', 'service panel')}
       </h3>

--- a/src/panel/service/ServicePanelMobile.jsx
+++ b/src/panel/service/ServicePanelMobile.jsx
@@ -14,7 +14,6 @@ class ServicePanelMobile extends React.Component {
       resizable
       minimizedTitle={_('Unfold to see quick actions', 'service panel')}
       className="service_panel"
-      white
     >
       {directionConf.enabled && <Fragment>
         <h3 className="u-text--smallTitle u-center u-mb-12">

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -67,16 +67,11 @@ $bottom-margin: 40px;
   .panel {
     width: 100vw;
     position: fixed;
-    background: #f4f6fa;
     border-radius: 12px 12px 0 0;
     bottom: 0;
 
     &-close {
       color: $primary_text;
-    }
-
-    &--white {
-      background: white;
     }
 
     &:not(.panel--holding) {

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -1,6 +1,5 @@
 .service_panel {
   position: relative;
-  background: white;
   background-size: 100% 5px;
   @include card_shadow();
   @include card_radius();


### PR DESCRIPTION
## Description
Set white as the new default (and only) color for the Panel component.
Previously it was gray for mobile panels, with white as an explicit prop. So we can simplify the API of Panel with one less prop.

## Why
We don't have gray background designs any more.
Following https://github.com/QwantResearch/erdapfel/pull/795, the generic item list style changed so items are now full-width, no-border, white background. This doesn't fit anymore with gray backgrounds, so favorites and route results seem broken, with a gray header. They will soon be explicitely redesigned, but until now let's fix them at least.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 87674_2 33186 destination=latlon_48 88692_2 35252 mode=driving pt=true(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/243653/94794647-770d9780-03dc-11eb-96f1-7ff24ad5d625.png)|![localhost_3000_favs_(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/94794653-7a088800-03dc-11eb-93b3-d7e41a81f075.png)|
|![localhost_3000_routes__origin=latlon_48 87674_2 33186 destination=latlon_48 88692_2 35252 mode=driving pt=true(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/94794669-7f65d280-03dc-11eb-8136-68a7953929b0.png)|![localhost_3000_routes__origin=latlon_48 87674_2 33186 destination=latlon_48 88692_2 35252 mode=driving pt=true(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/94794678-812f9600-03dc-11eb-9ea7-3caf52160746.png)|




