### PR TITLE
No subclass/hours separator when no subclass displayed

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -33,7 +33,7 @@ const PoiItem = React.memo(({ poi,
       </div>}
       <div className="poiItem-subclassAndHours">
         <div className="poiItem-subclass u-text--subtitle">{subclass}</div>
-        {inList && openingHours && '\u00A0⋅\u00A0'}
+        {inList && subclass && openingHours && '\u00A0⋅\u00A0'}
         {openingHours && <div className="poiItem-openingHour">
           <OpeningHour schedule={new OsmSchedule(poi.blocksByType.opening_hours)} />
         </div>}


### PR DESCRIPTION
## Description
Don't display the medium point separator between subclass and hours in POI item if there is no subclass (?).

But this may not be the right fix, I don't know if it's normal that some POI in lists don't have a subclass.