### PR TITLE
Fix roadmap scrolling view on mobile

### DIFF
--- a/src/scss/includes/mobileRouteDetails.scss
+++ b/src/scss/includes/mobileRouteDetails.scss
@@ -11,7 +11,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   z-index: 3;
   animation: fullscreenLegDetails 0.3s forwards;
 
@@ -47,7 +47,6 @@
   }
 
   .itinerary_roadmap {
-    height: 100%;
     overflow: auto;
   }
 }


### PR DESCRIPTION
## Description
On Android browsers, the last item of the scrollable roadmap was unreachable.
The reason was the use of `100vh` as height for the container, which ignores the height of the browser address bar.

![localhost_3000_routes__origin=latlon_48 89186_2 27712 destination=latlon_47 99849_1 69436 mode=driving pt=true](https://user-images.githubusercontent.com/243653/97004802-dd01c080-153d-11eb-9aea-49efe8f6a321.png)
