### PR TITLE
Fix 'back' button not clickable in direction input on some mobiles

### DIFF
--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -118,9 +118,10 @@ class DirectionInput extends React.Component {
           </div>
           <div className="icon-x direction-field-clear" onMouseDown={this.clear} />
         </div>
-        <div className="direction-field-return">
+        <button type="button" className="direction-field-return">
+          {/* The only purpose of this button is to unfocus the input */}
           <span className="icon-arrow-left"/>
-        </div>
+        </button>
         {mounted &&
             <Suggest
               inputNode={inputRef.current}


### PR DESCRIPTION
## Description
Use an explicit `<button>` element instead of a `<div>` that was not clickable on some mobiles (iOS or Firefox on Android).
This button has no proper action, except unfocusing the input.

