### PR TITLE
[Tests] Add integration tests for category/POI list

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -73,7 +73,7 @@ export default class CategoryPanel extends React.Component {
       return;
     }
 
-    if (window.map.mb.isMoving()) {
+    if (window.map.mb.isMoving && window.map.mb.isMoving()) {
       /*
         Do not trigger API search and zoom change when the map
         is already moving, to avoid flickering.

--- a/tests/integration/tests/poi_list.js
+++ b/tests/integration/tests/poi_list.js
@@ -1,0 +1,86 @@
+import { initBrowser, exists, isHidden, getInputValue } from '../tools';
+
+async function gotoRestaurantCategory(page) {
+  await page.goto(`${APP_URL}/places/?type=restaurant`);
+  await page.waitForSelector('.category__panel');
+}
+
+async function clickInputClearButton(page) {
+  // click either the mobile or desktop button, depending on which is visible
+  const handler = await Promise.race([
+    page.waitForSelector('#clear_button_mobile', { visible: true }),
+    page.waitForSelector('#clear_button_desktop', { visible: true }),
+  ]);
+  await handler.click();
+}
+
+let browser;
+let page;
+
+beforeAll(async () => {
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+});
+
+describe('Opening/closing', () => {
+  test('the category panel is opened via category button', async () => {
+    await page.goto(APP_URL);
+    await page.waitForSelector('.service_panel__categories .mainActionButton');
+    await page.click('.service_panel__categories .mainActionButton');
+    await page.waitFor(200);
+    expect(await exists(page, '.category__panel')).toBeTruthy();
+  });
+
+  test('the category panel is opened via direct url', async () => {
+    await page.goto(`${APP_URL}/places/?type=restaurant`);
+    expect(await exists(page, '.category__panel')).toBeTruthy();
+  });
+
+  test('the category panel is closed by navigating backwards', async () => {
+    await page.goto(APP_URL);
+    await page.waitForSelector('.service_panel__categories');
+    await page.click('.service_panel__categories .mainActionButton');
+    await page.waitForSelector('.category__panel');
+    await page.goBack();
+    expect(await isHidden(page, '.category_panel')).toBeTruthy();
+  });
+
+  test('the category panel is closed by clicking the search input clear button', async () => {
+    await gotoRestaurantCategory(page);
+    await clickInputClearButton(page);
+    expect(await isHidden(page, '.category_panel')).toBeTruthy();
+  });
+});
+
+describe('Search input content', () => {
+  test('the category name is displayed in the search input', async () => {
+    await gotoRestaurantCategory(page);
+    const searchValueInput = await getInputValue(page, '#search');
+    expect(searchValueInput).toEqual('Restaurant');
+  });
+
+  test('the category name is removed from the search input when closing the panel', async () => {
+    await gotoRestaurantCategory(page);
+    await clickInputClearButton(page);
+    const searchValueInput = await getInputValue(page, '#search');
+    expect(searchValueInput).toEqual('');
+  });
+});
+
+// @TODO:
+// Query in input (see autocomplete test)
+// Data fetching
+// PagesJaunes or not
+// Empty result/error cases
+// Click on map (POI, empty area, etc.)
+
+afterEach(async () => {
+  await page.close();
+});
+
+afterAll(async () => {
+  await browser.close();
+});


### PR DESCRIPTION
## Description
Add a new integration test suite for the POI list (aka. "category panel") feature, which wasn't tested at all for now (!).
For now let's start small by testing some "easy" things:
 - how the category panel is opened or closed
 - how the main input content is changed when the panel is active

In the next step, I'll try to test parts of the data logic, but this will probably require complex mocking of API and map, so let's do it separately.