### PR TITLE
Truncate POI name when displayed in list

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -35,7 +35,7 @@ const PoiItem = React.memo(({ poi,
   return <div className={classnames('poiItem', className)} {...rest}>
     <div className="poiItem-left">
       <div className="u-mb-xxs">
-        <PoiTitle poi={poi} withAlternativeName={withAlternativeName} />
+        <PoiTitle poi={poi} withAlternativeName={withAlternativeName} inList={inList} />
       </div>
       <Reviews />
       <OpenStatus />

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -1,10 +1,11 @@
 /* global _ */
 import React from 'react';
+import classnames from 'classnames';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import { capitalizeFirst } from 'src/libs/string';
 import Address from 'src/components/ui/Address';
 
-const PoiTitle = ({ poi, withAlternativeName }) => {
+const PoiTitle = ({ poi, withAlternativeName, inList }) => {
   const { name, localName, subClassName, address } = poi;
 
   // LatLon PoI
@@ -37,7 +38,9 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
 
   // Location / address
   return <div className="poiTitle">
-    <h2 className="poiTitle-main u-text--heading6">{title || subclass}</h2>
+    <h2 className={classnames('poiTitle-main u-text--heading6', { 'u-ellipsis': inList })}>
+      {title || subclass}
+    </h2>
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
       {alternative}
     </div>}

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -14,6 +14,12 @@
   text-transform: uppercase;
 }
 
+.u-ellipsis {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 @keyframes placeholderPulse {
   from { opacity: 0.6; }
   to { opacity: 1; }


### PR DESCRIPTION
## Description
Truncate POI names when displayed in result lists, to uniformize the height of items.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_places__type=restaurant(iPhone 6_7_8 Plus) (3)](https://user-images.githubusercontent.com/243653/98920031-e2648200-24cf-11eb-8907-b624628900f9.png)|![localhost_3000_places__type=restaurant(iPhone 6_7_8 Plus) (2)](https://user-images.githubusercontent.com/243653/98920276-35d6d000-24d0-11eb-9665-54a43afd6427.png)|