### PR TITLE
Qmaps 1775 - Fix suggest overlap route results

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -329,8 +329,8 @@ export default class DirectionPanel extends React.Component {
           {!activePreviewRoute && origin && destination &&
             <Panel
               resizable
-              fitContent={['default']} 
-              marginTop={this.mobileFormRef.current.offsetHeight}
+              fitContent={['default']}
+              marginTop={this.mobileFormRef.current?.offsetHeight}
             >
               {result}
             </Panel>}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -41,6 +41,8 @@ export default class DirectionPanel extends React.Component {
 
     this.lastQueryId = 0;
 
+    this.mobileFormRef = React.createRef();
+
     this.state = {
       vehicle: activeVehicle,
       origin: null,
@@ -310,7 +312,7 @@ export default class DirectionPanel extends React.Component {
     return <DeviceContext.Consumer>
       {isMobile => isMobile
         ? <Fragment>
-          {!activePreviewRoute && <div className="direction-panel">
+          {!activePreviewRoute && <div className="direction-panel" ref={this.mobileFormRef}>
             <Flex
               className="direction-panel-header"
               alignItems="center"
@@ -325,7 +327,11 @@ export default class DirectionPanel extends React.Component {
             />}
           </div>}
           {!activePreviewRoute && origin && destination &&
-            <Panel resizable marginTop={160} fitContent={['default']}>
+            <Panel
+              resizable
+              fitContent={['default']} 
+              marginTop={this.mobileFormRef.current.offsetHeight}
+            >
               {result}
             </Panel>}
           {activePreviewRoute && <MobileRoadMapPreview

--- a/src/scss/includes/direction-panel.scss
+++ b/src/scss/includes/direction-panel.scss
@@ -9,6 +9,7 @@
     top: 0;
     left: 0;
     padding-top: 20px;
+    z-index: 1;
 
     .direction-close {
       display: flex;


### PR DESCRIPTION
## Description
Two fixes on the relationship between the top (form) and bottom (result) parts of the direction mobile UI.
 - ensure the suggest dropdown is displayed above the result panel, instead of below
 - ensure the result panel maximized height is limited by the top part