### PR TITLE
Qmaps 1791 fix step by step

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -328,8 +328,10 @@ export default class DirectionPanel extends React.Component {
             <Panel resizable marginTop={160} fitContent={['default']}>
               {result}
             </Panel>}
-          {activePreviewRoute &&
-            <MobileRoadMapPreview steps={getAllSteps(activePreviewRoute)} />}
+          {activePreviewRoute && <MobileRoadMapPreview
+            steps={getAllSteps(activePreviewRoute)}
+            onClose={this.onClose}
+          />}
         </Fragment>
         : <Panel
           className="direction-panel"

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -310,7 +310,7 @@ export default class DirectionPanel extends React.Component {
     return <DeviceContext.Consumer>
       {isMobile => isMobile
         ? <Fragment>
-          <div className="direction-panel">
+          {!activePreviewRoute && <div className="direction-panel">
             <Flex
               className="direction-panel-header"
               alignItems="center"
@@ -318,12 +318,12 @@ export default class DirectionPanel extends React.Component {
               {title}
               <CloseButton onClick={this.onClose} />
             </Flex>
-            {!activePreviewRoute && form}
+            {form}
             {<div
               id="direction-autocomplete_suggestions"
               className="direction-autocomplete_suggestions"
             />}
-          </div>
+          </div>}
           {!activePreviewRoute && origin && destination &&
             <Panel resizable marginTop={160} fitContent={['default']}>
               {result}

--- a/src/panel/direction/MobileRoadMapPreview.jsx
+++ b/src/panel/direction/MobileRoadMapPreview.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RoadMapStep from './RoadMapStep';
 import { fire } from 'src/libs/customEvents';
+import { CloseButton } from 'src/components/ui';
 
 export default class MobileRoadMapPreview extends React.Component {
   static propTypes = {
     steps: PropTypes.array.isRequired,
+    onClose: PropTypes.func.isRequired,
   }
 
   state = {
@@ -40,6 +42,7 @@ export default class MobileRoadMapPreview extends React.Component {
 
     return <React.Fragment>
       <div className="itinerary_mobile_step">
+        <CloseButton onClick={this.props.onClose} />
         <RoadMapStep step={currentStep} />
       </div>
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -477,14 +477,13 @@ button.direction_shortcut {
 
   .itinerary_mobile_step {
     position: fixed;
-    top: 36px;
+    top: 12px;
+    left: 12px;
+    right: 12px;
     background: $background;
-    margin: 0 15px;
     border-radius: 3px;
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.16);
-    width: calc(100% - 30px);
     user-select: none;
-    z-index: 3;
 
     .itinerary_roadmap_item {
       border-left: 0;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -485,6 +485,12 @@ button.direction_shortcut {
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.16);
     user-select: none;
 
+    .closeButton {
+      position: absolute;
+      top: 0;
+      right: 0;
+    }
+
     .itinerary_roadmap_item {
       border-left: 0;
       padding: 12px;


### PR DESCRIPTION
## Description
"Quick fix" of the step-by-step mode design.
Remove the direction form element remaining behind, normalize margins and add a close button.

## Why
Just make things appear not broken, until the real redesign is prioritized.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-10-16 à 10 54 52](https://user-images.githubusercontent.com/243653/96237821-0babf400-0f9e-11eb-93d9-328ede9e1bb5.png)|![Capture d’écran 2020-10-16 à 10 54 23](https://user-images.githubusercontent.com/243653/96237838-1070a800-0f9e-11eb-9e1c-3e41ce6c094d.png)|
