### PR TITLE
Inline class and opening hour in POI items

### DIFF
--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -21,7 +21,7 @@ const getStatusMessage = status => {
   return { label: '', color: '#fff' };
 };
 
-const OpeningHour = ({ schedule, showNextOpenOnly = false, withIcon, className }) => {
+const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
   if (!schedule) {
     return null;
   }
@@ -61,7 +61,6 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, withIcon, className }
     )}
     style={{ color }}
   >
-    {withIcon && <i className="icon-icon_clock u-mr-xxs"/>}
     {getDescription()}
   </span>;
 };

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -5,6 +5,8 @@ import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
 import classnames from 'classnames';
+import poiSubClass from 'src/mapbox/poi_subclass';
+import { capitalizeFirst } from 'src/libs/string';
 
 const PoiItem = React.memo(({ poi,
   withOpeningHours,
@@ -16,29 +18,25 @@ const PoiItem = React.memo(({ poi,
 }) => {
   const reviews = poi.blocksByType?.grades;
 
-  const Reviews = () =>
-    reviews
-      ? <span className="poiItem-reviews">
-        <ReviewScore reviews={reviews} poi={poi} inList={inList} compact={inList} />
-      </span>
-      : null
-  ;
+  const subclass = capitalizeFirst(poiSubClass(poi.subClassName));
 
-  const OpenStatus = () =>
-    withOpeningHours && poi?.blocksByType?.opening_hours
-      ? <OpeningHour
-        withIcon
-        schedule={new OsmSchedule(poi.blocksByType.opening_hours)}
-      />
-      : null;
+  const openingHours = withOpeningHours && poi?.blocksByType?.opening_hours;
 
   return <div className={classnames('poiItem', className)} {...rest}>
     <div className="poiItem-left">
       <div className="u-mb-xxs">
         <PoiTitle poi={poi} withAlternativeName={withAlternativeName} />
       </div>
-      <Reviews />
-      <OpenStatus />
+      {reviews && <div className="poiItem-reviews">
+        <ReviewScore reviews={reviews} poi={poi} inList={inList} />
+      </div>}
+      <div className="poiItem-subclassAndHours">
+        <div className="poiItem-subclass u-text--subtitle">{subclass}</div>
+        {inList && openingHours && '\u00A0⋅\u00A0'}
+        {openingHours && <div className="poiItem-openingHour">
+          <OpeningHour schedule={new OsmSchedule(poi.blocksByType.opening_hours)} />
+        </div>}
+      </div>
     </div>
 
     {withImage && <div className="poiItem-right">

--- a/src/components/PoiTitle.jsx
+++ b/src/components/PoiTitle.jsx
@@ -41,7 +41,6 @@ const PoiTitle = ({ poi, withAlternativeName }) => {
     {alternative && <div className="poiTitle-alternative u-text--subtitle u-italic">
       {alternative}
     </div>}
-    {title && <div className="poiTitle-subclass u-text--subtitle">{subclass}</div>}
   </div>;
 };
 

--- a/src/scss/includes/components/poiItem.scss
+++ b/src/scss/includes/components/poiItem.scss
@@ -20,11 +20,6 @@
     margin-bottom: 4px;
   }
 
-  &-reviews {
-    display: inline-flex;
-    margin-bottom: 4px;
-  }
-
   &-right {
     margin-left: 16px;
     display: flex;

--- a/src/scss/includes/openingHour.scss
+++ b/src/scss/includes/openingHour.scss
@@ -1,5 +1,0 @@
-.openingHour {
-  margin: 0;
-  display: flex;
-  align-items: center;
-}

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -2,6 +2,11 @@
   .poiItem {
     padding: 16px 14px;
   }
+
+  .poiItem-subclassAndHours {
+    display: flex;
+    flex-wrap: wrap;
+  }
 }
 
 .category__panel__pj {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -38,7 +38,6 @@ $font_system: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetic
 
 @import "includes/ui_components";
 @import "includes/reviewScore";
-@import "includes/openingHour";
 @import "includes/poiTitleImage";
 @import "includes/placeIcon";
 

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -30,8 +30,8 @@ beforeEach(async () => {
 test('click on a poi', async () => {
   await page.goto(APP_URL);
   await clickPoi(page);
-  expect(await exists(page, '.poiTitle')).toBeTruthy();
-  const translatedSubClass = await getText(page, '.poiTitle-subclass');
+  expect(await exists(page, '.poiItem')).toBeTruthy();
+  const translatedSubClass = await getText(page, '.poiItem-subclass');
   expect(translatedSubClass).toEqual('Musée');
 });
 


### PR DESCRIPTION
## Description
Display the POI subclass and opening hours on the same line in a result list.
If there is no room for both on the same line, make sure that the break happens between the two elements. To implement this behavior, I used a `flex-wrap: no-wrap;` instead of simply preventing the break inside the opening hour text. That way, on really small screens and with long wordings, it can still be broken itself if needed.

Also simplify the structure of the PoiItem component a bit, to separate data management from JSX rendering and avoid creating on-the-fly components.

#Why
Design trade-off to make room for the address as last-line (to come in another PR).

## Screenshots
|![Capture d’écran 2020-11-12 à 12 24 00](https://user-images.githubusercontent.com/243653/98934327-31b3ae00-24e2-11eb-87c9-01b351e37501.png)|![Capture d’écran 2020-11-12 à 12 23 31](https://user-images.githubusercontent.com/243653/98934307-2b253680-24e2-11eb-9ac2-83f9afcf36b7.png)|
