### PR TITLE
[Clean-up] Simplify SuggestDropdown

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -120,8 +120,6 @@ const Suggest = ({
   const SuggestsDropdownElement = () =>
     <SuggestsDropdown
       className={className}
-      inputNode={inputNode}
-      isAttachedToInput={!outputNode}
       suggestItems={items}
       isLoading={isLoading}
       onHighlight={item => {
@@ -142,14 +140,12 @@ const Suggest = ({
       onClear={onClear}
     />;
 
-  return outputNode
-    ? ReactDOM.createPortal(<SuggestsDropdownElement />, outputNode)
-    : <SuggestsDropdownElement />;
+  return ReactDOM.createPortal(<SuggestsDropdownElement />, outputNode);
 };
 
 Suggest.propTypes = {
   inputNode: object.isRequired,
-  outputNode: object,
+  outputNode: object.isRequired,
   withCategories: bool,
   withGeoloc: bool,
   onSelect: func,

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,47 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
-import { object, func, string, arrayOf, bool } from 'prop-types';
+import { object, func, string, arrayOf } from 'prop-types';
 
 import SuggestItem from './SuggestItem';
 
-const computeStyle = (isAttachedToInput, inputNode, suggestItems) => {
-  let style = {};
-
-  if (isAttachedToInput) {
-    // In case no output node is specified,
-    // suggestions are rendered just below inputNode
-    const boundingRect = inputNode.getBoundingClientRect();
-    style = {
-      ...style,
-      position: 'fixed',
-      top: boundingRect.bottom,
-      left: boundingRect.left,
-      width: boundingRect.width,
-    };
-  }
-
-  if (suggestItems.length === 0 ||
-      suggestItems.length > 0 && suggestItems[suggestItems.length - 1].simpleLabel) {
-    // Revove bottom padding if last item is a simple label (no results)
-    style = {
-      ...style,
-      paddingBottom: 0,
-    };
-  }
-
-  return style;
-};
-
 const SuggestsDropdown = ({
-  inputNode,
-  isAttachedToInput,
   className = '',
   suggestItems,
   onSelect,
   onHighlight,
 }) => {
   const [highlighted, setHighlighted] = useState(null);
-  const style = computeStyle(isAttachedToInput, inputNode, suggestItems);
 
   useEffect(() => {
     const keyDownHandler = e => {
@@ -97,10 +66,7 @@ const SuggestsDropdown = ({
   });
 
   return (
-    <ul
-      className={classnames('autocomplete_suggestions', className)}
-      style={style}
-    >
+    <ul className={classnames('autocomplete_suggestions', className)}>
       {suggestItems.map((suggest, index) =>
         <li
           key={index}
@@ -126,8 +92,6 @@ SuggestsDropdown.propTypes = {
   onHighlight: func.isRequired,
   onSelect: func.isRequired,
   className: string,
-  inputNode: object.isRequired,
-  isAttachedToInput: bool,
 };
 
 export default SuggestsDropdown;


### PR DESCRIPTION
## Description
Remove obsolete styling function of the SuggestsDropdown component, because:
 - we always pass an `outputNode` to our `<Suggest>` instances, so the `isAttachedToInput` mode was legacy
 - the `paddingBottom` rule override as no effect on the current design
 - it's possible and better to change both these points with CSS only, if needed.

As a result, we can remove two props and reduce coupling with the DOM.

## Why
First step of simplifying the `<Suggest>` component. The plan is to make it usable with a React `<TopBar>` implementation.