### PR TITLE
Disable highlighting of routes on hover

### DIFF
--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -7,7 +7,7 @@ import { DeviceContext } from 'src/libs/device';
 
 const Route = ({
   id, route, vehicle, showDetails, origin, destination, isActive,
-  toggleDetails, openPreview, selectRoute, hoverRoute,
+  toggleDetails, openPreview, selectRoute,
 }) => {
   const isMobile = useContext(DeviceContext);
   const portalContainer = document.createElement('div');
@@ -22,10 +22,7 @@ const Route = ({
   }, [isMobile, showDetails]);
 
   return <Fragment>
-    <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}
-      onMouseEnter={() => { !isMobile && hoverRoute(id, true); }}
-      onMouseLeave={() => { !isMobile && hoverRoute(id, false); }}
-    >
+    <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}>
       <RouteSummary
         id={id}
         route={route}

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -57,13 +57,6 @@ export default class RouteResult extends React.Component {
     window.app.navigateTo('routes/' + search, {}, { replace: true });
   }
 
-  hoverRoute = (routeId, highlightMapRoute) => {
-    if (routeId === this.props.activeRouteId) {
-      return;
-    }
-    fire('set_main_route', { routeId: highlightMapRoute ? routeId : this.props.activeRouteId });
-  }
-
   toggleRouteDetails = routeId => {
     Telemetry.add(Telemetry.ITINERARY_ROUTE_TOGGLE_DETAILS);
     if (this.props.activeRouteId === routeId) {
@@ -141,7 +134,6 @@ export default class RouteResult extends React.Component {
               toggleDetails={this.toggleRouteDetails}
               openPreview={this.openPreview}
               selectRoute={this.selectRoute}
-              hoverRoute={this.hoverRoute}
             />
           </Item>)}
         </ItemList>


### PR DESCRIPTION
## Description
Now that route labels have been added, highlighting of route alternatives on the map from hovering their text summary has not much value. Design asks we simply remove it.
