### PR TITLE
three dots icon with pseudo element (alternative)

### DIFF
--- a/src/scss/includes/direction-form.scss
+++ b/src/scss/includes/direction-form.scss
@@ -58,6 +58,22 @@
 
     .direction-fields-block {
       width: 100%;
+      position: relative;
+
+      &:after {
+        content: '•••';
+        position: absolute;
+        color: $grey-grey;
+        top: 50%;
+        left: 23px;
+        transform: translateY(-50%) rotate(90deg);
+        letter-spacing: 2px;
+        font-size: 12px;
+
+        @media (max-width: 640px) {
+          left: 15px;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Using pseudo element with `content: '•••';`

## Screenshots
*For PRs with visual impacts. It's sometimes useful to provide before/after images.*
![image](https://user-images.githubusercontent.com/2981774/95863056-02cfde00-0d64-11eb-8aad-8c5914497c3b.png)
