### PR TITLE
QMAPS-1752 suggest

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -53,7 +53,7 @@ const Suggest = ({
     };
 
     const handleBlur = () => {
-      //close();
+      close();
     };
 
     const fetchItems = debounce(value => {

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -53,7 +53,7 @@ const Suggest = ({
     };
 
     const handleBlur = () => {
-      close();
+      //close();
     };
 
     const fetchItems = debounce(value => {
@@ -69,7 +69,7 @@ const Suggest = ({
       currentQuery = query;
 
       query
-        .then(suggestions => modifyList(suggestions, withGeoloc, value))
+        .then(suggestions => modifyList(suggestions, withGeoloc && value === '', value))
         .then(items => {
           setItems(items);
           currentQuery = null;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -742,6 +742,6 @@ button.direction_shortcut {
   }
 
   .autocomplete_suggestions {
-    height: calc(100vh - 64px);
+    height: 100vh;
   }
 }

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -740,4 +740,8 @@ button.direction_shortcut {
       }
     }
   }
+
+  .autocomplete_suggestions {
+    height: calc(100vh - 64px);
+  }
 }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -154,11 +154,9 @@ input[type="search"] {
   width: 60px;
   flex-shrink: 0;
   text-align: center;
-  margin-right: 14px;
 }
 
 .autocomplete_suggestion--geoloc {
-  border-bottom: 1px solid #e0e1e6;
   padding-top: 12px;
   padding-bottom: 12px;
 


### PR DESCRIPTION
- make suggest list full-height on mobile (top bar +direction panel)
- show more text in suggest list items (only 60px of space on the left for the icon)
- direction panel: hide "your position" when we started typing, and no border below "your position" when it's visible.

## Screenshots


![image](https://user-images.githubusercontent.com/1225909/95188075-40fd5880-07cc-11eb-834d-4e8bab504b8f.png)
![image](https://user-images.githubusercontent.com/1225909/95188205-64c09e80-07cc-11eb-8b11-fcc17dcd23f2.png)

![image](https://user-images.githubusercontent.com/1225909/95188134-4eb2de00-07cc-11eb-8780-2e8406241508.png)
![image](https://user-images.githubusercontent.com/1225909/95188371-99ccf100-07cc-11eb-919f-15dcef18c27a.png)



