### PR TITLE
Make the PJ partnership footer visible on default mobile panel

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -5,6 +5,7 @@ import Panel from 'src/components/ui/Panel';
 import PoiItemList from './PoiItemList';
 import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
+import PJPartnershipFooter from './PJPartnershipFooter';
 import Telemetry from 'src/libs/telemetry';
 import nconf from '@qwant/nconf-getter';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
@@ -150,7 +151,7 @@ export default class CategoryPanel extends React.Component {
       if (hasError) {
         panelContent = <CategoryPanelError zoomIn={zoomIn} />;
       } else {
-        panelContent =
+        panelContent = ({ size: panelSize, isMobile }) =>
         <>
           <PoiItemList
             pois={pois}
@@ -158,10 +159,9 @@ export default class CategoryPanel extends React.Component {
             highlightMarker={this.highlightPoiMarker}
             dataSource={dataSource}
           />
-          {dataSource === sources.pagesjaunes &&
-          <div className="category__panel__pj">
-            {_('Results in partnership with PagesJaunes', 'categories')}
-          </div>}
+          {dataSource === sources.pagesjaunes
+            && panelSize !== 'minimized'
+            && <PJPartnershipFooter isMobile={isMobile} />}
         </>;
       }
     }

--- a/src/panel/category/PJPartnershipFooter.jsx
+++ b/src/panel/category/PJPartnershipFooter.jsx
@@ -1,0 +1,24 @@
+/* global _ */
+import React, { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+const FooterContent = () => <div className="category__panel__pj">
+  {_('Results in partnership with PagesJaunes', 'categories')}
+</div>;
+
+const PJPartnershipFooter = ({ isMobile }) => {
+  const portalContainer = useRef(document.createElement('div'));
+
+  useEffect(() => {
+    document.body.appendChild(portalContainer.current);
+    return () => {
+      document.body.removeChild(portalContainer.current);
+    };
+  }, [isMobile]);
+
+  return isMobile
+    ? ReactDOM.createPortal(<FooterContent />, portalContainer.current)
+    : <FooterContent />;
+};
+
+export default PJPartnershipFooter;

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -68,12 +68,8 @@
     line-height: 36px;
     font-size: 14px;
     border-radius: 0;
-  }
-
-  .minimized:not(.panel--holding) {
-    .category__panel__pj {
-      display: none;
-    }
+    background-color: white;
+    z-index: 3;
   }
 
   .category__panel__error {


### PR DESCRIPTION
## Description
Ensure the PJ partnership footer is visible on the default mobile panel size.
Previously we encountered the now-classic bug of a `position: fixed` element (the footer) inside a `transform: translate(…)` element (the panel), which made impossible the footer not positionned relative to the viewport, but to the panel.
Like some other occurences of this problem, we use a React Portal so the footer isn't a DOM child of the Panel.

## Screenshots
|Before|After|
|---|---|
|![Screenshot_20201110-162756_Chrome](https://user-images.githubusercontent.com/243653/98694819-3bb69f00-2372-11eb-9cfb-75417a3102ec.jpg)|![Screenshot_20201110-162724_Chrome](https://user-images.githubusercontent.com/243653/98694824-3ce7cc00-2372-11eb-9c8d-88d2d87cef47.jpg)|
