### PR TITLE
Qmaps 1602 pin marker icons for filtered POI lists

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -107,6 +107,7 @@ const mainJsChunkConfig = buildMode => {
               output: 'production', // 'debug' | 'production' | 'omt'
               outPath: __dirname + '/../public/mapstyle',
               i18n: true,
+              pins: true,
               icons: true,
               pixelRatios: [1, 2],
             },

--- a/public/images/map/pin-maxi.svg
+++ b/public/images/map/pin-maxi.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="26" height="49" viewBox="0 0 26 49">
+    <defs>
+        <ellipse id="xj77o4ovab" cx="12" cy="41" rx="4" ry="2"/>
+        <filter id="ddcndnhopa" width="262.5%" height="425%" x="-81.2%" y="-137.5%" filterUnits="objectBoundingBox">
+            <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+            <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="2"/>
+            <feColorMatrix in="shadowBlurOuter1" result="shadowMatrixOuter1" values="0 0 0 0 0.0470588235 0 0 0 0 0.0470588235 0 0 0 0 0.0549019608 0 0 0 0.2 0"/>
+            <feOffset in="SourceAlpha" result="shadowOffsetOuter2"/>
+            <feGaussianBlur in="shadowOffsetOuter2" result="shadowBlurOuter2" stdDeviation="1"/>
+            <feColorMatrix in="shadowBlurOuter2" result="shadowMatrixOuter2" values="0 0 0 0 0.0470588235 0 0 0 0 0.0470588235 0 0 0 0 0.0549019608 0 0 0 0.12 0"/>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"/>
+                <feMergeNode in="shadowMatrixOuter2"/>
+            </feMerge>
+        </filter>
+    </defs>
+    <g fill="none" fill-rule="evenodd" transform="translate(1 1)">
+        <use fill="#000" filter="url(#ddcndnhopa)" xlink:href="#xj77o4ovab"/>
+        <path stroke="#900014" d="M12-.5l.369.005c3.305.096 6.289 1.475 8.47 3.656C23.1 5.423 24.5 8.548 24.5 12c0 3.44-1.537 6.222-3.641 8.815C16.468 26.225 13.5 31.922 13.5 39c0 .414-.168.79-.44 1.06-.27.272-.646.44-1.06.44-.414 0-.79-.168-1.06-.44-.272-.27-.44-.646-.44-1.06 0-7.078-2.968-12.776-7.359-18.185C1.037 18.222-.5 15.44-.5 12c0-3.452 1.4-6.577 3.661-8.839C5.423.9 8.548-.5 12-.5h0z"/>
+        <path fill="#E2001C" d="M12 0c6.627 0 12 5.373 12 12 0 3.321-1.5 6-3.53 8.5C16.003 26.003 13 31.803 13 39c0 .552-.448 1-1 1s-1-.448-1-1c0-7.197-3.003-12.997-7.47-18.5C1.5 18 0 15.321 0 12 0 5.373 5.373 0 12 0z"/>
+        <circle cx="12" cy="12" r="4" fill="#FFF"/>
+    </g>
+</svg>

--- a/src/adapters/icon_manager.js
+++ b/src/adapters/icon_manager.js
@@ -95,3 +95,14 @@ export function createMapGLIcon(imageFile, width, height) {
     img.src = imageFile;
   });
 }
+
+export function createPinIcon(iconOptions) {
+  const element = document.createElement('div');
+  element.innerHTML = `
+    <div
+      class="marker ${iconOptions.className || ''}"
+      ${iconOptions.disablePointerEvents && 'style="pointer-events:none;"'}
+    ></div>
+  `;
+  return element.firstElementChild;
+}

--- a/src/adapters/icon_manager.js
+++ b/src/adapters/icon_manager.js
@@ -1,4 +1,5 @@
 import styleIcons from '@qwant/qwant-basic-gl-style/icons.yml';
+import classnames from 'classnames';
 
 const nameToClass = iconName => iconName.match(/^(.*?)-[0-9]{1,2}$/)[1];
 
@@ -96,13 +97,11 @@ export function createMapGLIcon(imageFile, width, height) {
   });
 }
 
