### PR TITLE
Add shortcuts to main categories on all types of POI panel 

### DIFF
--- a/src/panel/poi/PoiBlockContainer.jsx
+++ b/src/panel/poi/PoiBlockContainer.jsx
@@ -38,23 +38,24 @@ export default class PoiBlockContainer extends React.Component {
       ? informationBlock.blocks.find(b => b.type === 'wikipedia')
       : null;
 
+    const hasAddressBlock = this.props.poi.address && this.props.poi.subClassName !== 'latlon';
+    const hasDetailBlocks = hasAddressBlock
+    || websiteBlock
+    || informationBlock
+    || phoneBlock
+    || hourBlock
+    || recyclingBlock
+    || contactBlock;
+
     return <div className="poi_panel__info">
-      {wikipedia && <WikiBlock block={wikipedia} />}
+      {wikipedia && <div className="u-mb-m"><WikiBlock block={wikipedia} /></div>}
       {displayCovidInfo &&
         <CovidBlock block={covidBlock} countryCode={this.props.poi.address.country_code} />}
-      <Divider />
-      {
-        (
-          (this.props.poi.address && this.props.poi.subClassName !== 'latlon')
-          || websiteBlock
-          || informationBlock
-          || phoneBlock
-          || hourBlock
-          || recyclingBlock
-          || contactBlock
-        ) && <h3 className="u-text--smallTitle">{_('Information')}</h3>
-      }
-      {this.props.poi.address && this.props.poi.subClassName !== 'latlon' &&
+      {hasDetailBlocks && <>
+        <Divider paddingTop={0} />
+        <h3 className="u-text--smallTitle">{_('Information')}</h3>
+      </>}
+      {hasAddressBlock &&
         <Block className="block-address" icon="map-pin" title={_('address')}>
           <Address inline address={this.props.poi.address} omitCountry />
         </Block>

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -17,7 +17,7 @@ import { addToFavorites, removeFromFavorites, isInFavorites } from 'src/adapters
 import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
 import { DeviceContext } from 'src/libs/device';
-import { Flex, Panel, PanelNav, CloseButton } from 'src/components/ui';
+import { Flex, Panel, PanelNav, CloseButton, Divider } from 'src/components/ui';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -265,7 +265,7 @@ export default class PoiPanel extends React.Component {
               />
               <CloseButton onClick={isMobile ? backAction : this.closeAction} position="topRight" />
             </Flex>
-            <div className="u-mb-xs">
+            <div className="u-mb-l">
               <ActionButtons
                 poi={poi}
                 isDirectionActive={this.isDirectionActive}
@@ -278,18 +278,17 @@ export default class PoiPanel extends React.Component {
             <div className="poi_panel__fullContent">
               <PoiBlockContainer poi={poi} covid19Enabled={covid19Enabled} />
               {isFromPagesJaunes(poi) &&
-              <div className="poi_panel__info-partnership u-text--caption">
+              <div className="poi_panel__info-partnership u-text--caption u-mb-s">
                 {_('In partnership with')}
                 <img src="./statics/images/pj.svg" alt="PagesJaunes" width="80" height="16" />
               </div>
               }
-              {poi.id.match(/latlon:/) && <div className="service_panel__categories--poi">
-                <h3 className="u-text--smallTitle">
-                  {_('Search around this place', 'poi')}
-                </h3>
-                <CategoryList />
-              </div>}
               {isFromOSM(poi) && <OsmContribution poi={poi} />}
+              <Divider paddingTop={0} className="poi_panel__fullWidthDivider" />
+              <h3 className="u-text--smallTitle u-mb-s">
+                {_('Search around this place', 'poi')}
+              </h3>
+              <CategoryList className="poi_panel__categories u-mb-s" limit={4} />
             </div>
           </div>
         </Panel>

--- a/src/scss/includes/components/panelNav.scss
+++ b/src/scss/includes/components/panelNav.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   &-content {
-    padding: 0 20px;
+    padding: 0 $spacing-xxs;
     height: 100%;
   }
 }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -13,8 +13,13 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
 .poi_panel__content {
   animation: appear 600ms forwards;
-  padding: 20px 30px 10px 30px;
+  padding: 20px 14px 0;
   position: relative;
+
+  .poi_panel__fullWidthDivider {
+    margin-left: -14px;
+    margin-right: -14px;
+  }
 }
 
 @keyframes appear {
@@ -188,12 +193,9 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   content: '';
 }
 
-.service_panel__categories--poi {
-  margin-bottom: 12px;
-
+.poi_panel__categories {
   .mainActionButton {
     width: 25%;
-    margin: 5px 0 15px 0;
   }
 }
 
@@ -207,7 +209,12 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
 @media (max-width: 640px) {
   .poi_panel__content {
-    padding: 0 12px 12px;
+    padding: 0 $spacing-s;
+
+    .poi_panel__fullWidthDivider {
+      margin-left: -$spacing-s;
+      margin-right: -$spacing-s;
+    }
   }
 
   .poi_panel.panel {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -13,7 +13,7 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
 .poi_panel__content {
   animation: appear 600ms forwards;
-  padding: 20px 14px 0;
+  padding: $spacing-l 14px 0;
   position: relative;
 
   .poi_panel__fullWidthDivider {


### PR DESCRIPTION
## Description
Instead of displaying the full list of categories at the bottom of the "address" POI panel, we now display the first four only but on all types of POI panels (address, POI from OSM or PJ, mobile or desktop).

Adding the categories themselves was the easy part thanks to the `CategoryList` component, but other things had to be adjusted to fit the design.
As part of these changes, the padding of the desktop POI panel was finally reduced to match the design. Until now it was the only one still having a large horizontal padding value. Now it should look more consistent with other parts of the application.

## Screenshots

|Before|After|
|---|---|
|![Capture d’écran 2020-11-26 à 14 36 14](https://user-images.githubusercontent.com/243653/100357365-dd85ef00-2ff4-11eb-9110-e80687f5a899.png)|![Capture d’écran 2020-11-26 à 14 35 49](https://user-images.githubusercontent.com/243653/100357381-e676c080-2ff4-11eb-9587-cbb591460548.png)|
|![Capture d’écran 2020-11-26 à 14 40 42](https://user-images.githubusercontent.com/243653/100357759-643acc00-2ff5-11eb-9acc-397b69a2cba8.png)|![Capture d’écran 2020-11-26 à 14 40 49](https://user-images.githubusercontent.com/243653/100357765-66048f80-2ff5-11eb-9cbd-3f956c9c43b2.png)|
|![Capture d’écran 2020-11-26 à 14 43 35](https://user-images.githubusercontent.com/243653/100358299-4752c880-2ff6-11eb-806e-97f43efdd562.png)|![Capture d’écran 2020-11-26 à 14 43 25](https://user-images.githubusercontent.com/243653/100358310-4e79d680-2ff6-11eb-8dcf-2f0def584905.png)|
