### PR TITLE
Make sure the route labeler doesn't crash on edge case

### DIFF
--- a/src/libs/route_labeler.js
+++ b/src/libs/route_labeler.js
@@ -33,6 +33,11 @@ function distinctSegment(coordinates, coordCounts) {
   // a distinct segment is a part of a line where coordinates
   // appear only once accross all the features
   const start = coordinates.findIndex(coord => coordCounts.get(asKey(coord)) === 1);
+  // in some rare cases, an alternative will share all its parts with others.
+  // when this happens, just return the whole line
+  if (start === -1) {
+    return lineString(coordinates);
+  }
   const end = start + coordinates
     .slice(start)
     .findIndex(coord => coordCounts.get(asKey(coord)) !== 1);


### PR DESCRIPTION
## Description
There is a rare edge-case with 3 alternative routes when no distinct segment can be found on one of the alternative.
Alternative A shares a part of its path with alternative B and the rest with alternative C.
In that case, the distinct segment will be null and generate an error.
Let's return the full path instead, the label will be put at the middle and there will some ambiguity for the user, but at least it doesn't crash.