### PR TITLE
Direction: handle selected state as search param

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -65,3 +65,10 @@ export function buildQueryString(queriesObject) {
   const params = new URLSearchParams(removeNullEntries(queriesObject)).toString();
   return params ? `?${params}` : '';
 }
+
+export function updateQueryString(queriesObject) {
+  return buildQueryString({
+    ...parseQueryString(window.location.search),
+    ...queriesObject,
+  });
+}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -347,7 +347,7 @@ export default class DirectionPanel extends React.Component {
       isInitializing={isInitializing}
     />;
     const result = <RouteResult
-      selected={this.sanitizeSelected()}
+      activeRouteId={this.sanitizeSelected()}
       isLoading={isLoading || routes.length > 0 && isDirty}
       vehicle={vehicle}
       error={error}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -311,6 +311,15 @@ export default class DirectionPanel extends React.Component {
     return handler(e);
   }
 
+  sanitizeSelected() {
+    const selectedParsed = parseInt(this.props.selected);
+    const isSelectedValid =
+      typeof selectedParsed === 'number' &&
+      selectedParsed < this.state.routes.length;
+
+    return isSelectedValid ? selectedParsed : 0;
+  }
+
   render() {
     const {
       origin, destination, vehicle,
@@ -338,6 +347,7 @@ export default class DirectionPanel extends React.Component {
       isInitializing={isInitializing}
     />;
     const result = <RouteResult
+      selected={this.sanitizeSelected()}
       isLoading={isLoading || routes.length > 0 && isDirty}
       vehicle={vehicle}
       error={error}

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -18,7 +18,7 @@ export default class RouteResult extends React.Component {
     isLoading: PropTypes.bool,
     error: PropTypes.number,
     openMobilePreview: PropTypes.func.isRequired,
-    activeRouteId: PropTypes.number.isRequired,
+    activeRouteId: PropTypes.number,
   }
 
   static defaultProps = {
@@ -35,6 +35,12 @@ export default class RouteResult extends React.Component {
     });
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.routes.length !== prevProps.routes.length) {
+      this.updateUrl({ selected: this.props.activeRouteId });
+    }
+  }
+
   selectRoute = routeId => {
     if (routeId === this.props.activeRouteId) {
       return;
@@ -43,7 +49,11 @@ export default class RouteResult extends React.Component {
     Telemetry.add(Telemetry.ITINERARY_ROUTE_SELECT);
     fire('set_main_route', { routeId, fitView: true });
 
-    const search = updateQueryString({ selected: routeId });
+    this.updateUrl({ selected: routeId });
+  }
+
+  updateUrl = queryObject => {
+    const search = updateQueryString(queryObject);
     window.app.navigateTo('routes/' + search, {}, { replace: true });
   }
 

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { Item, ItemList } from 'src/components/ui/ItemList';
 import PlaceholderText from 'src/components/ui/PlaceholderText';
 import { fire, listen } from 'src/libs/customEvents';
+import { updateQueryString } from 'src/libs/url_utils';
 import Telemetry from 'src/libs/telemetry';
 
 export default class RouteResult extends React.Component {
@@ -24,7 +25,6 @@ export default class RouteResult extends React.Component {
   }
 
   state = {
-    activeRouteId: 0,
     activeDetails: false,
   }
 
@@ -34,36 +34,32 @@ export default class RouteResult extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.routes.length !== prevProps.routes.length) {
-      this.setState({ activeRouteId: 0 });
-    }
-  }
-
   selectRoute = routeId => {
-    if (routeId === this.state.activeRouteId) {
+    if (routeId === this.props.selected) {
       return;
     }
+
     Telemetry.add(Telemetry.ITINERARY_ROUTE_SELECT);
     fire('set_main_route', { routeId, fitView: true });
-    this.setState({ activeRouteId: routeId });
+
+    const search = updateQueryString({ selected: routeId });
+    window.app.navigateTo('routes/' + search, {}, { replace: true });
   }
 
   hoverRoute = (routeId, highlightMapRoute) => {
-    if (routeId === this.state.activeRouteId) {
+    if (routeId === this.props.selected) {
       return;
     }
-    fire('set_main_route', { routeId: highlightMapRoute ? routeId : this.state.activeRouteId });
+    fire('set_main_route', { routeId: highlightMapRoute ? routeId : this.props.selected });
   }
 
   toggleRouteDetails = routeId => {
     Telemetry.add(Telemetry.ITINERARY_ROUTE_TOGGLE_DETAILS);
-    if (this.state.activeRouteId === routeId) {
+    if (this.props.selected === routeId) {
       this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
     } else {
       fire('set_main_route', { routeId, fitView: true });
       this.setState({
-        activeRouteId: routeId,
         activeDetails: true,
       });
     }
@@ -129,8 +125,8 @@ export default class RouteResult extends React.Component {
               origin={this.props.origin}
               destination={this.props.destination}
               vehicle={this.props.vehicle}
-              isActive={this.state.activeRouteId === index}
-              showDetails={this.state.activeRouteId === index && this.state.activeDetails}
+              isActive={this.props.selected === index}
+              showDetails={this.props.selected === index && this.state.activeDetails}
               toggleDetails={this.toggleRouteDetails}
               openPreview={this.openPreview}
               selectRoute={this.selectRoute}

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -18,6 +18,7 @@ export default class RouteResult extends React.Component {
     isLoading: PropTypes.bool,
     error: PropTypes.number,
     openMobilePreview: PropTypes.func.isRequired,
+    activeRouteId: PropTypes.number.isRequired,
   }
 
   static defaultProps = {
@@ -35,7 +36,7 @@ export default class RouteResult extends React.Component {
   }
 
   selectRoute = routeId => {
-    if (routeId === this.props.selected) {
+    if (routeId === this.props.activeRouteId) {
       return;
     }
 
@@ -47,15 +48,15 @@ export default class RouteResult extends React.Component {
   }
 
   hoverRoute = (routeId, highlightMapRoute) => {
-    if (routeId === this.props.selected) {
+    if (routeId === this.props.activeRouteId) {
       return;
     }
-    fire('set_main_route', { routeId: highlightMapRoute ? routeId : this.props.selected });
+    fire('set_main_route', { routeId: highlightMapRoute ? routeId : this.props.activeRouteId });
   }
 
   toggleRouteDetails = routeId => {
     Telemetry.add(Telemetry.ITINERARY_ROUTE_TOGGLE_DETAILS);
-    if (this.props.selected === routeId) {
+    if (this.props.activeRouteId === routeId) {
       this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
     } else {
       fire('set_main_route', { routeId, fitView: true });
@@ -125,8 +126,8 @@ export default class RouteResult extends React.Component {
               origin={this.props.origin}
               destination={this.props.destination}
               vehicle={this.props.vehicle}
-              isActive={this.props.selected === index}
-              showDetails={this.props.selected === index && this.state.activeDetails}
+              isActive={this.props.activeRouteId === index}
+              showDetails={this.props.activeRouteId === index && this.state.activeDetails}
               toggleDetails={this.toggleRouteDetails}
               openPreview={this.openPreview}
               selectRoute={this.selectRoute}


### PR DESCRIPTION
## Description
- Add `updateQueryString(queriesObject)` to url_utils.js : it applies a diff to the current search params.
- Handle selected route as a search param (`selected`). We don't need any state for this in `RouteResult` anymore.
- Sanitize selected search param in `DirectionPanel`. It would be even better to update the url if the user entered an invalid value like `selected=randomstring`, but we think it would be overcomplex for now.

## Why
Ongoing work to properly handle routing in Direction Panel

## Screenshots
![image](https://user-images.githubusercontent.com/2981774/98007760-0bac5080-1df4-11eb-9be6-2b79f4537505.png)
(note the selected search params)

![Peek 2020-11-03 16-53](https://user-images.githubusercontent.com/2981774/98008840-38149c80-1df5-11eb-9c45-0a93abab2f37.gif)
Here, we can see the last selected route is restored from history.

