### PR TITLE
Review score stars are blue even when empty

### DIFF
--- a/src/scss/includes/reviewScore.scss
+++ b/src/scss/includes/reviewScore.scss
@@ -16,6 +16,7 @@
     }
   }
 
+  .icon-icon_star,
   .icon-icon_star-filled,
   &-score {
     color: $action-blue-base;


### PR DESCRIPTION
## Description
Review score stars should be blue, even when empty.
 
## Screenshots
![Capture d’écran de 2020-11-17 18-13-57](https://user-images.githubusercontent.com/243653/99423430-d712bb80-2900-11eb-9b86-9326fb1a2e10.png)
