### PR TITLE
RoutesList: On mobile, move active route to top

### DIFF
--- a/src/panel/direction/RoutesList.jsx
+++ b/src/panel/direction/RoutesList.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
+import { DeviceContext } from 'src/libs/device';
 import { Item, ItemList } from 'src/components/ui/ItemList';
 import PlaceholderText from 'src/components/ui/PlaceholderText';
 import Route from './Route';
@@ -17,10 +18,15 @@ const RoutesList = ({
   isLoading,
 }) => {
 
+  const isMobile = useContext(DeviceContext);
+  const orderedRoutes = isMobile
+    ? moveRouteToTop(routes, activeRouteId)
+    : routes;
+
   return isLoading
     ? <Placeholder />
     : <ItemList>
-      {routes.map(route =>
+      {orderedRoutes.map(route =>
         <Item
           key={route.id}>
           <Route
@@ -61,6 +67,19 @@ const Placeholder = () => {
       </Item>
     </ItemList>
   );
+};
+
+const moveRouteToTop = (routes, id) => {
+  if (!id) {
+    return routes;
+  }
+
+  return routes
+    .slice() // clone the array as sort operates on-place
+    .sort((a, b) => a.id === id
+      ? -1
+      : b.id === id ? 1 : 0
+    );
 };
 
 export default RoutesList;


### PR DESCRIPTION
## Description
On mobile, move active route to the top

Remaining task should be to resize the panel, using `fitContent`, in order to only show the selected route.

## Why
UX changes

## Screenshots
![Peek 2020-11-13 17-28](https://user-images.githubusercontent.com/2981774/99095661-b59a9280-25d5-11eb-9208-12a0bbc93933.gif)

On desktop, behavior has not changed.
