### PR TITLE
Direction summaries tweaks

### DIFF
--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Route from './Route';
-import { getVehicleIcon } from 'src/libs/route_utils';
 import classnames from 'classnames';
 import { Item, ItemList } from 'src/components/ui/ItemList';
 import PlaceholderText from 'src/components/ui/PlaceholderText';
@@ -101,7 +100,6 @@ export default class RouteResult extends React.Component {
           <Item>
             <div className="itinerary_leg itinerary_leg--placeholder">
               <div className="itinerary_leg_summary">
-                <div className={`itinerary_leg_icon ${getVehicleIcon(this.props.vehicle)}`} />
                 <div className="itinerary_leg_via">
                   <div className="routeVia">
                     <PlaceholderText length={17} />

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -38,11 +38,12 @@ export default class RouteSummary extends React.Component {
   }
 
   render() {
-    const { route, isActive, showDetails, vehicle } = this.props;
+    const { id, route, isActive, showDetails, vehicle } = this.props;
 
     return <div className="itinerary_leg_summary" onClick={this.onClick}>
 
       <RouteSummaryInfo
+        isFastest={id === 0}
         route={route}
         vehicle={vehicle}
       />

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -1,7 +1,6 @@
 /* global _ */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getVehicleIcon } from 'src/libs/route_utils';
 import { Button, Flex } from 'src/components/ui';
 import ShareMenu from 'src/components/ui/ShareMenu';
 import Telemetry from 'src/libs/telemetry';
@@ -39,17 +38,14 @@ export default class RouteSummary extends React.Component {
   }
 
   render() {
-    const { route, vehicle, isActive, showDetails } = this.props;
+    const { route, isActive, showDetails, vehicle } = this.props;
 
     return <div className="itinerary_leg_summary" onClick={this.onClick}>
 
-      <Flex>
-        <div className={`itinerary_leg_icon ${getVehicleIcon(vehicle)}`} />
-        <RouteSummaryInfo
-          route={route}
-          vehicle={vehicle}
-        />
-      </Flex>
+      <RouteSummaryInfo
+        route={route}
+        vehicle={vehicle}
+      />
 
       {isActive &&
         <Flex className="itinerary_leg_details-buttons">

--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -1,19 +1,23 @@
+/* globals _ */
 import React from 'react';
 
 import RouteVia from './RouteVia';
 import { Badge } from 'src/components/ui';
 import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
-const RouteSummaryInfo = ({ route, vehicle }) =>
+const RouteSummaryInfo = ({ isFastest, route, vehicle }) =>
   <div>
     <div className="u-text--title route-summary-info-duration">
       {formatDuration(route.duration)}
     </div>
 
     <RouteVia className="u-mb-8" route={route} vehicle={vehicle} />
-    <Badge>
+
+    <Badge className="u-mr-8">
       {formatDistance(route.distance)}
     </Badge>
+
+    {isFastest && <span className="u-text--subtitle">{_('Fastest route')}</span>}
   </div>
 ;
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -100,15 +100,6 @@
   cursor: pointer;
 }
 
-.itinerary_leg_icon {
-  width: 20px;
-  height: 20px;
-  margin: 0 18px 0 9px;
-  font-size: 18px;
-  color: $primary_text;
-  flex-shrink: 0;
-}
-
 .itinerary_leg_via {
   align-self: flex-end;
   flex-grow: 1;
@@ -399,11 +390,6 @@ button.direction_shortcut {
 
   .itinerary_leg_details-buttons {
     margin-top: 12px;
-  }
-
-  .itinerary_leg_icon,
-  .itinerary_panel__item__share {
-    display: none;
   }
 
   .itinerary_leg_via {


### PR DESCRIPTION
## Description
- Remove deprecated vehicle icons in route summary.
- Display "fastest route" label on first summary (as results are now ordered)
 ![image](https://user-images.githubusercontent.com/2981774/96899922-caca4880-1491-11eb-8350-19721ced9994.png)
