### PR TITLE
Fix on-map UI positions when leaving panel

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -93,7 +93,7 @@ class Panel extends React.Component {
   }
 
   componentWillUnmount() {
-    this.updateMobileMapUI();
+    this.updateMobileMapUI({ closing: true });
     this.removeListeners();
     window.removeEventListener('resize', this.handleViewportResize);
   }
@@ -102,9 +102,9 @@ class Panel extends React.Component {
     this.setState({ height: window.innerHeight - this.props.marginTop });
   }
 
-  updateMobileMapUI = () => {
+  updateMobileMapUI = ({ closing } = {}) => {
     if (this.props.resizable) {
-      const heightFromBottom = this.state.height - this.state.translateY;
+      const heightFromBottom = closing ? 0 : this.state.height - this.state.translateY;
 
       window.execOnMapLoaded(() => {
         fire('move_mobile_bottom_ui', heightFromBottom);


### PR DESCRIPTION
## Description
Fix a bug where on-map UI elements (scale, zoom, etc.) are not put at the bottom of the screen when entering the Directions feature on mobile.

## Why
The on-map UI position is controlled by the height of the `<Panel>` component. When it unmounts (like in the case of the Directions feature which doesn't use a Panel instance), it should restore the position to the bottom of the screen. This unmounting case was removed in a previous refacto.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_(iPhone 6_7_8) (7)](https://user-images.githubusercontent.com/243653/95082186-f66fd380-071a-11eb-8503-843ed762ce24.png)|![localhost_3000_(iPhone 6_7_8) (6)](https://user-images.githubusercontent.com/243653/95082200-fbcd1e00-071a-11eb-963b-5a01c4521115.png)|
