### PR TITLE
Tweak mobile direction field when focused

### DIFF
--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -18,11 +18,11 @@
         position: fixed;
         display: block;
         z-index: 1;
-        top: 5px;
+        top: 8px;
         left: 0;
         width: 100%;
-        height: 64px;
-        line-height: 56px;
+        height: 48px;
+        line-height: 50px;
         background-color: $background;
 
         /* START Focus-gradient effect */
@@ -32,7 +32,7 @@
           top: 0; right: 10px; bottom: 0; left: 10px;
           z-index: -1;
           margin: -1px;
-          height: 56px;
+          height: 50px;
           border-radius: 50px;
           background: $focus-gradient;
         }
@@ -43,7 +43,7 @@
           position: absolute;
           top: 0; right: 10px; bottom: 0; left: 10px;
           z-index: -1;
-          height: 54px;
+          height: 48px;
           border-radius: 50px;
           background: $background;
         }
@@ -53,9 +53,9 @@
           display: block;
           position: fixed;
           z-index: 2;
-          left: 15px;
-          top: 20px;
-          font-size: 25px;
+          left: 24px;
+          top: 22px;
+          font-size: 20px;
           color: #353C52;
         }
 


### PR DESCRIPTION
## Description
Just some hardcoded tweaks so that the focused mobile direction fields look more alike the general search field.
The right way to solve the inconsistencies would be to use the same markup/CSS for both (with some flex <3), but this is more work (especially if we want the same React component), so let's keep it for later and fix only the look for now.
 - adjust height and padding
 - adjust size and positions of the back icon

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2020-10-09 17-00-51](https://user-images.githubusercontent.com/243653/95599680-aca42780-0a51-11eb-9a5f-b251f2b110d4.png)|![Capture d’écran de 2020-10-09 16-58-28](https://user-images.githubusercontent.com/243653/95599694-b168db80-0a51-11eb-9631-e089b48dfb07.png)|

