### PR TITLE
Qmaps 1795 route summary info

### DIFF
--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -1,10 +1,10 @@
 /* global _ */
 import React, { useRef } from 'react';
-import RouteVia from './RouteVia';
 import RoadMap from './RoadMap';
-import { Badge, Button, CloseButton, Divider, Flex } from 'src/components/ui';
-import { formatDuration, formatDistance } from 'src/libs/route_utils';
+import { Button, Divider, Flex } from 'src/components/ui';
 import classnames from 'classnames';
+
+import RouteSummaryInfo from './RouteSummaryInfo';
 
 const MobileRouteDetails =
 ({ id, route, origin, destination, vehicle, toggleDetails, openPreview }) => {
@@ -18,22 +18,18 @@ const MobileRouteDetails =
   >
     <div className="mobile-route-details-header">
       <div className="mobile-route-details-header-content">
-        <Flex alignItems="center" justifyContent="space-between" className="u-text--title">
-          {formatDuration(route.duration)}
-          <CloseButton onClick={() => { toggleDetails(id); }} />
-        </Flex>
-
-        <RouteVia className="u-mb-8" route={route} vehicle={vehicle} />
-        <Badge className={isPublicTransport ? 'u-mb-20' : ''}>
-          {formatDistance(route.distance)}
-        </Badge>
+        <RouteSummaryInfo
+          route={route}
+          vehicle={vehicle}
+          onClose={() => toggleDetails(id)}
+        />
 
         {isPublicTransport &&
           <Button
             className="u-firstCap"
             onClick={() => { openPreview(id); }}
             variant="primary"
-            style={{ width: '100%' }}
+            style={{ width: '100%', marginTop: 20 }}
           >
             <Flex alignItems="center" justifyContent="center">
               <img className="u-mr-4" src="./statics/images/direction_icons/guide.svg" />

--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -23,7 +23,7 @@ const MobileRouteDetails =
             route={route}
             vehicle={vehicle}
           />
-          <CloseButton onClick={() => toggleDetails(id)} />
+          <CloseButton position="topRight" onClick={() => toggleDetails(id)} />
         </Flex>
 
         {isPublicTransport &&

--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -1,7 +1,7 @@
 /* global _ */
 import React, { useRef } from 'react';
 import RoadMap from './RoadMap';
-import { Button, Divider, Flex } from 'src/components/ui';
+import { Button, CloseButton, Divider, Flex } from 'src/components/ui';
 import classnames from 'classnames';
 
 import RouteSummaryInfo from './RouteSummaryInfo';
@@ -18,11 +18,13 @@ const MobileRouteDetails =
   >
     <div className="mobile-route-details-header">
       <div className="mobile-route-details-header-content">
-        <RouteSummaryInfo
-          route={route}
-          vehicle={vehicle}
-          onClose={() => toggleDetails(id)}
-        />
+        <Flex alignItems="flex-start" justifyContent="space-between">
+          <RouteSummaryInfo
+            route={route}
+            vehicle={vehicle}
+          />
+          <CloseButton onClick={() => toggleDetails(id)} />
+        </Flex>
 
         {isPublicTransport &&
           <Button

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -108,9 +108,9 @@ export default class RouteResult extends React.Component {
                   </div>
                   <PlaceholderText length={10} className="itinerary_leg_via_details"/>
                 </div>
-                <div className="itinerary_leg_info">
-                  <PlaceholderText length={5} className="itinerary_leg_duration" />
-                  <PlaceholderText length={7} className="itinerary_leg_distance" />
+                <div>
+                  <PlaceholderText length={5} />
+                  <PlaceholderText length={7} />
                 </div>
               </div>
             </div>

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -1,12 +1,12 @@
 /* global _ */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { formatDuration, formatDistance, getVehicleIcon } from 'src/libs/route_utils';
-import RouteVia from './RouteVia';
-import Button from 'src/components/ui/Button';
+import { getVehicleIcon } from 'src/libs/route_utils';
+import { Button, Flex } from 'src/components/ui';
 import ShareMenu from 'src/components/ui/ShareMenu';
 import Telemetry from 'src/libs/telemetry';
 
+import RouteSummaryInfo from './RouteSummaryInfo';
 
 export default class RouteSummary extends React.Component {
   static propTypes = {
@@ -40,22 +40,20 @@ export default class RouteSummary extends React.Component {
     const { route, vehicle } = this.props;
 
     return <div className="itinerary_leg_summary" onClick={this.onClick}>
-      <div className={`itinerary_leg_icon ${getVehicleIcon(vehicle)}`} />
-      <div className="itinerary_leg_via">
-        <RouteVia route={route} vehicle={vehicle} />
-        <div className="itinerary_leg_via_details" onClick={this.onClickDetails}>
-          <i className="itinerary_leg_via_details_icon" />
-          {_('Details', 'direction')}
-        </div>
+
+      <Flex>
+        <div className={`itinerary_leg_icon ${getVehicleIcon(vehicle)}`} />
+        <RouteSummaryInfo
+          route={route}
+          vehicle={vehicle}
+        />
+      </Flex>
+
+      <div className="itinerary_leg_via_details" onClick={this.onClickDetails}>
+        <i className="itinerary_leg_via_details_icon" />
+        {_('Details', 'direction')}
       </div>
-      <div className="itinerary_leg_info">
-        <div className="itinerary_leg_duration">
-          {formatDuration(route.duration)}
-        </div>
-        <div className="itinerary_leg_distance">
-          {formatDistance(route.distance)}
-        </div>
-      </div>
+
       <ShareMenu url={window.location.toString()} scrollableParent=".panel-content">
         {openMenu => <div
           className="itinerary_panel__item__share"
@@ -65,6 +63,7 @@ export default class RouteSummary extends React.Component {
           <i className="icon-share-2" />
         </div>}
       </ShareMenu>
+
       <div className="itinerary_leg_mobileActions">
         <Button className="itinerary_leg_detailsBtn" onClick={this.onClickDetails} icon="icon_list">
           {_('Details', 'direction')}

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -49,20 +49,22 @@ export default class RouteSummary extends React.Component {
         />
       </Flex>
 
-      <div className="itinerary_leg_via_details" onClick={this.onClickDetails}>
-        <i className="itinerary_leg_via_details_icon" />
-        {_('Details', 'direction')}
-      </div>
+      <Flex>
+        <div className="itinerary_leg_via_details" onClick={this.onClickDetails}>
+          <i className="itinerary_leg_via_details_icon" />
+          {_('Details', 'direction')}
+        </div>
 
-      <ShareMenu url={window.location.toString()} scrollableParent=".panel-content">
-        {openMenu => <div
-          className="itinerary_panel__item__share"
-          title={_('Share', 'direction')}
-          onClick={e => this.onShareClick(e, openMenu)}
-        >
-          <i className="icon-share-2" />
-        </div>}
-      </ShareMenu>
+        <ShareMenu url={window.location.toString()} scrollableParent=".panel-content">
+          {openMenu => <div
+            className="itinerary_panel__item__share"
+            title={_('Share', 'direction')}
+            onClick={e => this.onShareClick(e, openMenu)}
+          >
+            <i className="icon-share-2" />
+          </div>}
+        </ShareMenu>
+      </Flex>
 
       <div className="itinerary_leg_mobileActions">
         <Button className="itinerary_leg_detailsBtn" onClick={this.onClickDetails} icon="icon_list">

--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import RouteVia from './RouteVia';
-import { Badge, Flex } from 'src/components/ui';
+import { Badge } from 'src/components/ui';
 import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
 const RouteSummaryInfo = ({ route, vehicle }) =>
   <div>
-    <Flex alignItems="center" justifyContent="space-between" className="u-text--title">
+    <div className="u-text--title">
       {formatDuration(route.duration)}
-    </Flex>
+    </div>
 
     <RouteVia className="u-mb-8" route={route} vehicle={vehicle} />
     <Badge>

--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 
 import RouteVia from './RouteVia';
-import { Badge, CloseButton, Flex } from 'src/components/ui';
+import { Badge, Flex } from 'src/components/ui';
 import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
-const RouteSummaryInfo = ({ route, vehicle, onClose }) =>
+const RouteSummaryInfo = ({ route, vehicle }) =>
   <div>
     <Flex alignItems="center" justifyContent="space-between" className="u-text--title">
       {formatDuration(route.duration)}
-      {onClose && <CloseButton onClick={onClose} />}
     </Flex>
 
     <RouteVia className="u-mb-8" route={route} vehicle={vehicle} />

--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import RouteVia from './RouteVia';
+import { Badge, CloseButton, Flex } from 'src/components/ui';
+import { formatDuration, formatDistance } from 'src/libs/route_utils';
+
+const RouteSummaryInfo = ({ route, vehicle, onClose }) =>
+  <div>
+    <Flex alignItems="center" justifyContent="space-between" className="u-text--title">
+      {formatDuration(route.duration)}
+      {onClose && <CloseButton onClick={onClose} />}
+    </Flex>
+
+    <RouteVia className="u-mb-8" route={route} vehicle={vehicle} />
+    <Badge>
+      {formatDistance(route.distance)}
+    </Badge>
+  </div>
+;
+
+export default RouteSummaryInfo;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -105,6 +105,7 @@
   font-size: 12px;
   font-weight: bold;
   text-transform: uppercase;
+  margin-right: 8px;
 }
 
 .itinerary_leg_via_details:hover {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -74,6 +74,8 @@
 .itinerary_leg_summary {
   border-left: 4px solid $background;
   display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding: 20px;
   align-items: center;
   cursor: pointer;
@@ -89,7 +91,7 @@
 }
 
 .itinerary_leg_via {
-  align-self: flex-start;
+  align-self: flex-end;
   flex-grow: 1;
   margin-right: 9px;
   color: $primary_text;
@@ -102,7 +104,6 @@
 .itinerary_leg_via_details {
   font-size: 12px;
   font-weight: bold;
-  margin: 10px 0 0;
   text-transform: uppercase;
 }
 
@@ -123,24 +124,6 @@
 
 .itinerary_leg_via_details_icon.open {
   transform: rotate(90deg);
-}
-
-.itinerary_leg_info {
-  text-align: right;
-  align-self: flex-start;
-  margin-right: 15px;
-  font-size: 16px;
-}
-
-.itinerary_leg_duration {
-  font-weight: bold;
-  color: #ff3b4a;
-  margin-bottom: 6px;
-  white-space: nowrap;
-}
-
-.itinerary_leg_distance {
-  color: $primary_text;
 }
 
 .itinerary_leg_mobileActions {
@@ -417,19 +400,8 @@ button.direction_shortcut {
     display: none;
   }
 
-  .itinerary_leg_info {
-    text-align: left;
-    grid-area: info;
-  }
-
   .itinerary_leg_via {
     grid-area: via;
-  }
-
-  .itinerary_leg_duration,
-  .itinerary_leg_distance {
-    display: inline-block;
-    margin-right: 6px;
   }
 
   .itinerary_leg_mobileActions {


### PR DESCRIPTION
## Description
Define and reuse a `RouteComponentInfo` component on mobile and desktop. It renders route info like distance, duration, and "via" name.
- in `RouteResult` (desktop and mobile)
- in `MobileRouteDetails`
- Part of the new design on route summaries

## Why
New design

## Screenshots
*For PRs with visual impacts. It's sometimes useful to provide before/after images.*
![desktop](https://user-images.githubusercontent.com/2981774/96571282-a290ed00-12cb-11eb-87ae-a6b8cbba7942.png)
![mobile](https://user-images.githubusercontent.com/2981774/96570173-51ccc480-12ca-11eb-9d86-eef8c87b73c0.png)
![mobile route details](https://user-images.githubusercontent.com/2981774/96570220-5ee9b380-12ca-11eb-9e2e-0d2916723ebf.png)


