### PR TITLE
Button disabled: use grey-grey color

### DIFF
--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -29,7 +29,7 @@
   &:disabled {
     background-color: $grey-lighter;
     border-color: $grey-lighter;
-    color: $secondary_text;
+    color: $grey-grey;
     cursor: unset;
   }
 


### PR DESCRIPTION
Instead of `secondary_text`