### PR TITLE
Add tag on OSM edits (fix #460)

### DIFF
--- a/src/components/OsmContribution.jsx
+++ b/src/components/OsmContribution.jsx
@@ -4,8 +4,9 @@ import Telemetry from 'src/libs/telemetry';
 
 const OsmContribution = ({ poi }) => {
   const [_osmKey, itemKind, itemId] = poi.id.split(':');
+  const editParams = `editor=id&${itemKind}=${itemId}&hashtags=QwantMaps`;
   const viewUrl = `https://www.openstreetmap.org/${itemKind}/${itemId}`;
-  const editUrl = `https://www.openstreetmap.org/edit?editor=id&${itemKind}=${itemId}`;
+  const editUrl = `https://www.openstreetmap.org/edit?${editParams}`;
 
   const sendTelemetryEvent = event => () => Telemetry.sendPoiEvent(poi, event);
 


### PR DESCRIPTION
## Description

Based on an external suggestion (https://github.com/QwantResearch/erdapfel/issues/460), suggest the addition of a tag referring to QwantMaps when modifying a POI on OSM.

When using the link "modify", changing a POI on openstreetmap.org and validating the change, the confirm dialog will look like this:

![Screenshot_2020-10-22_14-00-17](https://user-images.githubusercontent.com/1173464/96869155-63030600-146f-11eb-8387-e1ce7bbc260a.png)


## Why

The main benefits I can see is that it could help with understanding how people are interested in updating POI informations when using https://qwant.com/maps.