### PR TITLE
Fix Firefox Android geoloc hanging

### DIFF
--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -38,7 +38,7 @@ export default class NavigatorGeolocalisationPoi extends Poi {
         }
         reject(error);
       },
-      { maximumAge: 10000 },
+      { timeout: 3000 },
       );
     });
   }


### PR DESCRIPTION
## Description
Firefox Android has serious problems with the geoloc calls from the direction panel (like when using "my position" from the suggest).
As far as we understand, some early calls hang indefinitely, and subsequent calls get blocked. As a result, the UI seems stuck.

It seems the `maximumAge` option creates more problems than it solves, so remove it.
And add an explicit `timeout` so that in case of a call hanging, at least the UI is unstuck. 