### PR TITLE
Use geolocation suggestion in one input at most

### DIFF
--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -66,6 +66,8 @@ export default class DirectionForm extends React.Component {
       onSelectVehicle,
       originInputText,
       destinationInputText,
+      origin,
+      destination,
     } = this.props;
 
     return <div className="direction-form">
@@ -77,6 +79,7 @@ export default class DirectionForm extends React.Component {
             pointType="origin"
             onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
             ref={this.originRef}
+            withGeoloc={destination ? destination.type !== 'geoloc' : true}
           />
           <Divider paddingTop={0} paddingBottom={0} />
           <DirectionInput
@@ -85,6 +88,7 @@ export default class DirectionForm extends React.Component {
             pointType="destination"
             onChangePoint={(input, point) => this.onChangePoint('destination', input, point)}
             ref={this.destinationRef}
+            withGeoloc={origin ? origin.type !== 'geoloc' : true}
           />
         </div>
 

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -16,6 +16,11 @@ class DirectionInput extends React.Component {
     onChangePoint: PropTypes.func.isRequired,
     pointType: PropTypes.oneOf(['origin', 'destination']).isRequired,
     inputRef: PropTypes.object.isRequired,
+    withGeoloc: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    withGeoloc: true,
   }
 
   state = {
@@ -92,7 +97,7 @@ class DirectionInput extends React.Component {
   }
 
   render() {
-    const { pointType, inputRef, isLoading } = this.props;
+    const { pointType, inputRef, isLoading, withGeoloc } = this.props;
     const { mounted, readOnly } = this.state;
 
     return (
@@ -126,7 +131,7 @@ class DirectionInput extends React.Component {
             <Suggest
               inputNode={inputRef.current}
               outputNode={document.getElementById('direction-autocomplete_suggestions')}
-              withGeoloc
+              withGeoloc={withGeoloc}
               onSelect={this.selectItem}
               onClear={this.clear}
             />


### PR DESCRIPTION
## Description
In direction suggestions, offer geolocation suggestion only once, as it makes no sense to use geolocation as both origin and destination.

## Why
UX improvement

## Screenshots
![image](https://user-images.githubusercontent.com/2981774/100246054-021c9100-2f39-11eb-99f7-9b2ea852dffd.png)
