### PR TITLE
Add '3 dots' background between origin/destinattion icons

### DIFF
--- a/src/scss/includes/direction-form.scss
+++ b/src/scss/includes/direction-form.scss
@@ -58,6 +58,17 @@
 
     .direction-fields-block {
       width: 100%;
+      background-image:
+        radial-gradient($grey-grey 100%, transparent 100%),
+        radial-gradient($grey-grey 100%, transparent 100%),
+        radial-gradient($grey-grey 100%, transparent 100%);
+      background-position: 23px calc(50% - 8px), 23px calc(50% - 1px), 23px calc(50% + 6px);
+      background-size: 2px 2px;
+      background-repeat: no-repeat;
+
+      @media (min-width: 641px) {
+        background-position: 31px calc(50% - 8px), 31px calc(50% - 1px), 31px calc(50% + 6px);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Use CSS trick of multiple gradients as background to add the 3 small dots between the origin and destination points.
Works fine on all tested browsers (Chrome Desktop/Android, Firefox Desktop/Android, Webkit-based Epiphany, and event IE11).

## Screenshots
![Capture d’écran de 2020-10-13 14-12-52](https://user-images.githubusercontent.com/243653/95859041-4aec0200-0d5e-11eb-8bf7-f509d9734a61.png)
![Capture d’écran de 2020-10-13 14-12-45](https://user-images.githubusercontent.com/243653/95859043-4b849880-0d5e-11eb-9f84-dddc2efc2d1c.png)

