### PR TITLE
Disable text selection on mobile devices

### DIFF
--- a/src/scss/includes/app.scss
+++ b/src/scss/includes/app.scss
@@ -1,4 +1,4 @@
-BODY {
+body {
   background: url("../images/backgrounds/grid.png");
 }
 
@@ -28,6 +28,13 @@ noscript {
 }
 
 @media (max-width: 640px) {
+  body {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
   .directions-open {
     .menu__button,
     .direction_shortcut,


### PR DESCRIPTION
## Description
Text selection on mobile devices cause a lot of problems on touch intensive UI like Maps, which try to mimic the behavior of a native map.
Let's disable it (note: this doesn't disable it on "input" elements).
In the cases where it's useful (ex : copying a POI address), appropriate design should provide tailored solutions, like one-click copy. This will be the object of further developments.