### PR TITLE
Tweak category list padding and footer

### DIFF
--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -5,6 +5,7 @@
 }
 
 .category__panel__pj {
+  width: 100%;
   height: 32px;
   border-top: 1px solid $grey-light;
   line-height: 32px;

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -1,20 +1,16 @@
 .category__panel {
   .poiItem {
-    padding: 16px 30px;
+    padding: 16px 14px;
   }
 }
 
 .category__panel__pj {
-  width: 100%;
-  height: 36px;
-  bottom: 0;
+  height: 32px;
   border-top: 1px solid $grey-light;
-  background: $background;
-  line-height: 36px;
-  text-align: center;
-  font-size: 14px;
+  line-height: 32px;
+  font-size: 12px;
+  padding: 0 14px;
   color: $grey-semi-darkness;
-  border-radius: 0 0 12px 12px;
 }
 
 .category__panel__items {
@@ -64,9 +60,12 @@
   }
 
   .category__panel__pj {
+    text-align: center;
     position: fixed;
     bottom: 0;
     height: 36px;
+    line-height: 36px;
+    font-size: 14px;
     border-radius: 0;
   }
 


### PR DESCRIPTION
## Description
Adjust paddings and PagesJaunes footer on the desktop category list, to match the design.

Let's focus on this panel only here, but it would be good too to soon make a pass over all our panels to ensure consistency of paddings. Introducing the spacing vars used by the design would be useful.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_places__type=restaurant (1)](https://user-images.githubusercontent.com/243653/95566245-9a11fa00-0a21-11eb-9037-3f0bda2c8c2f.png)|![localhost_3000_places__type=restaurant](https://user-images.githubusercontent.com/243653/95566257-9c745400-0a21-11eb-9725-da5b7dc0e6ee.png)|
