### PR TITLE
Simplify URL params management in DirectionPanel

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -65,10 +65,3 @@ export function buildQueryString(queriesObject) {
   const params = new URLSearchParams(removeNullEntries(queriesObject)).toString();
   return params ? `?${params}` : '';
 }
-
-export function updateQueryString(queriesObject) {
-  return buildQueryString({
-    ...parseQueryString(window.location.search),
-    ...queriesObject,
-  });
-}

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -65,3 +65,10 @@ export function buildQueryString(queriesObject) {
   const params = new URLSearchParams(removeNullEntries(queriesObject)).toString();
   return params ? `?${params}` : '';
 }
+
+export function updateQueryString(queriesObject) {
+  return buildQueryString({
+    ...parseQueryString(window.location.search),
+    ...queriesObject,
+  });
+}

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -151,6 +151,7 @@ export default class PanelManager extends React.Component {
       router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
         const params = parseQueryString(routeParams);
         params.details = params.details === 'true';
+        params.activeRouteId = Number(params.selected);
         this.setState({
           ActivePanel: DirectionPanel,
           options: { ...params, ...options, isPublicTransportActive },

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -151,7 +151,7 @@ export default class PanelManager extends React.Component {
       router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
         const params = parseQueryString(routeParams);
         params.details = params.details === 'true';
-        params.activeRouteId = Number(params.selected);
+        params.activeRouteId = Number(params.selected) || 0;
         this.setState({
           ActivePanel: DirectionPanel,
           options: { ...params, ...options, isPublicTransportActive },

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -149,9 +149,11 @@ export default class PanelManager extends React.Component {
         || parseQueryString(document.location.search)['pt'] === 'true';
 
       router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
+        const params = parseQueryString(routeParams);
+        params.details = params.details === 'true';
         this.setState({
           ActivePanel: DirectionPanel,
-          options: { ...parseQueryString(routeParams), ...options, isPublicTransportActive },
+          options: { ...params, ...options, isPublicTransportActive },
           panelSize: 'default',
         });
       });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -22,7 +22,7 @@ import { getInputValue } from 'src/libs/suggest';
 import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolocation';
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
-import { parseQueryString, buildQueryString, updateQueryString } from 'src/libs/url_utils';
+import { parseQueryString, buildQueryString } from 'src/libs/url_utils';
 import MobileRouteDetails from './MobileRouteDetails';
 import { isNullOrEmpty } from 'src/libs/object';
 
@@ -125,8 +125,7 @@ export default class DirectionPanel extends React.Component {
 
     if (this.props.activeRouteId !== prevProps.activeRouteId && this.state.routes.length > 0) {
       fire('set_main_route', { routeId: this.sanitizeSelected(), fitView: !isMobileDevice() });
-      const search = updateQueryString({ details: null });
-      window.app.navigateTo('routes/' + search, history.state, { replace: false });
+      this.updateUrl({ details: null });
     }
   }
 
@@ -330,8 +329,7 @@ export default class DirectionPanel extends React.Component {
   }
 
   toggleDetails() {
-    const search = updateQueryString({ details: !this.props.details });
-    window.app.navigateTo('routes/' + search, {}, { replace: false });
+    this.updateUrl({ details: this.props.details ? null : true });
   }
 
   sanitizeSelected() {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -22,7 +22,7 @@ import { getInputValue } from 'src/libs/suggest';
 import { geolocationPermissions, getGeolocationPermission } from 'src/libs/geolocation';
 import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import ShareMenu from 'src/components/ui/ShareMenu';
-import { parseQueryString, buildQueryString } from 'src/libs/url_utils';
+import { updateQueryString } from 'src/libs/url_utils';
 import MobileRouteDetails from './MobileRouteDetails';
 import { isNullOrEmpty } from 'src/libs/object';
 
@@ -242,16 +242,13 @@ export default class DirectionPanel extends React.Component {
   }
 
   updateUrl(params = {}, replace = false) {
-    const queryObject = {
-      ...parseQueryString(window.location.search),
+    const search = updateQueryString({
       mode: this.state.vehicle,
       origin: this.state.origin ? poiToUrl(this.state.origin) : null,
       destination: this.state.destination ? poiToUrl(this.state.destination) : null,
       pt: this.props.isPublicTransportActive ? 'true' : null,
       ...params,
-    };
-
-    const search = buildQueryString(queryObject);
+    });
     const relativeUrl = 'routes/' + search;
 
     window.app.navigateTo(relativeUrl, window.history.state, { replace });

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -124,7 +124,7 @@ export default class DirectionPanel extends React.Component {
     }
 
     if (this.props.activeRouteId !== prevProps.activeRouteId && this.state.routes.length > 0) {
-      fire('set_main_route', { routeId: this.sanitizeSelected(), fitView: !isMobileDevice() });
+      fire('set_main_route', { routeId: this.props.activeRouteId, fitView: !isMobileDevice() });
       this.updateUrl({ details: null });
     }
   }
@@ -217,7 +217,8 @@ export default class DirectionPanel extends React.Component {
           .map((route, i) => ({ ...route, id: i }));
 
         this.setState({ isLoading: false, error: 0, routes }, () => {
-          const activeRouteId = this.sanitizeSelected();
+          const activeRouteId = this.props.activeRouteId < this.state.routes.length
+            ? this.props.activeRouteId : 0;
           window.execOnMapLoaded(() => {
             fire('set_routes', { routes, vehicle, activeRouteId });
           });
@@ -332,10 +333,6 @@ export default class DirectionPanel extends React.Component {
     this.updateUrl({ details: this.props.details ? null : true });
   }
 
-  sanitizeSelected() {
-    return this.props.activeRouteId < this.state.routes.length ? this.props.activeRouteId : 0;
-  }
-
   render() {
     const {
       origin, destination, vehicle,
@@ -345,8 +342,7 @@ export default class DirectionPanel extends React.Component {
       marginTop,
     } = this.state;
 
-    const activeRouteId = this.sanitizeSelected();
-    const activeDetails = this.props.details;
+    const { activeRouteId, details: activeDetails } = this.props;
 
     const title = <h3 className="direction-title u-text--title u-firstCap">
       {_('calculate an itinerary', 'direction')}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -35,6 +35,7 @@ export default class DirectionPanel extends React.Component {
     poi: PropTypes.object,
     mode: PropTypes.string,
     isPublicTransportActive: PropTypes.bool,
+    details: PropTypes.bool,
   }
 
   constructor(props) {
@@ -119,7 +120,7 @@ export default class DirectionPanel extends React.Component {
 
     if (this.props.selected !== prevProps.selected && this.state.routes.length > 0) {
       fire('set_main_route', { routeId: this.sanitizeSelected(), fitView: !isMobileDevice() });
-      const search = updateQueryString({ details: false });
+      const search = updateQueryString({ details: null });
       window.app.navigateTo('routes/' + search, {}, { replace: false });
     }
   }
@@ -328,8 +329,7 @@ export default class DirectionPanel extends React.Component {
   }
 
   toggleDetails() {
-    const isDetailsInQuery = this.props.details === 'true';
-    const search = updateQueryString({ details: !isDetailsInQuery });
+    const search = updateQueryString({ details: !this.props.details });
     window.app.navigateTo('routes/' + search, {}, { replace: false });
   }
 
@@ -352,7 +352,7 @@ export default class DirectionPanel extends React.Component {
     } = this.state;
 
     const activeRouteId = this.sanitizeSelected();
-    const isDetailsInQuery = this.props.details === 'true';
+    const activeDetails = this.props.details;
 
     const title = <h3 className="direction-title u-text--title u-firstCap">
       {_('calculate an itinerary', 'direction')}
@@ -376,7 +376,7 @@ export default class DirectionPanel extends React.Component {
     const result =
       <RouteResult
         activeRouteId={activeRouteId}
-        activeDetails={isDetailsInQuery}
+        activeDetails={activeDetails}
         isLoading={isLoading || routes.length > 0 && isDirty}
         vehicle={vehicle}
         error={error}
@@ -444,7 +444,7 @@ export default class DirectionPanel extends React.Component {
             onClose={this.onClose}
           />}
 
-          {!activePreviewRoute && isMobile && isDetailsInQuery && activeRouteId >= 0 &&
+          {!activePreviewRoute && isMobile && activeDetails && activeRouteId >= 0 &&
             this.state.routes.length > 0 &&
             <MobileRouteDetails
               id={activeRouteId}

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -218,9 +218,11 @@ export default class DirectionPanel extends React.Component {
           .map((route, i) => ({ ...route, id: i }));
 
         this.setState({ isLoading: false, error: 0, routes }, () => {
+          const activeRouteId = this.sanitizeSelected();
           window.execOnMapLoaded(() => {
-            fire('set_routes', { routes, vehicle, activeRouteId: this.sanitizeSelected() });
+            fire('set_routes', { routes, vehicle, activeRouteId });
           });
+          this.updateUrl({ selected: activeRouteId }, true);
         });
       } else {
         // Error or empty response
@@ -239,25 +241,24 @@ export default class DirectionPanel extends React.Component {
     }
   }
 
-  updateUrl() {
+  updateUrl(params = {}, replace = false) {
     const queryObject = {
       ...parseQueryString(window.location.search),
       mode: this.state.vehicle,
       origin: this.state.origin ? poiToUrl(this.state.origin) : null,
       destination: this.state.destination ? poiToUrl(this.state.destination) : null,
       pt: this.props.isPublicTransportActive ? 'true' : null,
+      ...params,
     };
 
     const search = buildQueryString(queryObject);
     const relativeUrl = 'routes/' + search;
 
-    window.app.navigateTo(relativeUrl, window.history.state, {
-      replace: true,
-    });
+    window.app.navigateTo(relativeUrl, window.history.state, { replace });
   }
 
   update() {
-    this.updateUrl();
+    this.updateUrl({}, true);
     this.computeRoutes();
     this.context.setSize('default');
   }
@@ -380,6 +381,7 @@ export default class DirectionPanel extends React.Component {
         destination={destination}
         toggleDetails={() => this.toggleDetails()}
         openMobilePreview={() => this.openMobilePreview(routes[activeRouteId])}
+        selectRoute={routeId => this.updateUrl({ selected: routeId })}
       />;
 
     const isFormCompleted = origin && destination;

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { listen } from 'src/libs/customEvents';
-import { updateQueryString } from 'src/libs/url_utils';
 import Telemetry from 'src/libs/telemetry';
 
 import RoutesList from './RoutesList';
@@ -18,6 +17,8 @@ export default class RouteResult extends React.Component {
     error: PropTypes.number,
     openMobilePreview: PropTypes.func.isRequired,
     activeRouteId: PropTypes.number,
+    selectRoute: PropTypes.func.isRequired,
+    toggleDetails: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -30,25 +31,13 @@ export default class RouteResult extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.routes.length !== prevProps.routes.length) {
-      this.updateUrl({ selected: this.props.activeRouteId });
-    }
-  }
-
   selectRoute = routeId => {
     if (routeId === this.props.activeRouteId) {
       return;
     }
 
     Telemetry.add(Telemetry.ITINERARY_ROUTE_SELECT);
-
-    this.updateUrl({ selected: routeId });
-  }
-
-  updateUrl = queryObject => {
-    const search = updateQueryString(queryObject);
-    window.app.navigateTo('routes/' + search, window.history.state, { replace: true });
+    this.props.selectRoute(routeId);
   }
 
   toggleRouteDetails = () => {


### PR DESCRIPTION
## Description
Following recent additions to the URL scheme controlling the behavior of the DirectionPanel, this PR proposes some simplifications in the manipulation of query params and routes by this component.

1. The immediate parsing of `details` and `selected` is done outside of the `DirectionPanel`. It receives these as props with the correct type and can only focus on the consistency checks
2. The number of places where we directly change URL is reduces, and it's done only in the top component. That way it's easier to track and keep consistent with the internal state of the panel.

What do you think @G-Ray?
