### PR TITLE
Fix opening hour icon right margin

### DIFF
--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -61,7 +61,7 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, withIcon, className }
     )}
     style={{ color }}
   >
-    {withIcon && <i className="icon-icon_clock u-mr-4"/>}
+    {withIcon && <i className="icon-icon_clock u-mr-xxs"/>}
     {getDescription()}
   </span>;
 };


### PR DESCRIPTION
Forgot one occurence of `u-mr-4` when replacing by new name `u-mr-xxs` in https://github.com/QwantResearch/erdapfel/pull/899
:unamused: