### PR TITLE
[Tests] Add a new test suite for Instant Answer mode

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -70,7 +70,7 @@ export default class PanelManager extends React.Component {
     this.updateSearchBarContent(options);
   }
 
-  updateSearchBarContent({ poiFilters = {}, query }) {
+  updateSearchBarContent({ poiFilters = {}, query } = {}) {
     const topBarHandle = document.querySelector('.top_bar');
     if (poiFilters.category) {
       const categoryLabel = CategoryService.getCategoryByName(poiFilters.category)?.getInputValue();
@@ -155,7 +155,7 @@ export default class PanelManager extends React.Component {
     });
 
     // Default matching route
-    router.addRoute('Services', '/?', (_, options) => {
+    router.addRoute('Services', '/?', (_, options = {}) => {
       this.setState({
         ActivePanel: ServicePanel,
         options,

--- a/tests/integration/tests/instantAnswer.js
+++ b/tests/integration/tests/instantAnswer.js
@@ -1,0 +1,34 @@
+import { initBrowser, isHidden } from '../tools';
+
+let browser;
+let page;
+
+beforeAll(async () => {
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+  await page.setViewport({ width: 580, height: 240 }); // standard IA size
+});
+
+test('UI elements are hidden', async () => {
+  await page.goto(APP_URL + '/?no_ui=1');
+  await page.waitForSelector('.panel');
+  const uiElements = ['.top_bar', '.menu__button', '.panel_container', '.map_control_group'];
+  for (const selector of uiElements) {
+    expect(await isHidden(page, selector)).toBeTruthy();
+  }
+});
+
+// @TODO: other tests to add
+// - the map and its POIs don't react to clicks
+// - all the IA modes
+
+afterEach(async () => {
+  await page.close();
+});
+
+afterAll(async () => {
+  await browser.close();
+});

--- a/tests/integration/tools.js
+++ b/tests/integration/tools.js
@@ -75,8 +75,11 @@ export async function exists(page, selector) {
 
 export async function isHidden(page, selector) {
   try {
-    const result = await page.waitForSelector(selector, { hidden: true });
-    return result === null;
+    // returns null when the element is not in the DOM,
+    // or the handle if the element is in the DOM and hidden.
+    // Throws in other cases.
+    await page.waitForSelector(selector, { hidden: true });
+    return true;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Description
Add a new test suite dedicated to the Instant Answer. For now, just test some UI elements are hidden, but the suite is meant to be completed with other test cases.

Also fixes a JS error on the router argument parsing, detected when developping the test (when opening the maps root url with only `?no-ui=1`).

## Why
Now that the Instant Answer display will be controlled mostly by Erdapfel, it's important to test that to ensure we don't break anything.