### PR TITLE
on mobile, resize panel to fit one route

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -380,6 +380,7 @@ export default class DirectionPanel extends React.Component {
           </div>}
           {isResultDisplayed &&
             <Panel
+              className="direction-panel-mobile"
               resizable
               fitContent={['default']}
               marginTop={marginTop}

--- a/src/scss/includes/direction-panel.scss
+++ b/src/scss/includes/direction-panel.scss
@@ -49,3 +49,18 @@
     z-index: 0;
   }
 }
+
+.direction-panel-mobile {
+  .itemList > div:not(:first-child) {
+      display: none;
+  }
+}
+
+.direction-panel-mobile {
+  &.maximized, &.panel--holding {
+    .itemList > div:not(:first-child) {
+      display: block;
+    }
+  }
+}
+


### PR DESCRIPTION
## Description
After selecting a route, the panel is already set to default size. This PR hide the routes which are not selected, this way, the panel is resized to fit only the one selected route.

## Why
UX changes

## Screenshots
![gif](https://user-images.githubusercontent.com/2981774/99260858-3c40b100-281c-11eb-91d2-5d5a3e1ce1ec.gif)

Please note, in 0dff753e390735372f34e3a96b4b463540021102 we disable the automatic refit on the map, as this intrudce on huge dezoom when selecting a route, due to the tiny space reserved for displaying the map when the panel is maximized.