### PR TITLE
Qmaps 1788 direction panel fitcontent

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -192,11 +192,11 @@ class Panel extends React.Component {
     const panelHeight = this.panelContentRef.current.offsetHeight;
     const values = {
       'default': height -
-        (fitContent.includes('default') &&
+        (fitContent.indexOf('default') >= 0 &&
         (panelHeight + FIT_CONTENT_PADDING <= DEFAULT_SIZE)
           ? panelHeight + FIT_CONTENT_PADDING
           : DEFAULT_SIZE),
-      'minimized': height - (fitContent.includes('minimized')
+      'minimized': height - (fitContent.indexOf('minimized') >= 0
         ? panelHeight + FIT_CONTENT_PADDING
         : DEFAULT_MINIMIZED_SIZE),
       'maximized': 0,

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -52,6 +52,7 @@ class Panel extends React.Component {
   }
 
   static defaultProps = {
+    fitContent: [],
     size: 'default',
     marginTop: 64, // default top bar size,
   }

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -44,7 +44,7 @@ class Panel extends React.Component {
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
     minimizedTitle: PropTypes.node,
     resizable: PropTypes.bool,
-    fitContent: PropTypes.bool,
+    fitContent: PropTypes.arrayOf(PropTypes.oneOf(['default', 'minimized'])),
     size: PropTypes.string,
     setSize: PropTypes.func,
     marginTop: PropTypes.number,
@@ -191,10 +191,12 @@ class Panel extends React.Component {
     const { height } = this.state;
     const panelHeight = this.panelContentRef.current.offsetHeight;
     const values = {
-      'default': height - (fitContent
-        ? panelHeight + FIT_CONTENT_PADDING
-        : DEFAULT_SIZE),
-      'minimized': height - (fitContent
+      'default': height -
+        (fitContent.includes('default') &&
+        (panelHeight + FIT_CONTENT_PADDING <= DEFAULT_SIZE)
+          ? panelHeight + FIT_CONTENT_PADDING
+          : DEFAULT_SIZE),
+      'minimized': height - (fitContent.includes('minimized')
         ? panelHeight + FIT_CONTENT_PADDING
         : DEFAULT_MINIMIZED_SIZE),
       'maximized': 0,

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -325,7 +325,7 @@ export default class DirectionPanel extends React.Component {
             />}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel resizable marginTop={160} >
+            <Panel resizable marginTop={160} fitContent={['default']}>
               {result}
             </Panel>}
           {activePreviewRoute &&

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -241,7 +241,7 @@ export default class PoiPanel extends React.Component {
       {isMobile =>
         <Panel
           resizable
-          fitContent
+          fitContent={['default', 'minimized']}
           className={classnames('poi_panel', {
             'poi_panel--empty-header':
             !isFromPagesJaunes(poi) &&


### PR DESCRIPTION
## Description
- Panel now accept an array of strings (`default`, 'minimized`) for `fitContent` prop. This way, we can keep the existing behavior for PoiPanel, which need to be fitted in default and minimized states, meanwhile direction's results should be fitted only in default size.
Please note fitContent will have no effect if the content's size is higher than the DEFAULT_SIZE.
- Use Panel's `fitContent` prop in DirectionPanel.

## Why
Avoid useless space in panel when only one result in direction panel is displayed

## Screenshots
### One result:
![image](https://user-images.githubusercontent.com/2981774/95977498-3fa9dc80-0e19-11eb-8282-d4b52cee5c91.png)

### multiple results
Defaut size is used as the content overflows DEFAULT_SIZE constant. Should we tweak the default size in this case ? Please note this is the current behavior.
![image](https://user-images.githubusercontent.com/2981774/95978277-3bca8a00-0e1a-11eb-91c4-0b918e844cb7.png)

