### PR TITLE
fix: No input value was set for latlon items without address

### DIFF
--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -44,9 +44,6 @@ export const selectItem = (selectedItem, { query, replaceUrl = false, fromQueryP
 };
 
 export const getInputValue = item => {
-  if (item instanceof Poi) {
-    return item.name;
-  }
   if (item instanceof Category) {
     return item.getInputValue();
   }
@@ -55,6 +52,12 @@ export const getInputValue = item => {
       return item.category.getInputValue();
     }
     return item.fullTextQuery;
+  }
+  if (item.type === 'latlon' && item.address?.street) {
+    return item.address.street;
+  }
+  if (item.name) {
+    return item.name;
   }
   return '';
 };

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -18,6 +18,7 @@ import { CloseButton, Flex } from '../../components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import { PanelContext } from 'src/libs/panelContext.js';
+import { getInputValue } from 'src/libs/suggest';
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {
@@ -92,9 +93,7 @@ export default class DirectionPanel extends React.Component {
     if (poi.type === 'latlon') {
       poi.address = await address.fetch(poi);
     }
-
-    const inputValue = poi.type === 'latlon' ? poi.address.street : poi.name;
-    this.setState({ [which + 'InputText']: inputValue });
+    this.setState({ [which + 'InputText']: getInputValue(poi) });
   }
 
   async restorePoints({ origin: originUrlValue, destination: destinationUrlValue }) {


### PR DESCRIPTION
## Description
Extend and use `getInputValue` from "libs/suggest.js" to standardize the value used in input fields when an item is selected.

## Why
When dragging a direction point (origin or destination) to a latlon position where no address was found, the input field stayed in an empty state.