-export function createPinIcon(iconOptions) {
+export function createPinIcon({ className, disablePointerEvents }) {
   const element = document.createElement('div');
-  element.innerHTML = `
-    <div
-      class="marker ${iconOptions.className || ''}"
-      ${iconOptions.disablePointerEvents && 'style="pointer-events:none;"'}
-    ></div>
-  `;
-  return element.firstElementChild;
+  element.className = classnames('marker', className);
+  if (disablePointerEvents) {
+    element.style = 'pointer-events:none;';
+  }
+  return element;
 }

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -2,7 +2,7 @@
 export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
   type: 'symbol',
   layout: {
-    'icon-image': ['concat', 'pin-', ['get', 'subclass']],
+    'icon-image': ['concat', 'pin-', ['get', 'iconName']],
     'icon-allow-overlap': true,
     'icon-ignore-placement': false,
     'icon-padding': 0,

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -2,11 +2,10 @@
 export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
   type: 'symbol',
   layout: {
-    'icon-image': 'pin_with_dot',
+    'icon-image': ['concat', 'pin-', ['get', 'subclass']],
     'icon-allow-overlap': true,
     'icon-ignore-placement': false,
     'icon-padding': 0,
-    'icon-size': 0.5,
     'icon-anchor': 'bottom',
 
     'text-font': [ 'Noto Sans Bold' ],

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -19,6 +19,11 @@ export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
     'text-justify': 'auto',
   },
   paint: {
+    'icon-opacity': ['case',
+      ['==', ['feature-state', 'selected'], true], 0,
+      ['==', ['feature-state', 'hovered'], true], 0,
+      1,
+    ],
     'text-color': ['case', ['==', ['feature-state', 'selected'], true], '#900014', '#0c0c0e'],
     'text-halo-color': 'white',
     'text-halo-width': 1,

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -4,13 +4,25 @@ import constants from '../../config/constants.yml';
 import Telemetry from 'src/libs/telemetry';
 import { toUrl } from 'src/libs/pois';
 import { fire, listen } from 'src/libs/customEvents';
-import { poisToGeoJSON, emptyFeatureCollection } from 'src/libs/geojson';
+import { poiToGeoJSON, emptyFeatureCollection } from 'src/libs/geojson';
 import { getFilteredPoisStyle } from 'src/adapters/pois_styles';
 import { isMobileDevice } from 'src/libs/device';
 import { createMapGLIcon, createPinIcon } from 'src/adapters/icon_manager';
+import IconManager from 'src/adapters/icon_manager';
 
 const DYNAMIC_POIS_LAYER = 'poi-filtered';
 const mapStyleConfig = nconf.get().mapStyle;
+
+const poisToGeoJSON = pois => {
+  return {
+    type: 'FeatureCollection',
+    features: pois.map(poi => {
+      const poiFeature = poiToGeoJSON(poi);
+      poiFeature.properties.iconName = IconManager.get(poi).iconClass;
+      return poiFeature;
+    }),
+  };
+};
 
 export default class SceneCategory {
   constructor(map) {

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -138,17 +138,20 @@ export default class SceneCategory {
     });
   }
 
+  setPoiFeatureState = (id, state) => {
+    this.map.setFeatureState({ id, source: DYNAMIC_POIS_LAYER }, state);
+  }
+
   highlightPoiMarker = (poi, highlight) => {
-    if (poi) {
-      this.map.setFeatureState(
-        { id: poi.id, source: DYNAMIC_POIS_LAYER },
-        { hovered: highlight });
+    if (this.hoveredPoi) {
+      this.setPoiFeatureState(this.hoveredPoi.id, { hovered: false });
     }
     if (highlight) {
       this.hoveredPoi = poi;
       this.hoveredMarker
         .setLngLat(poi.latLon)
         .addTo(this.map);
+      this.setPoiFeatureState(this.hoveredPoi.id, { hovered: true });
     } else {
       this.hoveredMarker.remove();
       this.hoveredPoi = null;
@@ -160,18 +163,14 @@ export default class SceneCategory {
       return;
     }
     if (this.selectedPoi) {
-      this.map.setFeatureState(
-        { id: this.selectedPoi.id, source: DYNAMIC_POIS_LAYER },
-        { selected: false });
+      this.setPoiFeatureState(this.selectedPoi.id, { selected: false });
     }
     if (poi) {
       this.selectedPoi = poi;
       this.selectedMarker
         .setLngLat(poi.latLon)
         .addTo(this.map);
-      this.map.setFeatureState(
-        { id: poi.id, source: DYNAMIC_POIS_LAYER },
-        { selected: true });
+      this.setPoiFeatureState(this.selectedPoi.id, { selected: true });
     } else {
       this.selectedMarker.remove();
       this.selectedPoi = null;

--- a/src/libs/geojson.js
+++ b/src/libs/geojson.js
@@ -1,3 +1,4 @@
+import IconManager from 'src/adapters/icon_manager';
 
 const geoJsonGeometryToFeature = geometry => ({
   type: 'Feature',
@@ -25,6 +26,7 @@ export const poiToGeoJSON = poi => ({
     id: poi.id,
     name: poi.name,
     subclass: poi.subClassName,
+    iconName: IconManager.get(poi).iconClass,
   },
 });
 

--- a/src/libs/geojson.js
+++ b/src/libs/geojson.js
@@ -1,5 +1,3 @@
-import IconManager from 'src/adapters/icon_manager';
-
 const geoJsonGeometryToFeature = geometry => ({
   type: 'Feature',
   geometry,
@@ -26,7 +24,6 @@ export const poiToGeoJSON = poi => ({
     id: poi.id,
     name: poi.name,
     subclass: poi.subClassName,
-    iconName: IconManager.get(poi).iconClass,
   },
 });
 

--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -93,11 +93,9 @@ noscript {
   margin-top: calc(-25% + 3px);
 }
 
-.marker--category .marker-container {
-  width: 30px;
-  height: 35px;
-
-  i {
-    font-size: 24px;
-  }
+.marker--category {
+  width: 26px;
+  height: 49px;
+  margin-top: 6px;
+  background-image: url('../images/map/pin-maxi.svg');
 }


### PR DESCRIPTION
## Description
Uses this development branch of map-style-builder: https://github.com/QwantResearch/map-style-builder/pull/27
It generates new sprites including new pin-shaped icons:
![sprite](https://user-images.githubusercontent.com/243653/95879250-6ebb4200-0d76-11eb-9d22-27f9bced1125.png)

Also adds a standalone SVG pin for hovered/selected states.

## Why
Distinct design between filtered POI results (typically categories) and map layer POIs.

## Screenshots
![Capture d’écran de 2020-10-13 16-59-36](https://user-images.githubusercontent.com/243653/95878463-87772800-0d75-11eb-99c0-0e3962e1e6ee.png)
