### PR TITLE
QMAPS-1833 - Reimplement modal on geolocate control trigger

### DIFF
--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -7,7 +7,7 @@ import { isPoiCompliantKey } from 'src/libs/pois';
 
 const prefix = `qmaps_v${version}_`;
 
-function get(k) {
+export function get(k) {
   try {
     const prefixedKey = `${prefix}${k}`;
     return JSON.parse(localStorage.getItem(prefixedKey));
@@ -17,7 +17,7 @@ function get(k) {
   }
 }
 
-function set(k, v) {
+export function set(k, v) {
   try {
     const prefixedKey = `${prefix}${k}`;
     localStorage.setItem(prefixedKey, JSON.stringify(v));
@@ -26,7 +26,7 @@ function set(k, v) {
   }
 }
 
-function del(k) {
+export function del(k) {
   try {
     const prefixedKey = `${prefix}${k}`;
     localStorage.removeItem(prefixedKey);

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -1,5 +1,6 @@
 import * as Geolocation from '../libs/geolocation';
 import Telemetry from '../libs/telemetry';
+import { openPendingGeolocateModal } from 'src/modals/GeolocationModal';
 
 import { GeolocateControl } from 'mapbox-gl--ENV';
 
@@ -27,6 +28,13 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
   }
 
   async trigger() {
+    const state = await Geolocation.getGeolocationPermission();
+    if ( state === Geolocation.geolocationPermissions.PROMPT ) {
+      const isModalAccepted = await openPendingGeolocateModal();
+      if (!isModalAccepted) {
+        return;
+      }
+    }
     super.trigger();
   }
 

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -1,8 +1,10 @@
 import * as Geolocation from '../libs/geolocation';
 import Telemetry from '../libs/telemetry';
 import { openPendingGeolocateModal } from 'src/modals/GeolocationModal';
+import { get } from 'src/adapters/store';
 
 import { GeolocateControl } from 'mapbox-gl--ENV';
+import { set } from '../adapters/store';
 
 /**
 * Override default GeolocateControl
@@ -29,8 +31,10 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
 
   async trigger() {
     const state = await Geolocation.getGeolocationPermission();
-    if (state === Geolocation.geolocationPermissions.PROMPT) {
+    if (state === Geolocation.geolocationPermissions.PROMPT &&
+        !get('has_geolocate_modal_opened_once')) {
       await openPendingGeolocateModal();
+      set('has_geolocate_modal_opened_once', true);
     }
     super.trigger();
   }

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -29,11 +29,8 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
 
   async trigger() {
     const state = await Geolocation.getGeolocationPermission();
-    if ( state === Geolocation.geolocationPermissions.PROMPT ) {
-      const isModalAccepted = await openPendingGeolocateModal();
-      if (!isModalAccepted) {
-        return;
-      }
+    if (state === Geolocation.geolocationPermissions.PROMPT) {
+      await openPendingGeolocateModal();
     }
     super.trigger();
   }

--- a/src/mapbox/extended_geolocate_control.js
+++ b/src/mapbox/extended_geolocate_control.js
@@ -1,10 +1,9 @@
 import * as Geolocation from '../libs/geolocation';
 import Telemetry from '../libs/telemetry';
 import { openPendingGeolocateModal } from 'src/modals/GeolocationModal';
-import { get } from 'src/adapters/store';
+import * as store from 'src/adapters/store';
 
 import { GeolocateControl } from 'mapbox-gl--ENV';
-import { set } from '../adapters/store';
 
 /**
 * Override default GeolocateControl
@@ -32,9 +31,9 @@ export default class ExtendedGeolocateControl extends GeolocateControl {
   async trigger() {
     const state = await Geolocation.getGeolocationPermission();
     if (state === Geolocation.geolocationPermissions.PROMPT &&
-        !get('has_geolocate_modal_opened_once')) {
+        !store.get('has_geolocate_modal_opened_once')) {
       await openPendingGeolocateModal();
-      set('has_geolocate_modal_opened_once', true);
+      store.set('has_geolocate_modal_opened_once', true);
     }
     super.trigger();
   }

--- a/src/modals/GeolocationModal.jsx
+++ b/src/modals/GeolocationModal.jsx
@@ -18,7 +18,7 @@ const GeolocationModal = ({ status, onClose, onAccept }) => {
     }
   );
 
-  const pendingText = _('We look at your location to show you where you are, and that\'s it! (See our {privacyPolicyLink}our privacy policy{closeTag})',
+  const pendingText = _('We look at your location to show you where you are, and that\'s it! (See our {privacyPolicyLink}privacy policy{closeTag})',
     'geolocation', {
       privacyPolicyLink: '<a target="_blank" rel="noopener noreferrer" href="https://about.qwant.com/legal/privacy">',
       closeTag: '</a>',

--- a/src/modals/GeolocationModal.jsx
+++ b/src/modals/GeolocationModal.jsx
@@ -11,23 +11,29 @@ let hasPermissionModalOpenedOnce = false;
 const GeolocationModal = ({ status, onClose, onAccept }) => {
   /* eslint-disable max-len */
 
-  const pendingStatusText = _('Always respecting your privacy.<br>As stated in {privacyPolicyLink}our privacy policy{closeTag}, we don\'t store your information because we don\'t want to know your whereabouts.',
+  const pendingOnDirectionsText = _('Always respecting your privacy.<br>As stated in {privacyPolicyLink}our privacy policy{closeTag}, we don\'t store your information because we don\'t want to know your whereabouts.',
     'geolocation', {
       privacyPolicyLink: '<a target="_blank" rel="noopener noreferrer" href="https://about.qwant.com/legal/privacy">',
       closeTag: '</a>',
     }
   );
 
+  const pendingText = _('We look at your location to show you where you are, and that\'s it! (See our {privacyPolicyLink}our privacy policy{closeTag})',
+    'geolocation', {
+      privacyPolicyLink: '<a target="_blank" rel="noopener noreferrer" href="https://about.qwant.com/legal/privacy">',
+      closeTag: '</a>',
+    });
+
   const statuses = {
     PENDING: {
-      title: _('Geolocation with privacy!', 'geolocation'),
-      text: pendingStatusText,
-      button: _('Ok, I\'ve got it', 'geolocation'),
+      title: _('At Qwant, your travels are your private life', 'geolocation'),
+      text: pendingText,
+      button: _('Continue', 'geolocation'),
       className: 'modal__maps__pending',
     },
     PENDING_ON_DIRECTIONS: {
       title: _('Enable your geolocation for better directions', 'geolocation'),
-      text: pendingStatusText,
+      text: pendingOnDirectionsText,
       button: _('Ok, I\'ve got it', 'geolocation'),
       className: 'modal__maps__pending',
     },

--- a/src/modals/GeolocationModal.jsx
+++ b/src/modals/GeolocationModal.jsx
@@ -10,15 +10,24 @@ let hasPermissionModalOpenedOnce = false;
 
 const GeolocationModal = ({ status, onClose, onAccept }) => {
   /* eslint-disable max-len */
+
+  const pendingStatusText = _('Always respecting your privacy.<br>As stated in {privacyPolicyLink}our privacy policy{closeTag}, we don\'t store your information because we don\'t want to know your whereabouts.',
+    'geolocation', {
+      privacyPolicyLink: '<a target="_blank" rel="noopener noreferrer" href="https://about.qwant.com/legal/privacy">',
+      closeTag: '</a>',
+    }
+  );
+
   const statuses = {
     PENDING: {
+      title: _('Geolocation with privacy!', 'geolocation'),
+      text: pendingStatusText,
+      button: _('Ok, I\'ve got it', 'geolocation'),
+      className: 'modal__maps__pending',
+    },
+    PENDING_ON_DIRECTIONS: {
       title: _('Enable your geolocation for better directions', 'geolocation'),
-      text: _('Always respecting your privacy.<br>As stated in {privacyPolicyLink}our privacy policy{closeTag}, we don\'t store your information because we don\'t want to know your whereabouts.',
-        'geolocation', {
-          privacyPolicyLink: '<a target="_blank" rel="noopener noreferrer" href="https://about.qwant.com/legal/privacy">',
-          closeTag: '</a>',
-        }
-      ),
+      text: pendingStatusText,
       button: _('Ok, I\'ve got it', 'geolocation'),
       className: 'modal__maps__pending',
     },
@@ -75,7 +84,7 @@ export async function openPendingDirectionModal() {
   hasPermissionModalOpenedOnce = true;
   return new Promise(resolve => {
     open(
-      'PENDING',
+      'PENDING_ON_DIRECTIONS',
       () => {
         close();
         resolve(false); // close: prevent native geolocation popup
@@ -83,6 +92,22 @@ export async function openPendingDirectionModal() {
       () => {
         close();
         resolve(true); // click "OK": allow native geolocation popup
+      }
+    );
+  });
+}
+
+export async function openPendingGeolocateModal() {
+  return new Promise(resolve => {
+    open(
+      'PENDING',
+      () => {
+        close();
+        resolve(false);
+      },
+      () => {
+        close();
+        resolve(true);
       }
     );
   });

--- a/src/modals/GeolocationModal.jsx
+++ b/src/modals/GeolocationModal.jsx
@@ -26,7 +26,7 @@ const GeolocationModal = ({ status, onClose, onAccept }) => {
 
   const statuses = {
     PENDING: {
-      title: _('At Qwant, your travels are your private life', 'geolocation'),
+      title: _('At Qwant, your whereabouts are part of your privacy', 'geolocation'),
       text: pendingText,
       button: _('Continue', 'geolocation'),
       className: 'modal__maps__pending',

--- a/src/scss/includes/modals/index.scss
+++ b/src/scss/includes/modals/index.scss
@@ -32,7 +32,7 @@
 }
 
 .modal__maps__content {
-  padding: 0 12px;
+  padding: 0 $spacing-l;
 }
 
 .modal--active {


### PR DESCRIPTION
## Description
- Implement Geolocate modal logic in extended_geolocate_control (credits go to @amatissart)
- Update title, text, and padding
- Ask for location permissions even if user has dismissed the modal
- Store a boolean in LocalStorage to open the modal only once

## Why
New UX and text when the user clicks on the geolocate button.

## Screenshots
![image](https://user-images.githubusercontent.com/2981774/98706768-8854a700-237f-11eb-9542-73aae963e241.png)
