### PR TITLE
Keep map visual paddings updated with panel size

### DIFF
--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -1,4 +1,5 @@
 import { isMobileDevice } from '../libs/device';
+import { listen } from 'src/libs/customEvents';
 
 const DESKTOP_PANEL_WIDTH = 400;
 const ADDITIONAL_PADDING = 50;
@@ -8,21 +9,26 @@ const DESKTOP_SIDE_PANEL = {
   right: 60,
   bottom: 45,
 };
-const MOBILE_CARD = { top: 80, right: 70, bottom: 130, left: 20 };
-const MOBILE_FULL_SCREEN_PANEL = { top: 184, right: 70, bottom: 130, left: 20 };
+
+let mobileBottomPanelHeight = 0;
+listen('move_mobile_bottom_ui', height => {
+  mobileBottomPanelHeight = height;
+});
 
 export function getMapPaddings({ isMobile, isDirectionsActive }) {
   if (!isMobile) {
     return DESKTOP_SIDE_PANEL;
   }
-  if (isDirectionsActive) {
-    const resultPanel = document.querySelector('.directionResult_panel');
-    const bottomPadding = resultPanel
-      ? resultPanel.clientHeight + (ADDITIONAL_PADDING / 2)
-      : MOBILE_FULL_SCREEN_PANEL.bottom;
-    return { ...MOBILE_FULL_SCREEN_PANEL, bottom: bottomPadding };
-  }
-  return MOBILE_CARD;
+  const topUIElement = isDirectionsActive
+    ? '.direction-panel'
+    : '.top_bar';
+  const topUIHeight = document.querySelector(topUIElement)?.clientHeight || 0;
+  return {
+    bottom: mobileBottomPanelHeight + ADDITIONAL_PADDING / 2,
+    top: topUIHeight + ADDITIONAL_PADDING / 2,
+    right: 70,
+    left: 20,
+  };
 }
 
 export function getVisibleBbox(mb) {


### PR DESCRIPTION
## Description
Listen to panel height changes so the function used by the map to get its padding returns values corresponding to the current view, instead of using hardcoded (and obsolete) top/bottom paddings.

## Why
Make sure route result are drawn in the visible area.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 89184_2 27708 destination=latlon_48 79977_2 53944 mode=driving pt=true](https://user-images.githubusercontent.com/243653/96991825-52af6180-1529-11eb-8279-dff7f91c9dd2.png)|![localhost_3000_routes__origin=latlon_48 86484_2 45597 destination=latlon_48 73529_2 53220 mode=driving pt=true](https://user-images.githubusercontent.com/243653/96991842-580cac00-1529-11eb-8074-30e175446166.png)|