### PR TITLE
Ensure history state is not null when popped

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -30,7 +30,7 @@ export default class App {
     this.router = new Router(window.baseUrl);
 
     window.onpopstate = ({ state }) => {
-      this.router.routeUrl(getCurrentUrl(), state);
+      this.router.routeUrl(getCurrentUrl(), state || {});
     };
 
     const directionShortcut = document.querySelector('.search_form__direction_shortcut');


### PR DESCRIPTION
## Description
Fix the severe bug of the panel manager crashing when navigating back.
The reason is the `state` object of the popstate event is `null` (see ref https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event) when the history entry carries no state at all, which is the case when the site is loaded in its default view.
This `null` value gets carried by our router as our `options` object for routes, which caused an error when deserializing. And as it's `null` and not `undefined`, the default param syntax `function doStuff(foo = 'bar') { … }` won't help.
So we make sure the value is always at least an empty object in the main popstate listener.
