### PR TITLE
Fixes most double-tap issues on iOS

### DIFF
--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -7,6 +7,7 @@ import { fire, listen } from 'src/libs/customEvents';
 import { poisToGeoJSON, emptyFeatureCollection } from 'src/libs/geojson';
 import { getFilteredPoisStyle } from 'src/adapters/pois_styles';
 import { createMapGLIcon, createIcon } from 'src/adapters/icon_manager';
+import { isMobileDevice } from 'src/libs/device';
 
 const DYNAMIC_POIS_LAYER = 'poi-filtered';
 const mapStyleConfig = nconf.get().mapStyle;
@@ -58,8 +59,10 @@ export default class SceneCategory {
       id: DYNAMIC_POIS_LAYER,
     });
     this.map.on('click', DYNAMIC_POIS_LAYER, this.handleLayerMarkerClick);
-    this.map.on('mousemove', DYNAMIC_POIS_LAYER, this.handleLayerMarkerMouseMove);
-    this.map.on('mouseleave', DYNAMIC_POIS_LAYER, this.handleLayerMarkerMouseLeave);
+    if (!isMobileDevice()) {
+      this.map.on('mousemove', DYNAMIC_POIS_LAYER, this.handleLayerMarkerMouseMove);
+      this.map.on('mouseleave', DYNAMIC_POIS_LAYER, this.handleLayerMarkerMouseLeave);
+    }
   }
 
   getPointedPoi = mapMouseEvent => {

--- a/src/panel/category/PoiItemList.jsx
+++ b/src/panel/category/PoiItemList.jsx
@@ -1,20 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { ItemList, Item } from 'src/components/ui/ItemList';
 import PoiItem from 'src/components/PoiItem';
+import { DeviceContext } from 'src/libs/device';
 
 const PoiItems = ({
   pois,
   selectPoi,
   highlightMarker,
-}) =>
-  <ItemList hover className="category__panel__items">
+}) => {
+  const isMobile = useContext(DeviceContext);
+
+  return <ItemList hover className="category__panel__items">
     {pois.map(poi => <Item key={poi.id}
       onClick={() => { selectPoi(poi); }}
-      onMouseOver={() => { highlightMarker(poi, true); }}
-      onMouseOut={() => { highlightMarker(poi, false); }}
+      onMouseOver={() => { !isMobile && highlightMarker(poi, true); }}
+      onMouseOut={() => { !isMobile && highlightMarker(poi, false); }}
     >
       <PoiItem poi={poi} withOpeningHours withImage inList />
     </Item>)}
   </ItemList>;
+};
 
 export default PoiItems;

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -23,8 +23,8 @@ const Route = ({
 
   return <Fragment>
     <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
-      onMouseEnter={() => { hoverRoute(id, true); }}
-      onMouseLeave={() => { hoverRoute(id, false); }}
+      onMouseEnter={() => { !isMobile && hoverRoute(id, true); }}
+      onMouseLeave={() => { !isMobile && hoverRoute(id, false); }}
     >
       <RouteSummary
         id={id}

--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -56,8 +56,10 @@
     border: 0;
   }
 
-  &:not(.button--primary):not(:disabled):hover {
-    background: $action-blue-lighter;
+  @media (min-width: 641px) {
+    &:not(.button--primary):not(:disabled):hover {
+      background: $action-blue-lighter;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Don't declare mouseover-type actions on mobile, to prevent iOS browsers from assigning them to a first tap on the element, therefore requiring a second tap to trigger the click action…

This solves the most urgent matter but this is not a perfect solution, as this uses the screen size as indicator of the touch capabilities of the device. This means for example the double-tap will still be needed on large tablets, recognized as desktop but with touch-only capabilities.

There are more proper ways to solve that, using media queries like https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover and https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-pointer. Info on them could probably be included in our `DeviceContext`.
I propose to try an implementation based on them after we merge this partial solution.