### PR TITLE
Direction details: replace url conditionnally

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -327,7 +327,8 @@ export default class DirectionPanel extends React.Component {
   }
 
   toggleDetails() {
-    this.updateUrl({ details: this.props.details ? null : true });
+    const isDetailsInQuery = this.props.details;
+    this.updateUrl({ details: this.props.details ? null : true }, isDetailsInQuery);
   }
 
   render() {


### PR DESCRIPTION
## Description
- replace url only when details view is closing. This way, the "back" button on mobile can be used to go back to the previous state, where details view was previously closed, meanwhile we avoid "pushing" indefinetely into the history.

However, the back button will have no effect if the user opens a url already containing `details=true` search param. Do you have any idea to improve this behavior ?

## Why
Improve UX