### PR TITLE
buildQueryString: decode URI + test

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -65,3 +65,10 @@ export function buildQueryString(queriesObject) {
   const params = new URLSearchParams(removeNullEntries(queriesObject)).toString();
   return params ? `?${params}` : '';
 }
+
+export function buildRelativeUrl({
+  pathname = window.location.pathname,
+  search = window.location.search,
+}) {
+  return joinPath([pathname, search]);
+}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -22,6 +22,7 @@ import { getInputValue } from 'src/libs/suggest';
 import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolocation';
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
+import { parseQueryString, buildQueryString, buildRelativeUrl } from 'src/libs/url_utils';
 
 const MARGIN_TOP_OFFSET = 64; // reserve space to display map
 
@@ -222,18 +223,18 @@ export default class DirectionPanel extends React.Component {
   }
 
   updateUrl() {
-    const routeParams = [];
-    if (this.state.origin) {
-      routeParams.push('origin=' + poiToUrl(this.state.origin));
-    }
-    if (this.state.destination) {
-      routeParams.push('destination=' + poiToUrl(this.state.destination));
-    }
-    routeParams.push(`mode=${this.state.vehicle}`);
-    if (this.props.isPublicTransportActive) {
-      routeParams.push('pt=true');
-    }
-    window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, {
+    const queryObject = {
+      ...parseQueryString(window.location.search),
+      mode: this.state.vehicle,
+      origin: this.state.origin ? poiToUrl(this.state.origin) : null,
+      destination: this.state.destination ? poiToUrl(this.state.destination) : null,
+      pt: this.props.isPublicTransportActive ? 'true' : null,
+    };
+
+    const search = buildQueryString(queryObject);
+    const relativeUrl = buildRelativeUrl({ search });
+
+    window.app.navigateTo(relativeUrl, {}, {
       replace: true,
       routeUrl: false,
     });


### PR DESCRIPTION
## Description
When building a query string with `buildQueryString`,  decode URI components to get human readable urls, like in the actual Maps release.

## Why
previsouly, buildQueryString would return an encoded representation of a string like `admin:osm:relation:71525@Paris`.
