### PR TITLE
Qmaps 1782 direction panel update size

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -77,13 +77,14 @@ class Panel extends React.Component {
     this.updateMobileMapUI();
   }
 
-  componentDidUpdate(_, prevState) {
+  componentDidUpdate(prevProps, prevState) {
     const { fitContent, size } = this.props;
     const { holding } = this.state;
     this.updateMobileMapUI();
 
     if (fitContent && !holding && size !== 'maximized' ||
-        this.state.height !== prevState.height) {
+        this.state.height !== prevState.height ||
+        this.props.size !== prevProps.size) {
       // Resize panel according to content height
       const translateY = this.getTranslateY(size);
       if (translateY !== this.state.translateY) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -17,6 +17,7 @@ import * as address from '../../libs/address';
 import { CloseButton, Flex } from '../../components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
+import { PanelContext } from 'src/libs/panelContext.js';
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {
@@ -209,6 +210,7 @@ export default class DirectionPanel extends React.Component {
   update() {
     this.updateUrl();
     this.computeRoutes();
+    this.context.setSize('default');
   }
 
   onSelectVehicle = vehicle => {
@@ -340,3 +342,5 @@ export default class DirectionPanel extends React.Component {
     </DeviceContext.Consumer>;
   }
 }
+
+DirectionPanel.contextType = PanelContext;


### PR DESCRIPTION
## Description
- Resize panel on props.size updates
- When updating direction panel content, update size using PanelContext.

## Why
Usability

## Screenshots
![Peek 2020-10-13 17-59](https://user-images.githubusercontent.com/2981774/95885943-33247600-0d7e-11eb-91e5-5684718c4cf8.gif)

