### PR TITLE
DirectionPanel: history.back on close

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -224,7 +224,9 @@ export default class DirectionPanel extends React.Component {
       this.setState({ activePreviewRoute: null });
     } else {
       Telemetry.add(Telemetry.ITINERARY_CLOSE);
-      window.app.navigateTo('/');
+      this.props.poi
+        ? window.history.back() // Go back to the poi panel
+        : window.app.navigateTo('/');
     }
   }
 


### PR DESCRIPTION
Any downside doing this ?

## Description
In DirectionPanel, call `history.back()` when closing.

## Why
New UX:
- If the user comes from a POI, when closing the Direction Panel, the user should return to the poi.
- If the user comes from Home, when closing the Direction Panel, the user should return to the home (current behavior).