### PR TITLE
Memoize PoiItem, to avoid hiccups on list resize

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -6,7 +6,7 @@ import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
 
-const PoiItem = ({ poi,
+const PoiItem = React.memo(({ poi,
   withOpeningHours,
   withImage,
   withAlternativeName,
@@ -45,6 +45,7 @@ const PoiItem = ({ poi,
       <PoiTitleImage poi={poi} />
     </div>}
   </div>;
-};
+});
+PoiItem.displayName = 'PoiItem';
 
 export default PoiItem;


### PR DESCRIPTION
## Description
Use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) to reduce the number of renders of `PoiItem` used notably in `CategoryPanel`.

## Why
We noticed hiccups on mobile when resizing the `CategoryPanel`, because of expensive re-render of the list.


