### PR TITLE
Always route url changes through the router

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -66,18 +66,15 @@ export default class App {
   * @param {Object} state - State object to associate with the history entry.
   * @param {Object} options
   * @param {boolean} options.replace - If true, the new state/url will replace the current state in browser history
-  * @param {boolean} options.routeUrl- If true, the new URL will be evaluated by the router.
   */
-  navigateTo(url, state = {}, { replace = false, routeUrl = true } = {}) {
+  navigateTo(url, state = {}, { replace = false } = {}) {
     const urlWithCurrentHash = joinPath([window.baseUrl, url]) + location.hash;
     if (replace) {
       window.history.replaceState(state, null, urlWithCurrentHash);
     } else {
       window.history.pushState(state, null, urlWithCurrentHash);
     }
-    if (routeUrl) {
-      this.router.routeUrl(urlWithCurrentHash, state);
-    }
+    this.router.routeUrl(urlWithCurrentHash, state);
   }
 
   updateHash(hash) {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -235,7 +235,6 @@ export default class DirectionPanel extends React.Component {
     }
     window.app.navigateTo(`/routes/?${routeParams.join('&')}`, {}, {
       replace: true,
-      routeUrl: false,
     });
   }
 


### PR DESCRIPTION
## Description
Remove the `routeUrl` option from the `navigateTo` function, which allowed to prevent explicitely calling the routing system after a URL change.

## Why
This option was a hack used during the migration from vanilla/dotJS to React, when each panel lived in its own React tree.
Without this option, each url change triggering the router would have unmounted/remounted the component. We didn't want that in the DirectionPanel, while keeping the abililty to change the url dynamically.
Now that the app is a single React tree, triggering the router will simply result in a normal render cycle with the React diff capabilities, so already mounted components will simply update, like we want.