### PR TITLE
Mobile route details: use relative url for icon image

### DIFF
--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -36,7 +36,7 @@ const MobileRouteDetails =
             style={{ width: '100%' }}
           >
             <Flex alignItems="center" justifyContent="center">
-              <img className="u-mr-4" src="/statics/images/direction_icons/guide.svg" />
+              <img className="u-mr-4" src="./statics/images/direction_icons/guide.svg" />
               <span className="u-firstCap">{_('step by step', 'direction')}</span>
             </Flex>
           </Button>


### PR DESCRIPTION
## Why
In #852 a new `guide.svg` icon was used without relative path. Using a relative URL is such cases, to be compatible with the base URL used by the application (i.e when Erdapfel is deployed with a `/maps` path prefix.)

