### PR TITLE
RouteSummary: Update hover/active style

### DIFF
--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -6,7 +6,7 @@ import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
 const RouteSummaryInfo = ({ route, vehicle }) =>
   <div>
-    <div className="u-text--title">
+    <div className="u-text--title route-summary-info-duration">
       {formatDuration(route.duration)}
     </div>
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -92,7 +92,6 @@
 }
 
 .itinerary_leg_summary {
-  border-left: 4px solid $background;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -3,6 +3,17 @@
 @import "./direction-field.scss";
 @import "./mobileRouteDetails.scss";
 
+@mixin active-border-gradient {
+  content: '';
+  position: absolute;
+  top: 12px;
+  left: 0;
+  width: 4px;
+  height: calc(100% - 24px);
+  border-radius: 0 4px 4px 0;
+  background-image: $active-gradient-vertical;
+}
+
 @mixin icon_origin {
   width: 16px;
   height: 16px;
@@ -65,9 +76,18 @@
 .itinerary_leg {
   position: relative;
 
-  &--active .itinerary_leg_summary,
   &:hover .itinerary_leg_summary {
-    border-left: 4px solid #ff3b4a;
+    background-color: $grey-bright;
+  }
+
+  &--active .itinerary_leg_summary {
+    &:before {
+      @include active-border-gradient;
+    }
+
+    .route-summary-info-duration {
+      color: $action-blue-base;
+    }
   }
 }
 
@@ -185,14 +205,7 @@
     position: relative;
 
     &:before {
-      content: '';
-      position: absolute;
-      top: 12px;
-      left: 0;
-      width: 4px;
-      height: calc(100% - 24px);
-      border-radius: 0 4px 4px 0;
-      background-image: $active-gradient-vertical;
+      @include active-border-gradient;
     }
   }
 }


### PR DESCRIPTION
## Description
- Define a `grey-bright` hover effect on Summaries
- Define and reuse an `active-border-gradient` mixin.

## Screenshots
![Peek 2020-10-20 16-50](https://user-images.githubusercontent.com/2981774/96603560-6e7df200-12f4-11eb-8976-3e5f5d6e3776.gif)
