### PR TITLE
Minimize all panels on user interaction on the map

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -51,7 +51,7 @@ export default class PanelManager extends React.Component {
     window.times.appRendered = Date.now();
 
     listen('map_user_interaction', () => {
-      if (this.state.ActivePanel === PoiPanel && isMobileDevice()) {
+      if (isMobileDevice()) {
         this.setState({ panelSize: 'minimized' });
       }
     });


### PR DESCRIPTION
## Description
Automatically minimize all the mobile panels when the user interacts with the map, like we already do with the POI panel.

## Why
Give the user the maximum screen space when they want to interact with the map. 