### PR TITLE
No white background on link buttons

### DIFF
--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -22,7 +22,6 @@
   }
 
   &--tertiary {
-    background-color: white;
     color: $action-blue-base;
   }
 

--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -19,6 +19,7 @@
 }
 
 .service_panel__category_toggle {
+  background-color: white;
   box-shadow: 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);
 }
 


### PR DESCRIPTION
## Description
Don't define a white background on the normal state of "tertiary" buttons, so they display as simple links even on colored background.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran du 2020-10-26 11-27-35](https://user-images.githubusercontent.com/243653/97161611-5be53c00-177e-11eb-8cae-328821dcb50c.png)|![Capture d’écran du 2020-10-26 11-26-53](https://user-images.githubusercontent.com/243653/97161633-6273b380-177e-11eb-8c65-eddb92402a14.png)|
