### PR TITLE
QMAPS-avoid-icons-offset avoid icon offset on direction panel on screens < 340px

### DIFF
--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -141,7 +141,7 @@
     }
 
     input {
-      width: 100%;
+      width: calc(100% - 45px);
       height: 40px;
       border: none;
       color: $primary_text;


### PR DESCRIPTION
## Description
avoid icon offset on direction panel on screens < 340px
