### PR TITLE
[Fix] Properly return to the previous POI when closing the DirectionPanel with the button

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -245,7 +245,7 @@ export default class DirectionPanel extends React.Component {
     const search = buildQueryString(queryObject);
     const relativeUrl = 'routes/' + search;
 
-    window.app.navigateTo(relativeUrl, {}, {
+    window.app.navigateTo(relativeUrl, window.history.state, {
       replace: true,
     });
   }

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -52,7 +52,7 @@ export default class RouteResult extends React.Component {
 
   updateUrl = queryObject => {
     const search = updateQueryString(queryObject);
-    window.app.navigateTo('routes/' + search, {}, { replace: true });
+    window.app.navigateTo('routes/' + search, window.history.state, { replace: true });
   }
 
   toggleRouteDetails = routeId => {


### PR DESCRIPTION
## Description
Make sure the current history state is re-used when we update the url to reflect changes in the DirectionPanel.

## Why
The behavior of the panel close button depends on the existence of a POI object passed to DirectionPanel through the history state and the router.
If we pass an empty state, we lose the `poi` prop the first time we update the url, so the panel believes it wasn't initialized with a POI and consider the close action to be a return to the Service panel.