### PR TITLE
MobileRouteDetails: prevent onTouchStart bubbling

### DIFF
--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -21,6 +21,7 @@ const MobileRouteDetails =
   });
 
   return <div
+    onTouchStart={e => e.stopPropagation()}
     ref={panelElement}
     className={classnames('itinerary_legDetails', {
       ['itinerary_legDetails__scrolled']: scrolledDown,


### PR DESCRIPTION
## Description
We discovered a bug where the panel behind the `MobileRouteDetails` component would receive onTouchStart event.
This is due to the nature of React portals : https://reactjs.org/docs/portals.html#event-bubbling-through-portals

This fixes just prevent the bubbling to happen on `onTouchStart`.