### PR TITLE
Dynamic POIs layer: reduce collisions and define configuration flag

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -47,6 +47,7 @@ mapStyle:
   spritesUrl: /mapstyle/
   fontsUrl: /mapstyle/font/
   maxAge: '15m' # string accepted by the ms module, or milliseconds
+  showNamesWithPins: true
 
 mapPlugins:
   maxAge: '60s' # string accepted by the ms module, or milliseconds

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -4,7 +4,8 @@ export const filteredPoisStyle = {
   layout: {
     'icon-image': 'pin_with_dot',
     'icon-allow-overlap': true,
-    'icon-ignore-placement': true,
+    'icon-ignore-placement': false,
+    'icon-padding': 0,
     'icon-size': 0.5,
     'icon-anchor': 'bottom',
 

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -1,5 +1,5 @@
 
-export const filteredPoisStyle = {
+export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
   type: 'symbol',
   layout: {
     'icon-image': 'pin_with_dot',
@@ -11,7 +11,7 @@ export const filteredPoisStyle = {
 
     'text-font': [ 'Noto Sans Bold' ],
     'text-size': 10,
-    'text-field': ['get', 'name'],
+    'text-field': withName ? ['get', 'name'] : '',
     'text-allow-overlap': false,
     'text-ignore-placement': false,
     'text-optional': true,
@@ -25,4 +25,4 @@ export const filteredPoisStyle = {
     'text-halo-width': 1,
     'text-translate': [0, -2],
   },
-};
+});

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -1,13 +1,15 @@
+import nconf from '@qwant/nconf-getter';
 import { Marker } from 'mapbox-gl--ENV';
 import constants from '../../config/constants.yml';
 import Telemetry from 'src/libs/telemetry';
 import { toUrl } from 'src/libs/pois';
 import { fire, listen } from 'src/libs/customEvents';
 import { poisToGeoJSON, emptyFeatureCollection } from 'src/libs/geojson';
-import { filteredPoisStyle } from 'src/adapters/pois_styles';
+import { getFilteredPoisStyle } from 'src/adapters/pois_styles';
 import { createMapGLIcon, createIcon } from 'src/adapters/icon_manager';
 
 const DYNAMIC_POIS_LAYER = 'poi-filtered';
+const mapStyleConfig = nconf.get().mapStyle;
 
 export default class SceneCategory {
   constructor(map) {
@@ -51,7 +53,7 @@ export default class SceneCategory {
       promoteId: 'id',
     });
     this.map.addLayer({
-      ...filteredPoisStyle,
+      ...getFilteredPoisStyle({ withName: mapStyleConfig.showNamesWithPins }),
       source: DYNAMIC_POIS_LAYER,
       id: DYNAMIC_POIS_LAYER,
     });


### PR DESCRIPTION
## Description
* Use `'icon-ignore-placement': false` on the dynamic layer as an attempt to reduce collisions between names and pin symbols.
* Define a new setting `showNamesWithPins` to allow these names to be disabled in the configuration

## Why
In dense areas, many collisions between names and pins may occur. This change is an attempt to reduce these collisions, although it's still far from perfect.  
Options provided by mapbox-gl are quite confusing (https://docs.mapbox.com/help/troubleshooting/optimize-map-label-placement/#label-collision), it's unclear how to improve it.


## Screenshots
![Peek 13-10-2020 12-42](https://user-images.githubusercontent.com/4726554/95876445-585fb700-0d73-11eb-8a88-e6ac03456b83.gif)
![Peek 13-10-2020 14-58](https://user-images.githubusercontent.com/4726554/95876454-5bf33e00-0d73-11eb-92a6-8828ea880b11.gif)


