### PR TITLE
QMAPS-1766 log normal app starts and iframe displays separately

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -2,6 +2,8 @@ module.exports = {
   events: [
     /* App */
     'app_start',
+    /* IA Maps iframe */
+    'app_start_iframe',
     /* Suggest*/
     'suggest_selection',
     'suggest_submit',

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -40,13 +40,25 @@ export default class PanelManager extends React.Component {
     const initialRoute = this.initRouter();
     this.initTopBar();
 
-    Telemetry.add(Telemetry.APP_START, {
-      'language': window.getLang(),
-      'is_mobile': isMobileDevice(),
-      'url_pathname': initialUrlPathName,
-      'direct_search': initialRoute.name === directSearchRouteName && !!initialQueryParams['q'],
-      'url_client': initialQueryParams['client'] || null,
-    });
+    if (window.no_ui) {
+      // iframe
+      Telemetry.add(Telemetry.APP_START_IFRAME, {
+        'language': window.getLang(),
+        'is_mobile': isMobileDevice(),
+        'url_pathname': initialUrlPathName,
+        'direct_search': initialRoute.name === directSearchRouteName && !!initialQueryParams['q'],
+        'url_client': initialQueryParams['client'] || null,
+      });
+    } else {
+      // no iframe
+      Telemetry.add(Telemetry.APP_START, {
+        'language': window.getLang(),
+        'is_mobile': isMobileDevice(),
+        'url_pathname': initialUrlPathName,
+        'direct_search': initialRoute.name === directSearchRouteName && !!initialQueryParams['q'],
+        'url_client': initialQueryParams['client'] || null,
+      });
+    }
 
     window.times.appRendered = Date.now();
 


### PR DESCRIPTION
## Description
- Qwant Maps: log Telemetry.APP_START on load
- Qwant Maps iframe (when ?no_ui=1): log Telemetry.APP_START_IFRAME on load
- Update documentation: https://confluence.qwant.ninja/confluence/pages/viewpage.action?pageId=25809175

