### PR TITLE
No white background on the route details button 

### DIFF
--- a/src/scss/includes/components/button.scss
+++ b/src/scss/includes/components/button.scss
@@ -16,7 +16,6 @@
   }
 
   &--secondary {
-    background-color: white;
     border: 1px solid $action-blue-base;
     color: $action-blue-base;
   }


### PR DESCRIPTION
## Description
Define a transparent background for the "secondary" button variant, as specified by the design system.
As a result, the "Details" button on the selected route summary (with a grey background) isn't white anymore when hovering.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran du 2020-11-24 15-54-17](https://user-images.githubusercontent.com/243653/100110949-db455880-2e6d-11eb-8e32-cfd9959a7b80.png)|![Capture d’écran du 2020-11-24 15-55-01](https://user-images.githubusercontent.com/243653/100110988-e304fd00-2e6d-11eb-8de3-113faa55dba1.png)|
