### PR TITLE
mobile: Overflow only in itinerary_roadmap

### DIFF
--- a/src/scss/includes/mobileRouteDetails.scss
+++ b/src/scss/includes/mobileRouteDetails.scss
@@ -4,13 +4,14 @@
 }
 
 .mobile-route-details {
+  display: flex;
+  flex-direction: column;
   background-color: white;
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100vh;
-  overflow: auto;
   z-index: 3;
   animation: fullscreenLegDetails 0.3s forwards;
 
@@ -56,5 +57,10 @@
       height: 18px;
       margin-right: 9px;
     }
+  }
+
+  .itinerary_roadmap {
+    height: 100%;
+    overflow: auto;
   }
 }


### PR DESCRIPTION
## Description
It was possible to initiate a scroll from the header on mobile.
The scrolling area was including the header.
This fix set the scroll area to only be inside the roadmap.

![image](https://user-images.githubusercontent.com/2981774/96456329-a581d400-121e-11eb-98ae-8ed21c0a381b.png)

