### PR TITLE
Add a one-line address on POI items in result lists 

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -4,6 +4,7 @@ import OpeningHour from 'src/components/OpeningHour';
 import OsmSchedule from 'src/adapters/osm_schedule';
 import ReviewScore from 'src/components/ReviewScore';
 import PoiTitleImage from 'src/panel/poi/PoiTitleImage';
+import Address from 'src/components/ui/Address';
 import classnames from 'classnames';
 import poiSubClass from 'src/mapbox/poi_subclass';
 import { capitalizeFirst } from 'src/libs/string';
@@ -37,6 +38,9 @@ const PoiItem = React.memo(({ poi,
           <OpeningHour schedule={new OsmSchedule(poi.blocksByType.opening_hours)} />
         </div>}
       </div>
+      {inList && <div className="poiItem-address u-text--subtitle u-ellipsis">
+        <Address address={poi.address} inline omitCountry />
+      </div>}
     </div>
 
     {withImage && <div className="poiItem-right">

--- a/src/panel/category/PoiItemListPlaceholder.jsx
+++ b/src/panel/category/PoiItemListPlaceholder.jsx
@@ -5,11 +5,10 @@ import PlaceholderText from 'src/components/ui/PlaceholderText';
 const PoiItemPlaceholder = () =>
   <div className="poiItem">
     <div>
-      <PlaceholderText length={25} tagName="h3" className="u-text--smallTitle"/>
+      <PlaceholderText length={25} tagName="h3" className="u-text--heading6 u-mb-xxs"/>
       <PlaceholderText length={15} tagName="p" className="u-text--subtitle" />
-      <PlaceholderText length={25} tagName="p" className="poiItem-address" />
-      <div className="poiItem-reviews"><PlaceholderText length={15} /></div>
-      <div className="openingHour"><PlaceholderText length={10} /></div>
+      <PlaceholderText length={25} tagName="p" className="u-text--subtitle" />
+      <PlaceholderText length={20} tagName="p" className="u-text--subtitle" />
     </div>
     <div className="poiItem-right">
       <div className="poiTitleImage u-placeholder" />

--- a/src/scss/includes/components/poiItem.scss
+++ b/src/scss/includes/components/poiItem.scss
@@ -13,13 +13,6 @@
     flex: 1;
   }
 
-  &-address {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    margin-bottom: 4px;
-  }
-
   &-right {
     margin-left: 16px;
     display: flex;

--- a/src/scss/includes/utils.scss
+++ b/src/scss/includes/utils.scss
@@ -34,7 +34,6 @@
   animation: placeholderPulse 0.8s ease-in-out alternate infinite;
 
   &--text {
-    margin: 4px 0 3px;
     height: 13px;
     display: inline-block;
   }


### PR DESCRIPTION
## Description
Display the POI address as the last-line of POI items in result lists.
~~According to the design, we only display the street and street number, so I added a new option in `<Address>` to omit the city part.~~ Let's keep the city part for now.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-11-12 à 18 30 48](https://user-images.githubusercontent.com/243653/99080361-7f531800-25c1-11eb-8933-84130119eba0.png)|![Capture d’écran 2020-11-12 à 18 31 08](https://user-images.githubusercontent.com/243653/99080368-824e0880-25c1-11eb-8cc9-f32ff09c704f.png)|
