### PR TITLE
Update map-style-builder version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4329,9 +4329,9 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.16.0.tgz",
-      "integrity": "sha512-HtQCLg8NLgnYI0uOSbMNtTcwiCJc9WR5uZekhFaXbyjUWwZVNMW7ElKrDLYkaZ4lvUvbqjotyvZC2Holn/yhpg==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.17.0.tgz",
+      "integrity": "sha512-ZxOdHiuUmDcvQNc1uTnBLVJZxiQVYvoNZaQVxWwl+6Id6tjGQFtieZxXiv/RXIOpQQT35JuioatTKdsjpMsULA==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -4444,11 +4444,12 @@
       "version": "file:local_modules/gettext"
     },
     "@qwant/map-style-builder": {
-      "version": "git+https://github.com/QwantResearch/map-style-builder.git#d02b433c5a722d42229f88d12385f4e92a568c36",
-      "from": "git+https://github.com/QwantResearch/map-style-builder.git#d02b433",
+      "version": "git+https://github.com/QwantResearch/map-style-builder.git#e27cbfb7f195f72c911afa4ab90a586a2cff2996",
+      "from": "git+https://github.com/QwantResearch/map-style-builder.git#e27cbfb",
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.13.1",
         "@mapbox/spritezero": "^6.1.0",
+        "color": "^3.1.2",
         "fs-extra": "^1.0.0",
         "glob": "^7.1.2",
         "mkdirp": "^0.5.1",
@@ -7335,9 +7336,9 @@
       }
     },
     "css-what": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
-      "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
     },
     "csscolorparser": {
       "version": "1.0.3",
@@ -7643,9 +7644,9 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
         }
       }
     },
@@ -7803,9 +7804,9 @@
       }
     },
     "entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "errno": {
       "version": "0.1.7",
@@ -14365,20 +14366,13 @@
       }
     },
     "mapnik": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-4.4.0.tgz",
-      "integrity": "sha512-ENp0c33GPAvoVBp81HdcV9b9XGtMx3oxbnAaL1sh4yIV/ncocevaXKchgGmQsM3kRMf5qgby+TRHmYG7rV/+jg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-4.5.3.tgz",
+      "integrity": "sha512-nVPB/84Z94OWxWiShE1dMQXfZ1f7q83Vdf+ARl4AgzBu8qKxyqibKGERK1kS2sl/DuI/8Ce+1LAP5VwYZPgkDA==",
       "requires": {
         "mapnik-vector-tile": "3.0.1",
-        "nan": "~2.14.0",
+        "node-addon-api": "~3.0.1",
         "node-pre-gyp": "~0.13.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-        }
       }
     },
     "mapnik-vector-tile": {
@@ -14906,9 +14900,9 @@
       }
     },
     "needle": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
-      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -15005,6 +14999,11 @@
         "qs": "^6.5.1",
         "semver": "^5.5.0"
       }
+    },
+    "node-addon-api": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
+      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
     },
     "node-forge": {
       "version": "0.9.0",
@@ -18552,9 +18551,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
+      "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==",
       "optional": true
     },
     "unassert": {
@@ -18992,9 +18991,9 @@
       },
       "dependencies": {
         "underscore": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+          "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.8.0",
     "@qwant/gettext": "file:local_modules/gettext",
-    "@qwant/map-style-builder": "git+https://github.com/QwantResearch/map-style-builder.git#d02b433",
+    "@qwant/map-style-builder": "git+https://github.com/QwantResearch/map-style-builder.git#e27cbfb",
     "@qwant/mapbox_style_configure": "file:local_modules/mapbox_style_configure",
     "@qwant/merge-po": "file:local_modules/merge-po",
     "@qwant/nconf-builder": "file:local_modules/nconf_builder",


### PR DESCRIPTION
## Description
Update the [map-style-builder](https://github.com/QwantResearch/map-style-builder) dependency to use the latest version, including build improvements, reduced sprite size and support for new pin-shaped icons.
Doesn't activate pin-shaped icons for now, will be done in the [dedicated PR](https://github.com/QwantResearch/erdapfel/pull/840). 

