### PR TITLE
Qmaps 1775 fix suggest overlap route results

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -59,7 +59,6 @@ class Panel extends React.Component {
 
   constructor(props) {
     super(props);
-    const { marginTop } = this.props;
 
     this.startClientY = 0; // Y coordinate where finger started to touch panel
     this.startClientYOffset = 0; // offset between finger and top of panel
@@ -68,8 +67,8 @@ class Panel extends React.Component {
     this.panelContentRef = React.createRef();
     this.state = {
       holding: false,
-      height: window.innerHeight - marginTop,
-      translateY: window.innerHeight - marginTop - DEFAULT_SIZE,
+      height: this.getHeight(),
+      translateY: this.getInitialTranslateY(),
     };
   }
 
@@ -79,7 +78,7 @@ class Panel extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { fitContent, size } = this.props;
+    const { fitContent, size, marginTop } = this.props;
     const { holding } = this.state;
     this.updateMobileMapUI();
 
@@ -92,6 +91,13 @@ class Panel extends React.Component {
         this.setState({ translateY });
       }
     }
+
+    if (marginTop !== prevProps.marginTop) {
+      this.setState({
+        height: this.getHeight(),
+        translateY: this.getInitialTranslateY(),
+      });
+    }
   }
 
   componentWillUnmount() {
@@ -101,7 +107,7 @@ class Panel extends React.Component {
   }
 
   handleViewportResize = () => {
-    this.setState({ height: window.innerHeight - this.props.marginTop });
+    this.setState({ height: this.getHeight() });
   }
 
   updateMobileMapUI = ({ closing } = {}) => {
@@ -126,6 +132,14 @@ class Panel extends React.Component {
         fire('mobile_direction_button_visibility', false);
       }
     }
+  }
+
+  getHeight() {
+    return window.innerHeight - this.props.marginTop;
+  }
+
+  getInitialTranslateY() {
+    return window.innerHeight - this.props.marginTop - DEFAULT_SIZE;
   }
 
   removeListeners() {
@@ -219,7 +233,7 @@ class Panel extends React.Component {
       this.props.size,
       this.startHeight,
       this.stopHeight,
-      window.innerHeight - this.props.marginTop,
+      this.getHeight(),
     );
 
     if (newSize !== this.props.size) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -329,8 +329,8 @@ export default class DirectionPanel extends React.Component {
           {!activePreviewRoute && origin && destination &&
             <Panel
               resizable
-              fitContent={['default']} 
-              marginTop={this.mobileFormRef.current.offsetHeight}
+              fitContent={['default']}
+              marginTop={this.mobileFormRef.current?.offsetHeight}
             >
               {result}
             </Panel>}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -41,6 +41,8 @@ export default class DirectionPanel extends React.Component {
 
     this.lastQueryId = 0;
 
+    this.mobileFormRef = React.createRef();
+
     this.state = {
       vehicle: activeVehicle,
       origin: null,
@@ -310,7 +312,7 @@ export default class DirectionPanel extends React.Component {
     return <DeviceContext.Consumer>
       {isMobile => isMobile
         ? <Fragment>
-          <div className="direction-panel">
+          <div className="direction-panel" ref={this.mobileFormRef}>
             <Flex
               className="direction-panel-header"
               alignItems="center"
@@ -325,7 +327,11 @@ export default class DirectionPanel extends React.Component {
             />}
           </div>
           {!activePreviewRoute && origin && destination &&
-            <Panel resizable marginTop={160} fitContent={['default']}>
+            <Panel
+              resizable
+              fitContent={['default']} 
+              marginTop={this.mobileFormRef.current.offsetHeight}
+            >
               {result}
             </Panel>}
           {activePreviewRoute &&

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -40,8 +40,7 @@ export default class DirectionPanel extends React.Component {
       ? props.mode : modes.DRIVING;
 
     this.lastQueryId = 0;
-
-    this.mobileFormRef = React.createRef();
+    this.marginTop = 0;
 
     this.state = {
       vehicle: activeVehicle,
@@ -274,6 +273,11 @@ export default class DirectionPanel extends React.Component {
     this.setState({ activePreviewRoute: route });
   }
 
+  setMarginTop = el => {
+    this.marginTop = el ? el.offsetHeight : 0;
+    this.forceUpdate();
+  }
+
   render() {
     const {
       origin, destination, vehicle,
@@ -312,7 +316,7 @@ export default class DirectionPanel extends React.Component {
     return <DeviceContext.Consumer>
       {isMobile => isMobile
         ? <Fragment>
-          <div className="direction-panel" ref={this.mobileFormRef}>
+          <div className="direction-panel" ref={this.setMarginTop}>
             <Flex
               className="direction-panel-header"
               alignItems="center"
@@ -330,7 +334,7 @@ export default class DirectionPanel extends React.Component {
             <Panel
               resizable
               fitContent={['default']}
-              marginTop={this.mobileFormRef.current?.offsetHeight}
+              marginTop={this.marginTop}
             >
               {result}
             </Panel>}

--- a/src/scss/includes/direction-panel.scss
+++ b/src/scss/includes/direction-panel.scss
@@ -9,6 +9,7 @@
     top: 0;
     left: 0;
     padding-top: 20px;
+    z-index: 1;
 
     .direction-close {
       display: flex;


### PR DESCRIPTION
[copy from https://github.com/QwantResearch/erdapfel/pull/838]

## Description
Two fixes on the relationship between the top (form) and bottom (result) parts of the direction mobile UI.
 - ensure the suggest dropdown is displayed above the result panel, instead of below
 - ensure the result panel maximized height is limited by the top part

+ In Panel, handle props.marginTop updates to re-render it