### PR TITLE
Qmaps 1763: Display missing address in roadmap

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -131,7 +131,8 @@ export default class DirectionPanel extends React.Component {
   }
 
   async setTextInput(which, poi) {
-    if (poi.type === 'latlon') {
+    if (!poi.address || Object.keys(poi.address).length === 0) {
+      // fetch missing address
       poi.address = await address.fetch(poi);
     }
     this.setState({ [which + 'InputText']: getInputValue(poi) });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -24,6 +24,7 @@ import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
 import { parseQueryString, buildQueryString, updateQueryString } from 'src/libs/url_utils';
 import MobileRouteDetails from './MobileRouteDetails';
+import { isNullOrEmpty } from 'src/libs/object';
 
 const MARGIN_TOP_OFFSET = 64; // reserve space to display map
 
@@ -131,7 +132,7 @@ export default class DirectionPanel extends React.Component {
   }
 
   async setTextInput(which, poi) {
-    if (!poi.address || Object.keys(poi.address).length === 0) {
+    if (isNullOrEmpty(poi.address)) {
       // fetch missing address
       poi.address = await address.fetch(poi);
     }

--- a/src/panel/direction/RoadMapPoint.jsx
+++ b/src/panel/direction/RoadMapPoint.jsx
@@ -16,7 +16,7 @@ const RoadMapPoint = ({ point, ...rest }) => {
       <div className="u-text--subtitle">
         <Address
           address={address}
-          omitStreet={type === 'house' || type === 'street'}
+          omitStreet={type === 'house' || type === 'street' || type === 'latlon'}
           omitCountry
           inline
         />

--- a/src/panel/direction/RoadMapPoint.jsx
+++ b/src/panel/direction/RoadMapPoint.jsx
@@ -12,7 +12,7 @@ const RoadMapPoint = ({ point, ...rest }) => {
     {...rest}
   >
     <div className="u-text--smallTitle">{getInputValue(point)}</div>
-    {type !== 'latlon' && type !== 'geoloc' &&
+    {type !== 'geoloc' &&
       <div className="u-text--subtitle">
         <Address
           address={address}


### PR DESCRIPTION
## Description
- Fetch address if it's missing when setting a new origin/destination point. In some cases, like when clicking on the map to set a point, address is undefined (type `MapPoint`).
- Decide to display latlon poi, as they should have an address object too.

## Why
better UX as it can be considered as a bug.

## Screenshots

Setting a destination point from the map :
![Peek 2020-11-27 10-33](https://user-images.githubusercontent.com/2981774/100433940-14fba680-309c-11eb-9413-3f50419e9a8e.gif)

From a POI panel :
![Peek 2020-11-27 10-34](https://user-images.githubusercontent.com/2981774/100434012-26dd4980-309c-11eb-8d8a-c35eb8167cbe.gif)

