### PR TITLE
Hide fixed mobile POI list footer in no_ui mode

### DIFF
--- a/src/scss/includes/no_ui.scss
+++ b/src/scss/includes/no_ui.scss
@@ -15,4 +15,8 @@
   .map_control_group {
     visibility: hidden;
   }
+
+  .category__panel__pj {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
## Description
Hide explicitly the mobile PJ footer in no_ui mode, as since https://github.com/QwantResearch/erdapfel/pull/909 it is not a child element of the panel anymore.