### PR TITLE
Fix some 'hover' states on mobile

### DIFF
--- a/src/scss/includes/components/itemList.scss
+++ b/src/scss/includes/components/itemList.scss
@@ -5,13 +5,18 @@
 .itemList--hover .itemList-item {
   position: relative;
 
-  &:hover {
+  &:active {
     background: $surface;
+  }
+
+  @media (min-width: 641px) {
+    &:hover {
+      background: $surface;
+    }
   }
 }
 
 @media (max-width: 640px) {
-
   .itemList {
     padding-bottom: 12px;
   }

--- a/src/scss/includes/components/mainActionButton.scss
+++ b/src/scss/includes/components/mainActionButton.scss
@@ -1,6 +1,7 @@
 .mainActionButton {
   cursor: pointer;
   padding: 8px;
+  border-radius: 8px;
 
   &-label {
     font-size: 12px;
@@ -17,9 +18,14 @@
     margin-bottom: 4px;
   }
 
-  &:hover {
+  &:active {
     background-color: $grey-bright;
-    border-radius: 8px;
+  }
+
+  @media (min-width: 641px) {
+    &:hover {
+      background-color: $grey-bright;
+    }
   }
 }
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -92,8 +92,10 @@
   cursor: pointer;
   position: relative;
 
-  &:hover {
-    background-color: $grey-bright;
+  @media (min-width: 641px) {
+    &:hover {
+      background-color: $grey-bright;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Follow-up to https://github.com/QwantResearch/erdapfel/pull/873, to fix some other visual bugs coming from "hover" state being treated as persistent by iOS.
As a result, buttons may keep an hover style, as can be seen on iOS when clicking a category button in the service panel and coming back. The hover state is even "transmitted" to the POI item under the user finger when opening the category panel.
 
Solution:
 - Declare `:hover` only on desktop, as we started to do in the mentionned PR
 - As it's a usability feature to have elements visually react to touchs/clicks, use the `:active` state for that.