### PR TITLE
[ESLint] Rule to avoid useless braces in props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -95,6 +95,7 @@
         "object-curly-spacing": ["error", "always"],
         "object-shorthand": "error",
         "react/prop-types": 0,
+        "react/jsx-curly-brace-presence": ["error", "never"],
         "jsx-quotes": ["error", "prefer-double"]
     },
     "overrides": [

--- a/src/components/ui/Alert.jsx
+++ b/src/components/ui/Alert.jsx
@@ -24,7 +24,7 @@ const Alert = ({
         <span role="alert">{title}</span>
       </span>
       <button
-        className={'closeBtn'}
+        className="closeBtn"
         onClick={onClose}
         aria-label={closeButtonLabel}
       >


### PR DESCRIPTION
## Description
Add an [ESLint rule](https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-brace-presence.md) to avoid useless braces in React props.
So this will be rejected:
```jsx
<MyComponent propName={'propValue'}>{'Child content'}</MyComponent>;
```
Should be written as:
```jsx
<MyComponent propName="propValue">Child content</MyComponent>;
```