### PR TITLE
Fix left margin of direction form divider

### DIFF
--- a/src/components/ui/Divider.jsx
+++ b/src/components/ui/Divider.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import cx from 'classnames';
 
-const Divider = ({ className, paddingTop = 20, paddingBottom = 20, marginLeft = 0 }) =>
+const Divider = ({ className, paddingTop = 20, paddingBottom = 20 }) =>
   <div
     className={cx('divider', className)}
-    style={{
-      padding: `${paddingTop}px 0 ${paddingBottom}px 0`,
-      marginLeft,
-    }}
+    style={{ padding: `${paddingTop}px 0 ${paddingBottom}px 0` }}
   >
     <div className="divider-line" />
   </div>

--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -78,7 +78,7 @@ export default class DirectionForm extends React.Component {
             onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
             ref={this.originRef}
           />
-          <Divider paddingTop={0} paddingBottom={0} marginLeft={64}/>
+          <Divider paddingTop={0} paddingBottom={0} />
           <DirectionInput
             isLoading={isLoading}
             value={destinationInputText}

--- a/src/scss/includes/direction-form.scss
+++ b/src/scss/includes/direction-form.scss
@@ -60,4 +60,12 @@
       width: 100%;
     }
   }
+
+  .divider {
+    margin-left: 48px;
+
+    @media (min-width: 641px) {
+      margin-left: 64px;
+    }
+  }
 }


### PR DESCRIPTION
## Description
Fix the left margin of the divider between the two direction input fields so it's aligned on mobile too.
 
## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__mode=driving pt=true (1)](https://user-images.githubusercontent.com/243653/95843670-40267280-0d48-11eb-8557-9af03c8bda4f.png)|![localhost_3000_routes__destination=osm_way_846539966@Coll%C3%A8ge_Solveig_Anspach mode=driving pt=true](https://user-images.githubusercontent.com/243653/95843655-3b61be80-0d48-11eb-88c6-ed6142e051a0.png)|
