### PR TITLE
Don't focus the search when the MacOS Cmd 'key' is used

### DIFF
--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -75,7 +75,7 @@ export default class SearchInput {
       }
       // KeyboardEvent.key is either the printed character representation or a standard value for specials keys
       // See https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values
-      if (e.key.length === 1 && !e.ctrlKey) {
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
         if (document.activeElement
           && document.activeElement.tagName !== 'INPUT'
           && window.__searchInput.isEnabled) {


### PR DESCRIPTION
## Description
Same thing as https://github.com/QwantResearch/erdapfel/pull/846 but for the Mac OS "Cmd" key, which is mapped on the `metaKey` key event property.

## Why
Don't disturb native OS functions.