### PR TITLE
Don't select search input content on focus

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -44,7 +44,6 @@ const Suggest = ({
         setIsOpen(true);
         fetchItems('');
       } else {
-        inputNode.select();
         if (isMobile) {
           setIsOpen(true);
           fetchItems(inputNode.value);


### PR DESCRIPTION
## Description
Don't select the search input content on click focus (it will still be selected on keyboard focus but that's a native feature).

## Why
Don't trigger annoying copy/cut/paste selection tools on mobile OS.