### PR TITLE
Fix direction panel results

### DIFF
--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -1,4 +1,5 @@
-import React, { useContext, Fragment } from 'react';
+import React, { useContext, useEffect, Fragment } from 'react';
+import ReactDOM from 'react-dom';
 import MobileRouteDetails from './MobileRouteDetails';
 import RouteSummary from './RouteSummary';
 import RoadMap from './RoadMap';
@@ -9,6 +10,16 @@ const Route = ({
   toggleDetails, openPreview, selectRoute, hoverRoute,
 }) => {
   const isMobile = useContext(DeviceContext);
+  const portalContainer = document.createElement('div');
+
+  useEffect(() => {
+    if (showDetails && isMobile) {
+      document.body.appendChild(portalContainer);
+    }
+    return function removePortalContainer() {
+      portalContainer.remove();
+    };
+  }, [isMobile, showDetails]);
 
   return <Fragment>
     <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
@@ -27,7 +38,7 @@ const Route = ({
         destination={destination}
         vehicle={vehicle} />}
     </div>
-    {isMobile && showDetails && <MobileRouteDetails
+    {isMobile && showDetails && ReactDOM.createPortal(<MobileRouteDetails
       id={id}
       route={route}
       origin={origin}
@@ -35,7 +46,7 @@ const Route = ({
       vehicle={vehicle}
       toggleDetails={toggleDetails}
       openPreview={openPreview}
-    />}
+    />, portalContainer)}
   </Fragment>;
 };
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -5,7 +5,6 @@
   .panel-content {
     display: flex;
     flex-direction: column;
-    overflow-y: visible;
   }
 }
 


### PR DESCRIPTION
## Description
Fixes two separate problems touching the direction panel results:
 - on desktop, the result were not scrollable anymore, due to changes in how the panel content is built with flex stacking instead of computing inner content size.
 - on mobile, the route details view was displayed inside the panel, instead of fullscreen, because of the problem of fixed-positioned element in translated ones. => fixed with a React portal