### PR TITLE
Show direction title only when needed on mobile

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -330,29 +330,34 @@ export default class DirectionPanel extends React.Component {
       openMobilePreview={this.openMobilePreview}
     />;
 
+    const isFormCompleted = origin && destination;
+    const isResultDisplayed = !activePreviewRoute && isFormCompleted;
+
     return <DeviceContext.Consumer>
       {isMobile => isMobile
         ? <Fragment>
           {!activePreviewRoute && <div className="direction-panel" ref={this.setMarginTop}>
-            <Flex
+            {!isFormCompleted && <Flex
               className="direction-panel-header"
               alignItems="center"
               justifyContent="space-between">
               {title}
               <CloseButton onClick={this.onClose} />
             </Flex>
+            }
             {form}
             {<div
               id="direction-autocomplete_suggestions"
               className="direction-autocomplete_suggestions"
             />}
           </div>}
-          {!activePreviewRoute && origin && destination &&
+          {isResultDisplayed &&
             <Panel
               resizable
               fitContent={['default']}
               marginTop={this.marginTop}
               minimizedTitle={_('Unfold to show the results', 'direction')}
+              onClose={this.onClose}
             >
               {result}
             </Panel>}


### PR DESCRIPTION
## Description
On mobile, in order to maximize useful space, we can hide the title when the panel is opened
