### PR TITLE
Move minimizedTitle in content instead of drawer

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -276,11 +276,14 @@ class Panel extends React.Component {
                 onClick={() => this.handleHeaderClick()}
               >
                 <div className="panel-handle"/>
-                {size === 'minimized' && minimizedTitle
-                && <span className="minimizedTitle u-text--subtitle">{minimizedTitle}</span>}
               </div>
             }
             {size !== 'minimized' && <div className="panel-header">{renderHeader}</div>}
+            {size === 'minimized' && minimizedTitle &&
+              <div className="minimizedTitle u-text--subtitle u-center">
+                {minimizedTitle}
+              </div>
+            }
             <div
               className="panel-content"
               ref={this.panelContentRef}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -80,12 +80,6 @@ $bottom-margin: 40px;
       }
     }
 
-    &.minimized {
-      .panel-drawer {
-        min-height: 50px;
-      }
-    }
-
     .panel-drawer {
       flex-shrink: 0;
     }
@@ -96,6 +90,10 @@ $bottom-margin: 40px;
       margin: 4px auto;
       border-radius: 2.5px;
       background-color: #e0e1e6;
+    }
+
+    .minimizedTitle {
+      height: 30px;
     }
   }
 }


### PR DESCRIPTION
## Description
- Move minimizedTitle from drawer to content instead

## Screenshots
*For PRs with visual impacts. It's sometimes useful to provide before/after images.*
![image](https://user-images.githubusercontent.com/2981774/96122139-59b6ee00-0ef1-11eb-8cfa-79c01aa17d0a.png)
