### PR TITLE
DirectionPanel: Improve url construction

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -22,6 +22,7 @@ import { getInputValue } from 'src/libs/suggest';
 import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolocation';
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
+import { parseQueryString, buildQueryString } from 'src/libs/url_utils';
 
 const MARGIN_TOP_OFFSET = 64; // reserve space to display map
 
@@ -222,18 +223,18 @@ export default class DirectionPanel extends React.Component {
   }
 
   updateUrl() {
-    const routeParams = [];
-    if (this.state.origin) {
-      routeParams.push('origin=' + poiToUrl(this.state.origin));
-    }
-    if (this.state.destination) {
-      routeParams.push('destination=' + poiToUrl(this.state.destination));
-    }
-    routeParams.push(`mode=${this.state.vehicle}`);
-    if (this.props.isPublicTransportActive) {
-      routeParams.push('pt=true');
-    }
-    window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, {
+    const queryObject = {
+      ...parseQueryString(window.location.search),
+      mode: this.state.vehicle,
+      origin: this.state.origin ? poiToUrl(this.state.origin) : null,
+      destination: this.state.destination ? poiToUrl(this.state.destination) : null,
+      pt: this.props.isPublicTransportActive ? 'true' : null,
+    };
+
+    const search = buildQueryString(queryObject);
+    const relativeUrl = 'routes/' + search;
+
+    window.app.navigateTo(relativeUrl, {}, {
       replace: true,
       routeUrl: false,
     });


### PR DESCRIPTION
## Description
- In DirectionPanel, use functions from `src/libs/url_utils`.

 From now, urls params will not be overrided by DirectionPanel as we use `parseQueryString`. This is needed for future work, where we need to keep a `selected` query params which will be handled by `RouteResult`

Urls should now be built with encoded params. We need to be sure this has no negative impact accross the app.