### PR TITLE
Direction:  use search param to details status

### DIFF
--- a/src/panel/direction/MobileRouteDetails.jsx
+++ b/src/panel/direction/MobileRouteDetails.jsx
@@ -12,7 +12,6 @@ const MobileRouteDetails =
   const isPublicTransport = vehicle !== 'publicTransport';
 
   return <div
-    onTouchStart={e => e.stopPropagation()}
     ref={panelElement}
     className={classnames('mobile-route-details')}
   >

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -1,6 +1,4 @@
-import React, { useContext, useEffect, Fragment } from 'react';
-import ReactDOM from 'react-dom';
-import MobileRouteDetails from './MobileRouteDetails';
+import React, { useContext, Fragment } from 'react';
 import RouteSummary from './RouteSummary';
 import RoadMap from './RoadMap';
 import { DeviceContext } from 'src/libs/device';
@@ -10,16 +8,6 @@ const Route = ({
   toggleDetails, openPreview, selectRoute,
 }) => {
   const isMobile = useContext(DeviceContext);
-  const portalContainer = document.createElement('div');
-
-  useEffect(() => {
-    if (showDetails && isMobile) {
-      document.body.appendChild(portalContainer);
-    }
-    return function removePortalContainer() {
-      portalContainer.remove();
-    };
-  }, [isMobile, showDetails, portalContainer]);
 
   return <Fragment>
     <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}>
@@ -39,15 +27,6 @@ const Route = ({
         destination={destination}
         vehicle={vehicle} />}
     </div>
-    {isMobile && showDetails && ReactDOM.createPortal(<MobileRouteDetails
-      id={id}
-      route={route}
-      origin={origin}
-      destination={destination}
-      vehicle={vehicle}
-      toggleDetails={toggleDetails}
-      openPreview={openPreview}
-    />, portalContainer)}
   </Fragment>;
 };
 

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -24,10 +24,6 @@ export default class RouteResult extends React.Component {
     routes: [],
   }
 
-  state = {
-    activeDetails: false,
-  }
-
   componentDidMount() {
     listen('select_road_map', routeId => {
       this.selectRoute(routeId);
@@ -55,15 +51,9 @@ export default class RouteResult extends React.Component {
     window.app.navigateTo('routes/' + search, {}, { replace: true });
   }
 
-  toggleRouteDetails = routeId => {
+  toggleRouteDetails = () => {
     Telemetry.add(Telemetry.ITINERARY_ROUTE_TOGGLE_DETAILS);
-    if (this.props.activeRouteId === routeId) {
-      this.setState(prevState => ({ activeDetails: !prevState.activeDetails }));
-    } else {
-      this.setState({
-        activeDetails: true,
-      });
-    }
+    this.props.toggleDetails();
   }
 
   openPreview = routeId => {
@@ -102,7 +92,7 @@ export default class RouteResult extends React.Component {
           origin={this.props.origin}
           destination={this.props.destination}
           vehicle={this.props.vehicle}
-          activeDetails={this.state.activeDetails}
+          activeDetails={this.props.activeDetails}
           toggleRouteDetails={this.toggleRouteDetails}
           openPreview={this.openPreview}
           selectRoute={this.selectRoute}


### PR DESCRIPTION
## Description
- Use `details` search param in place of state to know if route details should be displayed.
- Render MobileRouteDetails in DirectionPanel. A React Portal is not required anymore.

## Why
Simpler state management, and ability to use browser's history to navigate between app states.
