### PR TITLE
Manage filtered POI labels and icons on 2 separate MapBox-GL layers

### DIFF
--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -1,5 +1,5 @@
 
-export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
+export const getFilteredPoisPinStyle = () => ({
   type: 'symbol',
   layout: {
     'icon-image': ['concat', 'pin-', ['get', 'iconName']],
@@ -7,10 +7,24 @@ export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
     'icon-ignore-placement': false,
     'icon-padding': 0,
     'icon-anchor': 'bottom',
+  },
+  paint: {
+    'icon-opacity': ['case',
+      ['==', ['feature-state', 'selected'], true], 0,
+      ['==', ['feature-state', 'hovered'], true], 0,
+      1,
+    ],
+  },
+});
 
+
+
+export const getFilteredPoisLabelStyle = () => ({
+  type: 'symbol',
+  layout: {
     'text-font': [ 'Noto Sans Bold' ],
     'text-size': 10,
-    'text-field': withName ? ['get', 'name'] : '',
+    'text-field': ['get', 'name'],
     'text-allow-overlap': false,
     'text-ignore-placement': false,
     'text-optional': true,
@@ -19,11 +33,6 @@ export const getFilteredPoisStyle = ({ withName = true } = {}) => ({
     'text-justify': 'auto',
   },
   paint: {
-    'icon-opacity': ['case',
-      ['==', ['feature-state', 'selected'], true], 0,
-      ['==', ['feature-state', 'hovered'], true], 0,
-      1,
-    ],
     'text-color': ['case', ['==', ['feature-state', 'selected'], true], '#900014', '#0c0c0e'],
     'text-halo-color': 'white',
     'text-halo-width': 1,


### PR DESCRIPTION
## Description
Split the drawing of the filtered POIs in two separate MapBox-GL layers, one for the pins, the other dedicated to the labels, so layout algorithms work better.
As both layers use the same GeoJSON data source and the dynamic states (active/selected) are managed on it, the duplication is minimal. But we still need to duplicate visibility toggling and event listener attachments.

## Why
The one-layer implementation had label layout issues, principaly many overlaps of labels on icons. It looked dirty and was bad for user readability.
It seems MapBox-GL overlap avoidance algorithms don't work well within the same layer, when we force it to display all icons. As the removal of labels on other layers below always worked correctly, we used the same principle for these labels.
Thanks @amatissart for the great and simple idea :)

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_places__type=restaurant bbox=0 1817103%2C49 6916535%2C0 2261389%2C49 7177631](https://user-images.githubusercontent.com/243653/99373872-37ced380-28c2-11eb-9a90-bca8d61b0b1f.png)|![localhost_3000_places__type=restaurant bbox=2 4152807%2C48 848743299999995%2C2 4828110999999997%2C48 878747399999995 (1)](https://user-images.githubusercontent.com/243653/99373885-3d2c1e00-28c2-11eb-88f6-95c7fdbed187.png)|
|![IMG_0008](https://user-images.githubusercontent.com/243653/99373418-af503300-28c1-11eb-8c8e-1c410d21e925.PNG)|![IMG_0007](https://user-images.githubusercontent.com/243653/99373426-b1b28d00-28c1-11eb-8f7a-0b3c3eeb3d02.PNG)|
|![localhost_3000_places__type=restaurant (5)](https://user-images.githubusercontent.com/243653/99373606-e6264900-28c1-11eb-852e-2687cffe12f0.png)|![localhost_3000_places__type=restaurant (4)](https://user-images.githubusercontent.com/243653/99373617-e9213980-28c1-11eb-960b-20da1f386b06.png)|