### PR TITLE
Don't :hover route summary when hovering roadmap details

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -76,10 +76,6 @@
 }
 
 .itinerary_leg {
-  &:hover .itinerary_leg_summary {
-    background-color: $grey-bright;
-  }
-
   &--active .itinerary_leg_summary {
     &:before {
       @include active-border-gradient;
@@ -95,6 +91,10 @@
   padding: 20px;
   cursor: pointer;
   position: relative;
+
+  &:hover {
+    background-color: $grey-bright;
+  }
 }
 
 .itinerary_leg_via {


### PR DESCRIPTION
## Description
Fix the `:hover` style rule on route summaries, so the summary itself doesn't appear highlighted when the mouse hovers a part of the roadmap.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran du 2020-11-10 15-31-09](https://user-images.githubusercontent.com/243653/98687366-effff780-2369-11eb-9e2d-67614cad8bbe.png)|![Capture d’écran du 2020-11-10 15-30-41](https://user-images.githubusercontent.com/243653/98687392-f7270580-2369-11eb-86a5-8334067db756.png)|
