### PR TITLE
Qmaps 1819 share button

### DIFF
--- a/src/components/ui/FloatingButton.jsx
+++ b/src/components/ui/FloatingButton.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-const FloatingButton = ({ onClick, icon }) =>
+const FloatingButton = ({ title, onClick, icon }) =>
   <button
+    title={title}
     className="floatingButton"
     onClick={onClick}
   >

--- a/src/components/ui/FloatingButton.jsx
+++ b/src/components/ui/FloatingButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const FloatingButton = ({ onClick, icon }) =>
+  <button
+    className="floatingButton"
+    onClick={onClick}
+  >
+    <i className={`icon-${icon}`} />
+  </button>
+;
+
+export default FloatingButton;

--- a/src/components/ui/FloatingItems.jsx
+++ b/src/components/ui/FloatingItems.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const FloatingItems = ({ items }) =>
+  <div className="floatingItems">
+    {items}
+  </div>
+;
+
+export default FloatingItems;

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -121,7 +121,7 @@ class Panel extends React.Component {
         fire('move_mobile_bottom_ui', heightFromBottom);
       });
 
-      if (!this.props.isMobileBottomUIDisplayed) {
+      if (!this.props.isMapBottomUIDisplayed) {
         // Hide buttons except scale
         window.execOnMapLoaded(() => {
           fire('mobile_geolocation_button_visibility', false);

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -50,6 +50,7 @@ class Panel extends React.Component {
     marginTop: PropTypes.number,
     className: PropTypes.string,
     updateMobileMapUI: PropTypes.bool,
+    floatingItems: PropTypes.arrayOf(PropTypes.object),
   }
 
   static defaultProps = {

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -49,7 +49,7 @@ class Panel extends React.Component {
     setSize: PropTypes.func,
     marginTop: PropTypes.number,
     className: PropTypes.string,
-    updateMobileMapUI: PropTypes.bool,
+    isMapBottomUIDisplayed: PropTypes.bool,
     floatingItems: PropTypes.arrayOf(PropTypes.object),
   }
 
@@ -57,7 +57,7 @@ class Panel extends React.Component {
     fitContent: [],
     size: 'default',
     marginTop: 64, // default top bar size,
-    updateMobileMapUI: true,
+    isMapBottomUIDisplayed: true,
   }
 
   constructor(props) {
@@ -114,14 +114,22 @@ class Panel extends React.Component {
   }
 
   updateMobileMapUI = ({ closing } = {}) => {
-    if (!this.props.updateMobileMapUI) {return;}
-
     if (this.props.resizable) {
       const heightFromBottom = closing ? 0 : this.state.height - this.state.translateY;
 
       window.execOnMapLoaded(() => {
         fire('move_mobile_bottom_ui', heightFromBottom);
       });
+
+      if (!this.props.isMobileBottomUIDisplayed) {
+        // Hide buttons except scale
+        window.execOnMapLoaded(() => {
+          fire('mobile_geolocation_button_visibility', false);
+          fire('mobile_direction_button_visibility', false);
+        });
+
+        return;
+      }
 
       if (heightFromBottom > DEFAULT_SIZE) {
         // Transition to maximized

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { fire } from 'src/libs/customEvents';
 import { DeviceContext } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext';
-import { CloseButton } from 'src/components/ui';
+import { CloseButton, FloatingItems } from 'src/components/ui';
 
 const getEventClientY = event => event.changedTouches
   ? event.changedTouches[0].clientY
@@ -49,12 +49,14 @@ class Panel extends React.Component {
     setSize: PropTypes.func,
     marginTop: PropTypes.number,
     className: PropTypes.string,
+    updateMobileMapUI: PropTypes.bool,
   }
 
   static defaultProps = {
     fitContent: [],
     size: 'default',
     marginTop: 64, // default top bar size,
+    updateMobileMapUI: true,
   }
 
   constructor(props) {
@@ -111,6 +113,8 @@ class Panel extends React.Component {
   }
 
   updateMobileMapUI = ({ closing } = {}) => {
+    if (!this.props.updateMobileMapUI) {return;}
+
     if (this.props.resizable) {
       const heightFromBottom = closing ? 0 : this.state.height - this.state.translateY;
 
@@ -265,7 +269,7 @@ class Panel extends React.Component {
   render() {
     const {
       children, minimizedTitle,
-      resizable, className, size, renderHeader, onClose } = this.props;
+      resizable, className, size, renderHeader, onClose, floatingItems } = this.props;
     const { translateY, holding } = this.state;
 
     return (
@@ -286,6 +290,7 @@ class Panel extends React.Component {
             onTransitionEnd={() => this.updateMobileMapUI()}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
+            {floatingItems && <FloatingItems items={floatingItems} />}
             {onClose && <CloseButton onClick={onClose} className="panel-close" />}
             {isMobile && resizable &&
               <div

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -13,6 +13,8 @@ import Suggest from './Suggest';
 import Text from './Text';
 import PanelNav from './PanelNav';
 import CloseButton from './CloseButton';
+import FloatingButton from './FloatingButton';
+import FloatingItems from './FloatingItems';
 
 export {
   Badge,
@@ -31,4 +33,6 @@ export {
   Text,
   PanelNav,
   CloseButton,
+  FloatingButton,
+  FloatingItems,
 };

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -14,7 +14,7 @@ import { getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import * as address from 'src/libs/address';
-import { Button, CloseButton, Flex } from 'src/components/ui';
+import { Button, CloseButton, Divider, Flex } from 'src/components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import { PanelContext } from 'src/libs/panelContext.js';
@@ -389,6 +389,7 @@ export default class DirectionPanel extends React.Component {
               {_('Share itinerary', 'direction')}
             </Button>}
           </ShareMenu>
+          <Divider paddingTop={8} paddingBottom={0} />
           {result}
         </Panel>}
     </DeviceContext.Consumer>;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -380,6 +380,7 @@ export default class DirectionPanel extends React.Component {
                 <ShareMenu key="action-share" url={window.location.toString()}>
                   {openMenu =>
                     <FloatingButton
+                      title={_('Share itinerary', 'direction')}
                       onClick={e => this.handleShareClick(e, openMenu)}
                       icon="share-2"
                     />

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -403,7 +403,7 @@ export default class DirectionPanel extends React.Component {
           <div id="direction-autocomplete_suggestions" />
           <ShareMenu url={window.location.toString()}>
             {openMenu => <Button
-              className="u-ml-auto u-flex-shrink-0"
+              className="u-ml-auto u-flex-shrink-0 u-mr-16"
               variant="tertiary"
               title={_('Share itinerary', 'direction')}
               onClick={e => this.handleShareClick(e, openMenu)}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -375,7 +375,7 @@ export default class DirectionPanel extends React.Component {
               marginTop={marginTop}
               minimizedTitle={_('Unfold to show the results', 'direction')}
               onClose={this.onClose}
-              updateMobileMapUI={false}
+              isMobileBottomUIDisplayed={false}
               floatingItems={[
                 <ShareMenu key="action-share" url={window.location.toString()}>
                   {openMenu =>

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -35,6 +35,7 @@ export default class DirectionPanel extends React.Component {
   constructor(props) {
     super(props);
 
+    this.directionPanelRef = React.createRef();
     this.vehicles = [modes.DRIVING, modes.WALKING, modes.CYCLING];
     if (this.props.isPublicTransportActive) {
       this.vehicles.splice(1, 0, modes.PUBLIC_TRANSPORT);
@@ -44,7 +45,6 @@ export default class DirectionPanel extends React.Component {
       ? props.mode : modes.DRIVING;
 
     this.lastQueryId = 0;
-    this.marginTop = 0;
 
     this.state = {
       vehicle: activeVehicle,
@@ -59,6 +59,7 @@ export default class DirectionPanel extends React.Component {
       isInitializing: true,
       originInputText: '',
       destinationInputText: '',
+      marginTop: 0,
     };
 
     this.restorePoints(props);
@@ -97,6 +98,18 @@ export default class DirectionPanel extends React.Component {
           // ignore possible error
         }
       }
+    }
+  }
+
+  componentDidUpdate() {
+    const marginTop = this.directionPanelRef.current
+      ? this.directionPanelRef.current.offsetHeight
+      : 0;
+
+    if (marginTop !== this.state.marginTop) {
+      this.setState({
+        marginTop,
+      });
     }
   }
 
@@ -291,11 +304,6 @@ export default class DirectionPanel extends React.Component {
     this.setState({ activePreviewRoute: route });
   }
 
-  setMarginTop = el => {
-    this.marginTop = el ? el.offsetHeight : 0;
-    this.forceUpdate();
-  }
-
   handleShareClick = (e, handler) => {
     Telemetry.add(Telemetry.ITINERARY_SHARE);
     return handler(e);
@@ -307,6 +315,7 @@ export default class DirectionPanel extends React.Component {
       routes, error, activePreviewRoute,
       isLoading, isDirty, isInitializing,
       originInputText, destinationInputText,
+      marginTop,
     } = this.state;
     const title = <h3 className="direction-title u-text--title u-firstCap">
       {_('calculate an itinerary', 'direction')}
@@ -342,7 +351,7 @@ export default class DirectionPanel extends React.Component {
     return <DeviceContext.Consumer>
       {isMobile => isMobile
         ? <Fragment>
-          {!activePreviewRoute && <div className="direction-panel" ref={this.setMarginTop}>
+          {!activePreviewRoute && <div className="direction-panel" ref={this.directionPanelRef}>
             {!isFormCompleted && <Flex
               className="direction-panel-header"
               alignItems="center"
@@ -361,7 +370,7 @@ export default class DirectionPanel extends React.Component {
             <Panel
               resizable
               fitContent={['default']}
-              marginTop={this.marginTop}
+              marginTop={marginTop}
               minimizedTitle={_('Unfold to show the results', 'direction')}
               onClose={this.onClose}
             >

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -23,6 +23,8 @@ import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolo
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
 
+const MARGIN_TOP_OFFSET = 128; // reserve space to display map
+
 export default class DirectionPanel extends React.Component {
   static propTypes = {
     origin: PropTypes.string,
@@ -103,7 +105,7 @@ export default class DirectionPanel extends React.Component {
 
   componentDidUpdate() {
     const marginTop = this.directionPanelRef.current
-      ? this.directionPanelRef.current.offsetHeight
+      ? this.directionPanelRef.current.offsetHeight + MARGIN_TOP_OFFSET
       : 0;
 
     if (marginTop !== this.state.marginTop) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -375,7 +375,7 @@ export default class DirectionPanel extends React.Component {
               marginTop={marginTop}
               minimizedTitle={_('Unfold to show the results', 'direction')}
               onClose={this.onClose}
-              isMobileBottomUIDisplayed={false}
+              isMapBottomUIDisplayed={false}
               floatingItems={[
                 <ShareMenu key="action-share" url={window.location.toString()}>
                   {openMenu =>

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -14,7 +14,7 @@ import { getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import * as address from 'src/libs/address';
-import { Button, CloseButton, Divider, Flex } from 'src/components/ui';
+import { Button, CloseButton, Divider, Flex, FloatingButton } from 'src/components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import { PanelContext } from 'src/libs/panelContext.js';
@@ -375,6 +375,17 @@ export default class DirectionPanel extends React.Component {
               marginTop={marginTop}
               minimizedTitle={_('Unfold to show the results', 'direction')}
               onClose={this.onClose}
+              updateMobileMapUI={false}
+              floatingItems={[
+                <ShareMenu key="action-share" url={window.location.toString()}>
+                  {openMenu =>
+                    <FloatingButton
+                      onClick={e => this.handleShareClick(e, openMenu)}
+                      icon="share-2"
+                    />
+                  }
+                </ShareMenu>,
+              ]}
             >
               {result}
             </Panel>}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -23,7 +23,7 @@ import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolo
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
 
-const MARGIN_TOP_OFFSET = 128; // reserve space to display map
+const MARGIN_TOP_OFFSET = 64; // reserve space to display map
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -14,13 +14,14 @@ import { getAllSteps } from 'src/libs/route_utils';
 import MobileRoadMapPreview from './MobileRoadMapPreview';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import * as address from 'src/libs/address';
-import { CloseButton, Flex } from 'src/components/ui';
+import { Button, CloseButton, Flex } from 'src/components/ui';
 import { isMobileDevice } from 'src/libs/device';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import { PanelContext } from 'src/libs/panelContext.js';
 import { getInputValue } from 'src/libs/suggest';
 import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolocation';
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
+import ShareMenu from 'src/components/ui/ShareMenu';
 
 export default class DirectionPanel extends React.Component {
   static propTypes = {
@@ -295,6 +296,11 @@ export default class DirectionPanel extends React.Component {
     this.forceUpdate();
   }
 
+  handleShareClick = (e, handler) => {
+    Telemetry.add(Telemetry.ITINERARY_SHARE);
+    return handler(e);
+  }
+
   render() {
     const {
       origin, destination, vehicle,
@@ -372,6 +378,17 @@ export default class DirectionPanel extends React.Component {
           renderHeader={form}
         >
           <div id="direction-autocomplete_suggestions" />
+          <ShareMenu url={window.location.toString()}>
+            {openMenu => <Button
+              className="u-ml-auto u-flex-shrink-0"
+              variant="tertiary"
+              title={_('Share itinerary', 'direction')}
+              onClick={e => this.handleShareClick(e, openMenu)}
+              icon="share-2"
+            >
+              {_('Share itinerary', 'direction')}
+            </Button>}
+          </ShareMenu>
           {result}
         </Panel>}
     </DeviceContext.Consumer>;

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Flex } from 'src/components/ui';
-import ShareMenu from 'src/components/ui/ShareMenu';
 import Telemetry from 'src/libs/telemetry';
 
 import RouteSummaryInfo from './RouteSummaryInfo';
@@ -61,14 +60,6 @@ export default class RouteSummary extends React.Component {
               : _('Details', 'direction')
             }
           </Button>
-
-          <ShareMenu url={window.location.toString()} scrollableParent=".panel-content">
-            {openMenu => <Button
-              title={_('Share', 'direction')}
-              onClick={e => this.onShareClick(e, openMenu)}
-              icon="share-2"
-            />}
-          </ShareMenu>
         </Flex>
       }
     </div>;

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -1,7 +1,7 @@
 /* global _ */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Flex } from 'src/components/ui';
+import { Button } from 'src/components/ui';
 import Telemetry from 'src/libs/telemetry';
 
 import RouteSummaryInfo from './RouteSummaryInfo';

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -48,19 +48,17 @@ export default class RouteSummary extends React.Component {
       />
 
       {isActive &&
-        <Flex className="itinerary_leg_details-buttons">
-          <Button
-            className="itinerary_leg_detailsBtn u-mr-8 u-firstCap"
-            onClick={this.onClickDetails}
-            icon={showDetails ? null : 'icon_list'}
-            variant={showDetails ? 'tertiary' : 'secondary'}
-          >
-            {showDetails
-              ? _('See less', 'direction')
-              : _('Details', 'direction')
-            }
-          </Button>
-        </Flex>
+        <Button
+          className="itinerary_leg_detailsBtn u-mr-8 u-firstCap"
+          onClick={this.onClickDetails}
+          icon={showDetails ? null : 'icon_list'}
+          variant={showDetails ? 'tertiary' : 'secondary'}
+        >
+          {showDetails
+            ? _('See less', 'direction')
+            : _('Details', 'direction')
+          }
+        </Button>
       }
     </div>;
   }

--- a/src/scss/includes/colors.scss
+++ b/src/scss/includes/colors.scss
@@ -41,3 +41,5 @@ $orange-base: #ff851e;
 $focus-gradient: linear-gradient(to right, #216fff, #af27cc);
 $active-gradient: linear-gradient(to right, $action-blue-base, $action-blue-light);
 $active-gradient-vertical: linear-gradient(to bottom, $action-blue-base, $action-blue-light);
+
+$shadow : 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);

--- a/src/scss/includes/components/floatingButton.scss
+++ b/src/scss/includes/components/floatingButton.scss
@@ -1,0 +1,17 @@
+.floatingButton {
+  height: 48px;
+  width: 48px;
+  border-radius: 50px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: $background;
+  box-shadow: $shadow;
+
+  i {
+    font-size: 24px;
+    color: $grey-semi-darkness;
+  }
+}

--- a/src/scss/includes/components/floatingItems.scss
+++ b/src/scss/includes/components/floatingItems.scss
@@ -1,0 +1,7 @@
+.floatingItems {
+  position: absolute;
+  display: grid;
+  right: 12px;
+  gap: 8px;
+  transform: translateY(calc(-100% - 12px));
+}

--- a/src/scss/includes/components/panel.scss
+++ b/src/scss/includes/components/panel.scss
@@ -60,6 +60,7 @@ $bottom-margin: 40px;
     position: fixed;
     border-radius: 12px 12px 0 0;
     bottom: 0;
+    overflow: unset;
 
     .panel-close {
       top: 9px;

--- a/src/scss/includes/direction-form.scss
+++ b/src/scss/includes/direction-form.scss
@@ -7,7 +7,7 @@
 
   @media (min-width: 641px) {
     flex-direction: column-reverse;
-    padding-bottom: 16px;
+    padding-bottom: 8px;
 
     .vehicleSelector {
       margin-left: -4px;

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -35,6 +35,10 @@
   }
 }
 
+.itinerary_leg_detailsBtn {
+  margin-top: 12px;
+}
+
 .itinerary_no-result {
   text-align: center;
   padding: 25px 50px;
@@ -90,11 +94,7 @@
 }
 
 .itinerary_leg_summary {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: 20px;
-  align-items: center;
   cursor: pointer;
   position: relative;
 }
@@ -389,16 +389,6 @@ button.direction_shortcut {
 
   .itinerary_result .itemList-item {
     overflow: hidden;
-  }
-
-  .itinerary_leg_summary {
-    display: grid;
-    grid-template-areas: "info" "via" "actions";
-    padding: 15px 18px;
-  }
-
-  .itinerary_leg_details-buttons {
-    margin-top: 12px;
   }
 
   .itinerary_leg_via {

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -12,3 +12,4 @@
 @import "./components/block";
 @import "./components/panelNav";
 @import "./components/closeButton";
+@import "./components/floatingButton"

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -12,4 +12,5 @@
 @import "./components/block";
 @import "./components/panelNav";
 @import "./components/closeButton";
-@import "./components/floatingButton"
+@import "./components/floatingButton";
+@import "./components/floatingItems";

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -92,6 +92,10 @@
   margin-right: 8px;
 }
 
+.u-mr-16 {
+  margin-right: 16px;
+}
+
 .u-mb-2 {
   margin-bottom: 2px;
 }

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -76,6 +76,10 @@
   font-weight: bold;
 }
 
+.u-ml-auto {
+  margin-left: auto;
+}
+
 .u-ml-4 {
   margin-left: 4px;
 }
@@ -106,4 +110,8 @@
 
 .u-mb-20 {
   margin-bottom: 20px;
+}
+
+.u-flex-shrink-0 {
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## Description
- Add `FloatingButton` ui component
- Add `FloatingItems` ui component, used by `Panel`, to position an array of items (like FloatingButtons).
- Use updateMobileMapUI propType on `Panel`, to avoid rendering buttons "automagically"
- Create a share button for desktop
- On mobile, Display a Share button using `floatingItems` prop
- Add `u-ml-auto` and `u-flex-shrink-0` css utils

Remember to test sharing feature on mobile with `HTTPS=true`.

## Screenshots
![desktop](https://user-images.githubusercontent.com/2981774/97026123-4642fd00-1559-11eb-9bd3-865484963e1b.png)
![mobile](https://user-images.githubusercontent.com/2981774/97442493-34cb6d80-192a-11eb-89d0-0fa0ae408a14.png)


