### PR TITLE
Fix style of the mobile vehicle selector highlight bar

### DIFF
--- a/src/scss/includes/vehicleSelector.scss
+++ b/src/scss/includes/vehicleSelector.scss
@@ -67,7 +67,9 @@
 
       &:after{
         content:'';
-        width: 100%;
+        position: absolute;
+        bottom: 0;
+        width: 80px;
         height: 4px;
         background: $active-gradient;
         border-radius: 4px 4px 0 0;


### PR DESCRIPTION
## Description
As asked in the ticket, ensure the bar highlighting the selected vehicle is always the same width (the button width itself can slightly change with the content, even if it's not really visible).
While we are at it, ensure this bar is always at the bottom of the area. In some languages and on very small screens, button labels can take two lines which breaks the design. Some translations adjustement could be made I guess, but at least it appears less broken :)

## Screenshots
|Before|After|
|---|---|
|![localhost_3000_routes__mode=publicTransport pt=true origin=latlon%3A48 85577%3A2 42699(Galaxy S5)](https://user-images.githubusercontent.com/243653/99404661-30242480-28ec-11eb-83d1-d97e7ed28ca9.png)|![localhost_3000_routes__mode=publicTransport pt=true origin=latlon%3A48 85577%3A2 42699(Galaxy S5) (1)](https://user-images.githubusercontent.com/243653/99404687-35816f00-28ec-11eb-9c22-280bdf8d83fc.png)|
