### PR TITLE
Restore the layout of public transport roadmaps

### DIFF
--- a/src/panel/direction/RoadMapItem.jsx
+++ b/src/panel/direction/RoadMapItem.jsx
@@ -3,19 +3,22 @@ import classnames from 'classnames';
 
 import { Divider, Flex } from 'src/components/ui';
 
-const RoadMapItem = ({ children, icon, distance, className, ...rest }) =>
-  <div className={classnames('itinerary_roadmap_item', className)} {...rest}>
-    <Flex className="itinerary_roadmap_item-block">
-      <div className={classnames(
-        'itinerary_roadmap_icon',
-        { [`itinerary_roadmap_icon_${icon}`]: icon }
-      )} />
-      <div>
-        <span className="itinerary_roadmap_instruction u-text--smallTitle">{children}</span>
-        <div className="u-text--subtitle">{distance}</div>
-      </div>
-    </Flex>
+const RoadMapItem = ({ children, icon, distance, className, line, ...rest }) =>
+  <>
+    <div className={classnames('itinerary_roadmap_item', className)} {...rest}>
+      {line}
+      <Flex alignItems="flex-start">
+        <div className={classnames(
+          'itinerary_roadmap_icon',
+          { [`itinerary_roadmap_icon_${icon}`]: icon }
+        )} />
+        <div className="itinerary_roadmap_step_description">
+          <span className="itinerary_roadmap_instruction u-text--smallTitle">{children}</span>
+          <div className="u-text--subtitle">{distance}</div>
+        </div>
+      </Flex>
+    </div>
     <Divider paddingTop={0} paddingBottom={0} />
-  </div>;
+  </>;
 
 export default RoadMapItem;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -74,8 +74,6 @@
 }
 
 .itinerary_leg {
-  position: relative;
-
   &:hover .itinerary_leg_summary {
     background-color: $grey-bright;
   }
@@ -98,6 +96,7 @@
   padding: 20px;
   align-items: center;
   cursor: pointer;
+  position: relative;
 }
 
 .itinerary_leg_via {
@@ -174,6 +173,10 @@
 
   .divider {
     margin: 0 12px;
+  }
+
+  .itinerary_roadmap_item {
+    position: relative;
   }
 
   .itinerary_roadmap_item:last-child {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -155,33 +155,27 @@
   background-size: contain;
 }
 
-.itinerary_roadmap_item-block {
-  padding: 10px 0;
-
-  &:hover {
-    background-color: $grey-bright;
-    cursor: pointer;
-    position: relative;
-
-    &:before {
-      @include active-border-gradient;
-    }
-  }
-}
-
 .itinerary_roadmap {
-
   .divider {
     margin: 0 12px;
+
+    &:last-child {
+      display: none;
+    }
   }
 
   .itinerary_roadmap_item {
     position: relative;
-  }
+    padding: 10px 0;
 
-  .itinerary_roadmap_item:last-child {
-    .divider {
-      display: none;
+    &:hover {
+      background-color: $grey-bright;
+      cursor: pointer;
+      position: relative;
+
+      &:before {
+        @include active-border-gradient;
+      }
     }
   }
 
@@ -191,7 +185,16 @@
       align-self: flex-start;
       line-height: 21px;
     }
+
+    .divider {
+      margin-left: 60px;
+    }
   }
+}
+
+.itinerary_roadmap_step_description {
+  padding-right: 12px;
+  flex-grow: 1;
 }
 
 .itinerary_roadmap_item_summary {
@@ -209,6 +212,7 @@
   display: flex;
   padding: 3px 0;
   position: relative;
+  font-size: 14px;
 
   &:last-child {
     border-bottom: none;
@@ -223,6 +227,7 @@
     position: absolute;
     top: 6px;
     left: -36px;
+    z-index: 2;
   }
 
   .itinerary_roadmap_icon {
@@ -240,10 +245,11 @@
 .itinerary_roadmap_line {
   position: absolute;
   width: 7px;
-  left: 34px;
+  left: 27px;
   height: calc(100% - 28px);
   top: 38px;
   border-radius: 3px;
+  z-index: 1;
 
   &--walk {
     background: url(../images/direction_icons/walking_bullet_roadmap.png) repeat space;

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -152,7 +152,8 @@ test('select itinerary step', async () => {
   await page.waitForSelector('.itinerary_leg');
 
   await page.click('.itinerary_leg_detailsBtn');
-  await page.click('.itinerary_roadmap_item:nth-of-type(2)');
+  // click the second item of the roadmap
+  await page.click('.itinerary_roadmap_item + .divider + .itinerary_roadmap_item');
 
   const { center } = await getMapView(page);
   expect(center).toEqual({ 'lat': 48.823566, 'lng': 2.290454 });


### PR DESCRIPTION
## Description
Some specific elements of the public transport roadmaps were lost during the redesign. This PR restore them.

*I'll probably do some CSS clean-up after this fix because diving again in this complicated part made me realized the mess it's still*

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 86631_2 37200 destination=pj_08721866@NOMAD_S mode=publicTransport pt=true (1)](https://user-images.githubusercontent.com/243653/97018323-50f89480-154f-11eb-8291-3cadd8f510fd.png)|![localhost_3000_routes__origin=latlon_48 86631_2 37200 destination=pj_08721866@NOMAD_S mode=publicTransport pt=true](https://user-images.githubusercontent.com/243653/97018473-79808e80-154f-11eb-8a59-a675c0ee3dfe.png)|


