### PR TITLE
Qmaps 1751 - Set current location as origin on mobile

### DIFF
--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -1,7 +1,7 @@
 /* global _ */
 
 import Poi from '../poi';
-import GeolocationCheck from 'src/libs/geolocation';
+import * as GeolocationCheck from 'src/libs/geolocation';
 
 export const navigatorGeolocationStatus = {
   PENDING: 'pending',

--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -24,7 +24,7 @@ export default class NavigatorGeolocalisationPoi extends Poi {
   }
 
   async geolocate(options = { displayErrorModal: true }) {
-    await GeolocationCheck.checkPrompt();
+    await GeolocationCheck.showGeolocationModalIfNeeded();
     return new Promise((resolve, reject) => {
       this.status = navigatorGeolocationStatus.PENDING;
       navigator.geolocation.getCurrentPosition(position => {

--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -23,7 +23,7 @@ export default class NavigatorGeolocalisationPoi extends Poi {
     return window.__navigatorGeolocalisationPoi;
   }
 
-  async geolocate() {
+  async geolocate(options = { displayErrorModal: true }) {
     await GeolocationCheck.checkPrompt();
     return new Promise((resolve, reject) => {
       this.status = navigatorGeolocationStatus.PENDING;
@@ -34,7 +34,11 @@ export default class NavigatorGeolocalisationPoi extends Poi {
         if (error.code === 1) {
           this.status = navigatorGeolocationStatus.FORBIDDEN;
         }
-        GeolocationCheck.handleError(error);
+
+        if (options.displayErrorModal) {
+          GeolocationCheck.handleError(error);
+        }
+
         reject(error);
       });
     });

--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -1,7 +1,7 @@
 /* global _ */
 
 import Poi from '../poi';
-import * as GeolocationCheck from 'src/libs/geolocation';
+import * as Geolocation from 'src/libs/geolocation';
 
 export const navigatorGeolocationStatus = {
   PENDING: 'pending',
@@ -24,7 +24,7 @@ export default class NavigatorGeolocalisationPoi extends Poi {
   }
 
   async geolocate(options = { displayErrorModal: true }) {
-    await GeolocationCheck.showGeolocationModalIfNeeded();
+    await Geolocation.showGeolocationModalIfNeeded();
     return new Promise((resolve, reject) => {
       this.status = navigatorGeolocationStatus.PENDING;
       navigator.geolocation.getCurrentPosition(position => {
@@ -36,7 +36,7 @@ export default class NavigatorGeolocalisationPoi extends Poi {
         }
 
         if (options.displayErrorModal) {
-          GeolocationCheck.handleError(error);
+          Geolocation.handleError(error);
         }
 
         reject(error);

--- a/src/libs/geolocation.js
+++ b/src/libs/geolocation.js
@@ -7,21 +7,23 @@ const geolocationPermissions = {
   DENIED: 'denied',
 };
 
-export async function checkPrompt(successCallback = () => {}) {
+let hasPermissionModalOpenedOnce = false;
+
+export async function checkPrompt() {
   if (!window.navigator.permissions) {
     // Some browsers (Safari, etc) do not implement Permissions API
-    return successCallback();
+    return;
   }
 
-  return window.navigator.permissions.query({ name: 'geolocation' }).then(async p => {
-    if (p.state === geolocationPermissions.PROMPT) {
-      if (window._GEO_QUESTION_ASKED !== true) {
-        window._GEO_QUESTION_ASKED = true;
-        await openAndWaitForClose();
-      }
-    }
-    return successCallback();
-  });
+  const p = await window.navigator.permissions.query({ name: 'geolocation' });
+  if (p.state !== geolocationPermissions.PROMPT) {
+    // allowed on denied
+    return;
+  }
+
+  if (hasPermissionModalOpenedOnce === true) {return;}
+  hasPermissionModalOpenedOnce = true;
+  await openAndWaitForClose();
 }
 
 export function handleError(error) {

--- a/src/libs/geolocation.js
+++ b/src/libs/geolocation.js
@@ -9,7 +9,7 @@ const geolocationPermissions = {
 
 let hasPermissionModalOpenedOnce = false;
 
-export async function checkPrompt() {
+export async function showGeolocationModalIfNeeded() {
   if (!window.navigator.permissions) {
     // Some browsers (Safari, etc) do not implement Permissions API
     return;

--- a/src/libs/geolocation.js
+++ b/src/libs/geolocation.js
@@ -7,30 +7,28 @@ const geolocationPermissions = {
   DENIED: 'denied',
 };
 
-export default class GeolocationCheck {
-  static async checkPrompt(successCallback = () => {}) {
-    if (!window.navigator.permissions) {
-      // Some browsers (Safari, etc) do not implement Permissions API
-      return successCallback();
-    }
-
-    return window.navigator.permissions.query({ name: 'geolocation' }).then(async p => {
-      if (p.state === geolocationPermissions.PROMPT) {
-        if (window._GEO_QUESTION_ASKED !== true) {
-          window._GEO_QUESTION_ASKED = true;
-          await openAndWaitForClose();
-        }
-      }
-      return successCallback();
-    });
+export async function checkPrompt(successCallback = () => {}) {
+  if (!window.navigator.permissions) {
+    // Some browsers (Safari, etc) do not implement Permissions API
+    return successCallback();
   }
 
-  static handleError(error) {
-    if (error.code === 1) {
-      // PERMISSION_DENIED
-      fire('open_geolocate_denied_modal');
-    } else {
-      fire('open_geolocate_not_activated_modal');
+  return window.navigator.permissions.query({ name: 'geolocation' }).then(async p => {
+    if (p.state === geolocationPermissions.PROMPT) {
+      if (window._GEO_QUESTION_ASKED !== true) {
+        window._GEO_QUESTION_ASKED = true;
+        await openAndWaitForClose();
+      }
     }
+    return successCallback();
+  });
+}
+
+export function handleError(error) {
+  if (error.code === 1) {
+    // PERMISSION_DENIED
+    fire('open_geolocate_denied_modal');
+  } else {
+    fire('open_geolocate_not_activated_modal');
   }
 }

--- a/src/libs/geolocation.js
+++ b/src/libs/geolocation.js
@@ -17,7 +17,7 @@ export async function showGeolocationModalIfNeeded() {
 
   const p = await window.navigator.permissions.query({ name: 'geolocation' });
   if (p.state !== geolocationPermissions.PROMPT) {
-    // allowed on denied
+    // allowed or denied
     return;
   }
 

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -1,4 +1,4 @@
-import GeolocationCheck from '../libs/geolocation';
+import * as GeolocationCheck from '../libs/geolocation';
 import Telemetry from '../libs/telemetry';
 
 import { GeolocateControl } from 'mapbox-gl--ENV';

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -27,7 +27,7 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
   }
 
   async trigger() {
-    await GeolocationCheck.checkPrompt();
+    await GeolocationCheck.showGeolocationModalIfNeeded();
     super.trigger();
   }
 

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -26,8 +26,9 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
     this._onReady = cb;
   }
 
-  trigger() {
-    GeolocationCheck.checkPrompt(() => super.trigger());
+  async trigger() {
+    await GeolocationCheck.checkPrompt();
+    super.trigger();
   }
 
   _setupUI(supported) {

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -1,4 +1,4 @@
-import * as GeolocationCheck from '../libs/geolocation';
+import * as Geolocation from '../libs/geolocation';
 import Telemetry from '../libs/telemetry';
 
 import { GeolocateControl } from 'mapbox-gl--ENV';
@@ -27,7 +27,7 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
   }
 
   async trigger() {
-    await GeolocationCheck.showGeolocationModalIfNeeded();
+    await Geolocation.showGeolocationModalIfNeeded();
     super.trigger();
   }
 
@@ -37,7 +37,7 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
   }
 
   _onError(error) {
-    GeolocationCheck.handleError(error);
+    Geolocation.handleError(error);
     super._onError(error);
   }
 }

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -17,7 +17,7 @@ import * as address from '../../libs/address';
 import { CloseButton, Flex } from '../../components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
-import * as GeolocationCheck from 'src/libs/geolocation';
+import * as Geolocation from 'src/libs/geolocation';
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {
@@ -67,7 +67,7 @@ export default class DirectionPanel extends React.Component {
 
     if (!this.props.origin && isMobileDevice()) {
       // If authorized, set origin to current position on mobile
-      await GeolocationCheck.showGeolocationModalIfNeeded();
+      await Geolocation.showGeolocationModalIfNeeded();
       const origin = new NavigatorGeolocalisationPoi();
       try {
         await origin.geolocate({ displayErrorModal: false });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -17,7 +17,7 @@ import * as address from '../../libs/address';
 import { CloseButton, Flex } from '../../components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
-import GeolocationCheck from 'src/libs/geolocation';
+import * as GeolocationCheck from 'src/libs/geolocation';
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -67,7 +67,7 @@ export default class DirectionPanel extends React.Component {
 
     if (!this.props.origin && isMobileDevice()) {
       // If authorized, set origin to current position on mobile
-      await new Promise(resolve => GeolocationCheck.checkPrompt(resolve));
+      await GeolocationCheck.checkPrompt();
       const origin = new NavigatorGeolocalisationPoi();
       try {
         await origin.geolocate({ displayErrorModal: false });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -17,7 +17,6 @@ import * as address from '../../libs/address';
 import { CloseButton, Flex } from '../../components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
-import * as Geolocation from 'src/libs/geolocation';
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {
@@ -67,7 +66,6 @@ export default class DirectionPanel extends React.Component {
 
     if (!this.props.origin && isMobileDevice()) {
       // If authorized, set origin to current position on mobile
-      await Geolocation.showGeolocationModalIfNeeded();
       const origin = new NavigatorGeolocalisationPoi();
       try {
         await origin.geolocate({ displayErrorModal: false });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -67,7 +67,7 @@ export default class DirectionPanel extends React.Component {
 
     if (!this.props.origin && isMobileDevice()) {
       // If authorized, set origin to current position on mobile
-      await GeolocationCheck.checkPrompt();
+      await GeolocationCheck.showGeolocationModalIfNeeded();
       const origin = new NavigatorGeolocalisationPoi();
       try {
         await origin.geolocate({ displayErrorModal: false });


### PR DESCRIPTION
## Description

- On mobile devices, if origin is not set as a props to `DirectionPanel` on mount, set current location as origin.
- geolocation: export functions instead of class
- asyncify checkPrompt
- checkPrompt -> showGeolocationModalIfNeeded

## Screenshots

Screencast when opening a default direction panel, and when opening an itinerary from a POI panel :
![Peek 2020-10-12 10-48](https://user-images.githubusercontent.com/2981774/95725864-7ac0da00-0c78-11eb-94ac-b09f599b014a.gif)
