### PR TITLE
Fix focused input not covering form entirely

### DIFF
--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -21,7 +21,7 @@
         top: 8px;
         left: 0;
         width: 100%;
-        height: 48px;
+        height: 54px;
         line-height: 50px;
         background-color: $background;
 


### PR DESCRIPTION
## Description
Fix focused direction input not covering form entirely, so part of it shows below.
Let's adjust fixed size of the container… until we refacto this input markup for smth more robust.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__origin=latlon_48 85570_2 42717 destination=latlon_48 89777_2 23767 mode=driving pt=true(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/97154208-ebd1b880-1773-11eb-9ca6-3c5ef9fa45c4.png)|![localhost_3000_routes__origin=latlon_48 85570_2 42717 destination=latlon_48 89777_2 23767 mode=driving pt=true(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/243653/97154226-f0966c80-1773-11eb-8640-681d123663a7.png)|

