### PR TITLE
store: refactor store.js with prefix handling

### DIFF
--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -1,7 +1,7 @@
 import Error from '../adapters/error';
 import { version } from '../../config/constants.yml';
 import { findIndexIgnoreCase } from '../libs/string';
-import { getKeyWithoutVersion } from 'src/libs/pois';
+import { getKey } from 'src/libs/pois';
 import { fire } from 'src/libs/customEvents';
 import { isPoiCompliantKey } from 'src/libs/pois';
 
@@ -77,7 +77,7 @@ export async function getFavoritesMatching(term) {
 
 export async function isInFavorites(poi) {
   try {
-    return Boolean(get(getKeyWithoutVersion(poi)));
+    return Boolean(get(getKey(poi)));
   } catch (e) {
     Error.sendOnce('store', 'has', 'error checking existing key', e);
   }
@@ -85,7 +85,7 @@ export async function isInFavorites(poi) {
 
 export async function addToFavorites(poi) {
   try {
-    set(getKeyWithoutVersion(poi), poi);
+    set(getKey(poi), poi);
     fire('poi_added_to_favs', poi);
   } catch (e) {
     Error.sendOnce('store', 'add', 'error adding poi', e);
@@ -94,7 +94,7 @@ export async function addToFavorites(poi) {
 
 export async function removeFromFavorites(poi) {
   try {
-    del(getKeyWithoutVersion(poi));
+    del(getKey(poi));
     fire('poi_removed_from_favs', poi);
   } catch (e) {
     Error.sendOnce('store', 'del', 'error removing item', e);

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -5,7 +5,7 @@ import { getKey } from 'src/libs/pois';
 import { fire } from 'src/libs/customEvents';
 import { isPoiCompliantKey } from 'src/libs/pois';
 
-async function get(k) {
+function get(k) {
   try {
     return JSON.parse(localStorage.getItem(k));
   } catch (e) {
@@ -14,7 +14,7 @@ async function get(k) {
   }
 }
 
-async function set(k, v) {
+function set(k, v) {
   try {
     localStorage.setItem(k, JSON.stringify(v));
   } catch (e) {
@@ -53,7 +53,7 @@ export async function getFavoritesMatching(term) {
 
 export async function isInFavorites(poi) {
   try {
-    return Boolean(await get(getKey(poi)));
+    return Boolean(get(getKey(poi)));
   } catch (e) {
     Error.sendOnce('store', 'has', 'error checking existing key', e);
   }
@@ -61,7 +61,7 @@ export async function isInFavorites(poi) {
 
 export async function addToFavorites(poi) {
   try {
-    await set(getKey(poi), poi);
+    set(getKey(poi), poi);
     fire('poi_added_to_favs', poi);
   } catch (e) {
     Error.sendOnce('store', 'add', 'error adding poi', e);

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -31,18 +31,33 @@ function del(k) {
   localStorage.removeItem(prefixedKey);
 }
 
+/**
+ * List keys without prefix.
+ * In case some keys are not prefixed, we don't return them
+ */
+function listKeys() {
+  return Object
+    .keys(localStorage || {})
+    .reduce((acc, k) => {
+      const parts = k.split(prefix);
+      return parts.length === 2
+        ? [...acc, parts[1]]
+        : acc;
+    }, []);
+}
+
 export async function getAllFavorites() {
-  let localStorageKeys = [];
+  let keys = [];
   try {
-    localStorageKeys = Object.keys(localStorage);
+    keys = listKeys();
   } catch (e) {
     Error.sendOnce('local_store', 'getAllPois', 'error getting pois keys', e);
     return [];
   }
-  const items = localStorageKeys.reduce((filtered, k) => {
+  const items = keys.reduce((filtered, k) => {
     if (isPoiCompliantKey(k)) {
       try {
-        const poi = JSON.parse(localStorage.getItem(k));
+        const poi = get(k);
         filtered.push(poi);
       } catch (e) {
         Error.sendOnce('local_store', 'getAllPois', 'error getting pois', e);

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -1,13 +1,16 @@
 import Error from '../adapters/error';
 import { version } from '../../config/constants.yml';
 import { findIndexIgnoreCase } from '../libs/string';
-import { getKey } from 'src/libs/pois';
+import { getKey, getKeyWithoutVersion } from 'src/libs/pois';
 import { fire } from 'src/libs/customEvents';
 import { isPoiCompliantKey } from 'src/libs/pois';
 
+const prefix = `qmaps_v${version}_`;
+
 function get(k) {
   try {
-    return JSON.parse(localStorage.getItem(k));
+    const prefixedKey = `${prefix}${k}`;
+    return JSON.parse(localStorage.getItem(prefixedKey));
   } catch (e) {
     Error.sendOnce('local_store', 'get', `error parsing item with key ${k}`, e);
     return null;
@@ -16,7 +19,8 @@ function get(k) {
 
 function set(k, v) {
   try {
-    localStorage.setItem(k, JSON.stringify(v));
+    const prefixedKey = `${prefix}${k}`;
+    localStorage.setItem(prefixedKey, JSON.stringify(v));
   } catch (e) {
     Error.sendOnce('local_store', 'set', 'error setting item', e);
   }
@@ -53,7 +57,7 @@ export async function getFavoritesMatching(term) {
 
 export async function isInFavorites(poi) {
   try {
-    return Boolean(get(getKey(poi)));
+    return Boolean(get(getKeyWithoutVersion(poi)));
   } catch (e) {
     Error.sendOnce('store', 'has', 'error checking existing key', e);
   }
@@ -61,7 +65,7 @@ export async function isInFavorites(poi) {
 
 export async function addToFavorites(poi) {
   try {
-    set(getKey(poi), poi);
+    set(getKeyWithoutVersion(poi), poi);
     fire('poi_added_to_favs', poi);
   } catch (e) {
     Error.sendOnce('store', 'add', 'error adding poi', e);
@@ -79,7 +83,7 @@ export async function removeFromFavorites(poi) {
 
 export async function getLastLocation() {
   try {
-    return get(`qmaps_v${version}_last_location`);
+    return get('last_location');
   } catch (e) {
     Error.sendOnce('store', 'getLastLocation', 'error getting last location', e);
     return null;
@@ -88,7 +92,7 @@ export async function getLastLocation() {
 
 export async function setLastLocation(loc) {
   try {
-    return set(`qmaps_v${version}_last_location`, loc);
+    return set('last_location', loc);
   } catch (e) {
     Error.sendOnce('store', 'setLastLocation', 'error setting location', e);
     throw e;

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -27,8 +27,12 @@ function set(k, v) {
 }
 
 function del(k) {
-  const prefixedKey = `${prefix}${k}`;
-  localStorage.removeItem(prefixedKey);
+  try {
+    const prefixedKey = `${prefix}${k}`;
+    localStorage.removeItem(prefixedKey);
+  } catch (e) {
+    Error.sendOnce('local_store', 'del', 'error deleting item', e);
+  }
 }
 
 /**

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -1,7 +1,7 @@
 import Error from '../adapters/error';
 import { version } from '../../config/constants.yml';
 import { findIndexIgnoreCase } from '../libs/string';
-import { getKey, getKeyWithoutVersion } from 'src/libs/pois';
+import { getKeyWithoutVersion } from 'src/libs/pois';
 import { fire } from 'src/libs/customEvents';
 import { isPoiCompliantKey } from 'src/libs/pois';
 
@@ -24,6 +24,11 @@ function set(k, v) {
   } catch (e) {
     Error.sendOnce('local_store', 'set', 'error setting item', e);
   }
+}
+
+function del(k) {
+  const prefixedKey = `${prefix}${k}`;
+  localStorage.removeItem(prefixedKey);
 }
 
 export async function getAllFavorites() {
@@ -74,7 +79,7 @@ export async function addToFavorites(poi) {
 
 export async function removeFromFavorites(poi) {
   try {
-    localStorage.removeItem(getKey(poi));
+    del(getKeyWithoutVersion(poi));
     fire('poi_removed_from_favs', poi);
   } catch (e) {
     Error.sendOnce('store', 'del', 'error removing item', e);

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -38,12 +38,8 @@ function del(k) {
 function listKeys() {
   return Object
     .keys(localStorage || {})
-    .reduce((acc, k) => {
-      const parts = k.split(prefix);
-      return parts.length === 2
-        ? [...acc, parts[1]]
-        : acc;
-    }, []);
+    .filter(k => k.indexOf(prefix) === 0)
+    .map(k => k.substring(prefix.length, k.length));
 }
 
 export async function getAllFavorites() {

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -1,4 +1,4 @@
-import { version, sources } from 'config/constants.yml';
+import { sources } from 'config/constants.yml';
 import { slug, htmlEncode } from 'src/libs/string';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import LatLonPoi from 'src/adapters/poi/latlon_poi';
@@ -45,12 +45,9 @@ export function fromUrl(urlParam) {
 
 // POI fav storage functions
 
-const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
-const storeKeyPrefixWithoutVersion = 'favorite_place_';
-
-export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
-export const getKeyWithoutVersion = poi => `favorite_place_${poi.id}`;
-export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefixWithoutVersion) === 0;
+const prefix = 'favorite_place_';
+export const getKey = poi => `${prefix}${poi.id}`;
+export const isPoiCompliantKey = key => key.indexOf(prefix) === 0;
 
 // POI source functions
 

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -46,10 +46,11 @@ export function fromUrl(urlParam) {
 // POI fav storage functions
 
 const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
+const storeKeyPrefixWithoutVersion = 'favorite_place_';
 
 export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
 export const getKeyWithoutVersion = poi => `favorite_place_${poi.id}`;
-export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;
+export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefixWithoutVersion) === 0;
 
 // POI source functions
 

--- a/src/libs/pois.js
+++ b/src/libs/pois.js
@@ -48,6 +48,7 @@ export function fromUrl(urlParam) {
 const storeKeyPrefix = `qmaps_v${version}_favorite_place_`;
 
 export const getKey = poi => `${storeKeyPrefix}${poi.id}`;
+export const getKeyWithoutVersion = poi => `favorite_place_${poi.id}`;
 export const isPoiCompliantKey = key => key.indexOf(storeKeyPrefix) === 0;
 
 // POI source functions

--- a/tests/integration/favorites_tools.js
+++ b/tests/integration/favorites_tools.js
@@ -1,6 +1,7 @@
 import Poi from 'src/adapters/poi/poi';
 import { getKey } from 'src/libs/pois';
 import { exists, waitForAnimationEnd } from './tools';
+import { version } from 'config/constants.yml';
 
 /**
  * Prerequisite : Favorite Panel Must be open
@@ -42,5 +43,5 @@ export async function storePoi(
   const poi = new Poi(id, title, 'poi', coords, '', '');
   await page.evaluate((storageKey, serializedPoi) => {
     window.localStorage.setItem(storageKey, serializedPoi);
-  }, getKey(poi), JSON.stringify(poi));
+  }, `qmaps_v${version}_${getKey(poi)}`, JSON.stringify(poi));
 }


### PR DESCRIPTION
## Description
- remove unnecessary async keyword
- Use prefix in get/set functions. This way, no user of store.js should set it explicitly.
- Add `del` function
- Add listKeys function

## Why
Simplify api. store can be used to store any value in LocalStorage with the correct maps/version prefix.
