### PR TITLE
routes: Ignore URL query when parsing place id

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -114,7 +114,7 @@ export default class PanelManager extends React.Component {
       });
     });
 
-    router.addRoute('POI', '/place/(.*)', async (poiUrl, options = {}) => {
+    router.addRoute('POI', '/place/([^?]+)', async (poiUrl, options = {}) => {
       const poiId = poiUrl.split('@')[0];
       this.setState({
         ActivePanel: PoiPanel,

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -24,7 +24,7 @@ beforeEach(async () => {
 
   const autocompleteMock = require('../../__data__/autocomplete.json');
   responseHandler.addPreparedResponse(autocompleteMock, /autocomplete/);
-  responseHandler.addPreparedResponse(poiMock, /places\/osm:way:63178753(\?.*)?$/);
+  responseHandler.addPreparedResponse(poiMock, /places\/osm:way:63178753(\?[^?]*)?$/);
 });
 
 test('click on a poi', async () => {
@@ -52,7 +52,7 @@ test('load a poi from url and click on directions', async () => {
 });
 
 test('load a poi from url with simple id', async () => {
-  await page.goto(`${APP_URL}/place/osm:way:63178753`);
+  await page.goto(`${APP_URL}/place/osm:way:63178753?client=example`);
   await page.waitForSelector('.poiTitle');
   const title = await page.evaluate(() => document.querySelector('.poiTitle').innerText);
   expect(title).toMatch(/Musée d'Orsay/);


### PR DESCRIPTION
## Description
This PR fixes how the POI id is extracted from a URL such as `/maps/place/id:4242?client=example`

## Why
When the `@PlaceName` suffix was not included in the URL, query params could be included in the POI id. And this invalid id was used in different contexts, eg. in URL to Idunn API, with unpredicable consequences.  
This behavior also broke the "hotload" mechanism as the id comparison with the prefetched data failed.
