### PR TITLE
Don't focus search field when pressing the Ctrl key

### DIFF
--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -75,7 +75,7 @@ export default class SearchInput {
       }
       // KeyboardEvent.key is either the printed character representation or a standard value for specials keys
       // See https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values
-      if (e.key.length === 1) {
+      if (e.key.length === 1 && !e.ctrlKey) {
         if (document.activeElement
           && document.activeElement.tagName !== 'INPUT'
           && window.__searchInput.isEnabled) {


### PR DESCRIPTION
## Description
Don't focus the search field on key strokes when they use the [Ctrl] key modifier.
Re-enable some browser/system features that were broken, like Ctrl+C for copying some text from the app.

## Why
A user filed an issue about that: https://github.com/QwantResearch/qwantmaps/issues/130
We improved this focus-on-character logic in https://github.com/QwantResearch/erdapfel/pull/748, but should have kept the condition on Ctrl.
