### PR TITLE
Factorize panel close button and fix interaction on PoiPanel

### DIFF
--- a/src/components/ui/Alert.jsx
+++ b/src/components/ui/Alert.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cs from 'classnames';
 import { string, oneOf, func, node, oneOfType } from 'prop-types';
+import { CloseButton } from 'src/components/ui';
 
 const AlertIcon = {
   success: 'check-circle',
@@ -15,7 +16,6 @@ const Alert = ({
   description,
   type = 'warning',
   onClose,
-  closeButtonLabel,
 }) =>
   <div className={cs('alert', className)}>
     <span className="alert-title">
@@ -23,13 +23,7 @@ const Alert = ({
         <i className={`alert-icon icon-${AlertIcon[type]} icon-${type}`}></i>
         <span role="alert">{title}</span>
       </span>
-      <button
-        className="closeBtn"
-        onClick={onClose}
-        aria-label={closeButtonLabel}
-      >
-        <i className="icon-x" />
-      </button>
+      <CloseButton onClick={onClose} position="topRight" />
     </span>
     <div className="alert-content">
       <span role="alert">{description}</span>

--- a/src/components/ui/CloseButton.jsx
+++ b/src/components/ui/CloseButton.jsx
@@ -1,0 +1,14 @@
+/* global _ */
+import React from 'react';
+import cx from 'classnames';
+
+const CloseButton = ({ className, onClick }) =>
+  <button
+    className={cx('closeButton', className)}
+    title={_('Close')}
+    onClick={onClick}
+  >
+    <i className="icon-x" />
+  </button>;
+
+export default CloseButton;

--- a/src/components/ui/CloseButton.jsx
+++ b/src/components/ui/CloseButton.jsx
@@ -2,9 +2,9 @@
 import React from 'react';
 import cx from 'classnames';
 
-const CloseButton = ({ className, onClick }) =>
+const CloseButton = ({ className, position, onClick }) =>
   <button
-    className={cx('closeButton', className)}
+    className={cx('closeButton', { [`closeButton--${position}`]: position }, className)}
     title={_('Close')}
     onClick={onClick}
   >

--- a/src/components/ui/CloseButton.jsx
+++ b/src/components/ui/CloseButton.jsx
@@ -1,6 +1,7 @@
 /* global _ */
 import React from 'react';
 import cx from 'classnames';
+import PropTypes from 'prop-types';
 
 const CloseButton = ({ className, position, onClick }) =>
   <button
@@ -10,5 +11,11 @@ const CloseButton = ({ className, position, onClick }) =>
   >
     <i className="icon-x" />
   </button>;
+
+CloseButton.propTypes = {
+  className: PropTypes.string,
+  position: PropTypes.oneOf(['topRight']),
+  onClick: PropTypes.func.isRequired,
+};
 
 export default CloseButton;

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -1,10 +1,10 @@
-/* globals _ */
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { fire } from 'src/libs/customEvents';
 import { DeviceContext } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext';
+import { CloseButton } from 'src/components/ui';
 
 const getEventClientY = event => event.changedTouches
   ? event.changedTouches[0].clientY
@@ -268,15 +268,7 @@ class Panel extends React.Component {
             onTransitionEnd={() => this.updateMobileMapUI()}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
-            {onClose &&
-              <button
-                className="panel-close"
-                title={_('Close')}
-                onClick={onClose}
-              >
-                <i className="icon-x" />
-              </button>
-            }
+            {onClose && <CloseButton onClick={onClose} className="panel-close" />}
             {isMobile && resizable &&
               <div
                 className="panel-drawer"

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -11,6 +11,7 @@ import PlaceholderText from './PlaceholderText';
 import Suggest from './Suggest';
 import Text from './Text';
 import PanelNav from './PanelNav';
+import CloseButton from './CloseButton';
 
 export {
   Button,
@@ -27,4 +28,5 @@ export {
   Suggest,
   Text,
   PanelNav,
+  CloseButton,
 };

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -265,7 +265,7 @@ export default class PoiPanel extends React.Component {
                 withOpeningHours
                 onClick={this.center}
               />
-              <CloseButton onClick={isMobile ? backAction : this.closeAction} />
+              <CloseButton onClick={isMobile ? backAction : this.closeAction} position="topRight" />
             </Flex>
             <div className="u-mb-8">
               <ActionButtons

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -17,7 +17,7 @@ import Store from '../../adapters/store';
 import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
 import { DeviceContext } from 'src/libs/device';
-import { Flex, Panel, PanelNav } from 'src/components/ui';
+import { Flex, Panel, PanelNav, CloseButton } from 'src/components/ui';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -257,7 +257,7 @@ export default class PoiPanel extends React.Component {
           }
         >
           <div className="poi_panel__content">
-            <Flex alignItems="flex-start">
+            <Flex alignItems="flex-start" justifyContent="space-between">
               <PoiItem
                 poi={poi}
                 className="u-mb-20 poi-panel-poiItem"
@@ -265,14 +265,7 @@ export default class PoiPanel extends React.Component {
                 withOpeningHours
                 onClick={this.center}
               />
-
-              <button
-                className="poi-panel-close"
-                title={_('Close')}
-                onClick={isMobile ? backAction : this.closeAction}
-              >
-                <i className="icon-x" />
-              </button>
+              <CloseButton onClick={isMobile ? backAction : this.closeAction} />
             </Flex>
             <div className="u-mb-8">
               <ActionButtons

--- a/src/scss/includes/components/alert.scss
+++ b/src/scss/includes/components/alert.scss
@@ -48,17 +48,6 @@
     font-size: 22px;
     margin-right: 8px;
   }
-
-  .closeBtn {
-    color: $grey-grey;
-    align-self: start;
-    cursor: pointer;
-
-    svg {
-      width: 12px;
-      height: 12px;
-    }
-  }
 }
 
 .icon-error {

--- a/src/scss/includes/components/closeButton.scss
+++ b/src/scss/includes/components/closeButton.scss
@@ -6,9 +6,12 @@
   justify-content: center;
   font-size: 22px;
   cursor: pointer;
-  margin-top: -9px;
-  margin-right: -9px;
   color: $primary_text;
+
+  &--topRight {
+    margin-top: -9px;
+    margin-right: -9px;
+  }
 
   @media (min-width: 641px) {
     color: $secondary_text;

--- a/src/scss/includes/components/closeButton.scss
+++ b/src/scss/includes/components/closeButton.scss
@@ -7,6 +7,7 @@
   font-size: 22px;
   cursor: pointer;
   color: $primary_text;
+  flex-shrink: 0;
 
   &--topRight {
     margin-top: -9px;

--- a/src/scss/includes/components/closeButton.scss
+++ b/src/scss/includes/components/closeButton.scss
@@ -1,0 +1,20 @@
+.closeButton {
+  height: 35px;
+  width: 35px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  cursor: pointer;
+  margin-top: -9px;
+  margin-right: -9px;
+  color: $primary_text;
+
+  @media (min-width: 641px) {
+    color: $secondary_text;
+    
+    &:hover {
+      color: $primary_text;
+    }  
+  }
+}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -32,21 +32,12 @@ $bottom-margin: 40px;
     align-self: center;
   }
 
-  &-close {
+  .panel-close {
     position: absolute;
-    top: 8px;
-    right: 16px;
     transition: background-color .1s;
     border-radius: 50%;
-    font-size: 20px;
-    height: 24px;
-    width: 24px;
-    color: $secondary_text;
-    cursor: pointer;
-
-    &:hover {
-      color: $primary_text;
-    }
+    top: 9px;
+    right: 18px;
   }
 }
 
@@ -72,8 +63,8 @@ $bottom-margin: 40px;
     border-radius: 12px 12px 0 0;
     bottom: 0;
 
-    &-close {
-      color: $primary_text;
+    .panel-close {
+      top: 18px;
     }
 
     &:not(.panel--holding) {

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -32,10 +32,8 @@ $bottom-margin: 40px;
     align-self: center;
   }
 
-  .panel-close {
+  &-close {
     position: absolute;
-    transition: background-color .1s;
-    border-radius: 50%;
     top: 9px;
     right: 18px;
   }

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -34,8 +34,7 @@ $bottom-margin: 40px;
 
   &-close {
     position: absolute;
-    top: 9px;
-    right: 18px;
+    right: 9px;
   }
 }
 
@@ -62,7 +61,7 @@ $bottom-margin: 40px;
     bottom: 0;
 
     .panel-close {
-      top: 18px;
+      top: 9px;
     }
 
     &:not(.panel--holding) {

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -28,6 +28,8 @@ $bottom-margin: 40px;
     cursor: -webkit-grab;
     cursor: grab;
     text-align: center;
+    width: 50%;
+    align-self: center;
   }
 
   &-close {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -9,17 +9,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   &-poiItem {
     flex-grow: 1;
   }
-
-  &-close {
-    height: 35px;
-    width: 35px;
-    margin-left: auto;
-    font-size: 22px;
-    cursor: pointer;
-    position: relative;
-    top: -5px;
-    right: -5px;
-  }
 }
 
 .poi_panel__content {
@@ -217,11 +206,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 }
 
 @media (max-width: 640px) {
-
-  .poi-panel-close {
-    right: 0;
-  }
-
   .poi_panel__content {
     padding: 0 12px 12px;
   }

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -10,3 +10,4 @@
 @import "./components/divider";
 @import "./components/block";
 @import "./components/panelNav";
+@import "./components/closeButton";

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -229,7 +229,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   expect(await exists(page, '.poiTitle')).toBeTruthy();
   expect(await exists(page, '.poi_panel')).toBeTruthy();
   await page.click('.poi_panel__actions .poi_panel__action__favorite');
-  await page.click('.poi-panel-close');
+  await page.click('.poi_panel .closeButton');
   // we check that the first favorite item is our poi
   await toggleFavoritePanel(page);
   let fav = await getFavorites(page);
@@ -244,7 +244,7 @@ test('add a poi as favorite and find it back in the favorite menu', async () => 
   expect(await exists(page, '.poi_panel')).toBeTruthy();
 
   await page.click('.poi_panel__actions .poi_panel__action__favorite');
-  await page.click('.poi-panel-close');
+  await page.click('.poi_panel .closeButton');
   // it should disappear from the favorites
   await toggleFavoritePanel(page);
   fav = await getFavorites(page);


### PR DESCRIPTION
## Description
 - Define a new generic component `CloseButton`, that encapsulates its own style for proper size, alignment, hover, etc. Can be extended later.
 - Use this component in PoiPanel, improves design conformity and reduces style specifity.
 - Use this component in Panel, when using the `onClose` prop
 - Also reduce the width of mobile Panel clickable area for auto-resize, so it isn't cliked by mistake when trying to close the panel

## Screenshot
|Before|After|
|---|---|
|![localhost_3000_place_pj_05353141@Kozo_Makita(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/94926592-510df300-04c1-11eb-80bb-cca5a2da4138.png)|![localhost_3000_favs(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/94926652-63882c80-04c1-11eb-831e-d36b23cdd2fc.png)|
|![localhost_3000_favs_(iPhone 6_7_8) (4)](https://user-images.githubusercontent.com/243653/94927294-5a4b8f80-04c2-11eb-8b95-5a59a4dc5d86.png)|![localhost_3000_favs_(iPhone 6_7_8) (3)](https://user-images.githubusercontent.com/243653/94927309-5f104380-04c2-11eb-8814-bc49565d589d.png)|



