### PR TITLE
Add missing call to computeRoutes on mobile + loc

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -69,7 +69,10 @@ export default class DirectionPanel extends React.Component {
       const origin = new NavigatorGeolocalisationPoi();
       try {
         await origin.geolocate({ displayErrorModal: false });
-        this.setState({ origin, originInputText: origin.name });
+        this.setState(
+          { origin, originInputText: origin.name },
+          this.update
+        );
       } catch (e) {
         // ignore possible error
       }


### PR DESCRIPTION
## Description
Location was used as origin, but we forgot to call `this.update` (which call `this.computeRoutes` and`this.updateUrl`) :medal_sports: 