### PR TITLE
Fix minimized panels appearance

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -352,6 +352,7 @@ export default class DirectionPanel extends React.Component {
               resizable
               fitContent={['default']}
               marginTop={this.marginTop}
+              minimizedTitle={_('Unfold to show the results', 'direction')}
             >
               {result}
             </Panel>}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -94,6 +94,7 @@ $bottom-margin: 40px;
 
     .minimizedTitle {
       height: 30px;
+      flex-shrink: 0;
     }
   }
 }


### PR DESCRIPTION
## Description
Ensure the panel content doesn't appear partially under the title on minimized size for very small screens.
This was again a problem of missing `flex-shrink: 0`, we should get the habit of checking that when we use flex layouts on constrained spaces.

Also assign a minimized title to the route result panel. This may not be the final design, but it won't appear broken until we redo it.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-10-23 à 09 24 47](https://user-images.githubusercontent.com/243653/96969103-3a801800-1512-11eb-878e-c7ac24f9ca2e.png)|![Capture d’écran 2020-10-23 à 09 25 06](https://user-images.githubusercontent.com/243653/96969114-3e139f00-1512-11eb-85d3-88165ba768dc.png)|
|![Capture d’écran 2020-10-23 à 09 25 30](https://user-images.githubusercontent.com/243653/96969138-48359d80-1512-11eb-8a1a-20e226be9869.png)|![Capture d’écran 2020-10-23 à 09 25 20](https://user-images.githubusercontent.com/243653/96969132-44098000-1512-11eb-87ab-2ed833fe28a2.png)|
