### PR TITLE
config: Use focused queries on wider zoom values (z>=7 by default)

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -30,7 +30,7 @@ services:
     useFocus: true
     focusPrecision: '0.1' # lat/lon degrees
     focusZoomPrecision: '1.0'
-    focusMinZoom: 11
+    focusMinZoom: 7
     useNlu: false
   idunn:
     url: override_by_environment


### PR DESCRIPTION
## Description
Now that the autocomplete endpoint accepts different `zoom` values (see https://github.com/QwantResearch/idunn/pull/162), and the implementation is ready for production, the minimum zoom value used for focused searches can be lowered.

Z=7 is a compromise between the current value (z=11) and the mininum value supported by our implementation (z=3 theoretically). If we are satisfied with the results, and the performance impact is low enough, we could consider use a lower value.
