### PR TITLE
Refactor Suggest: callback when suggestions open/close

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -6,7 +6,6 @@ import { bool, string, func, object } from 'prop-types';
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, selectItem, modifyList } from 'src/libs/suggest';
 import { DeviceContext } from 'src/libs/device';
-import { togglePanelVisibility } from 'src/libs/panel';
 
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
@@ -17,7 +16,7 @@ const Suggest = ({
   withGeoloc,
   onSelect = selectItem,
   onClear,
-  hidePanelOnOpen,
+  onToggleSuggestions,
   className,
 }) => {
   const [items, setItems] = useState([]);
@@ -32,10 +31,10 @@ const Suggest = ({
   };
 
   useEffect(() => {
-    if (hidePanelOnOpen) {
-      togglePanelVisibility(!isOpen);
+    if (onToggleSuggestions) {
+      onToggleSuggestions(isOpen);
     }
-  }, [isOpen, hidePanelOnOpen]);
+  }, [isOpen, onToggleSuggestions]);
 
   useEffect(() => {
     let currentQuery = null;
@@ -151,7 +150,7 @@ Suggest.propTypes = {
   withGeoloc: bool,
   onSelect: func,
   onClear: func,
-  hidePanelOnOpen: bool,
+  onToggleSuggestions: func,
   className: string,
 };
 

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -5,6 +5,7 @@ import PanelManager from 'src/panel/PanelManager';
 import Suggest from 'src/components/ui/Suggest';
 import { isMobileDevice, mobileDeviceMediaQuery, DeviceContext } from 'src/libs/device';
 import { fire } from 'src/libs/customEvents';
+import { togglePanelVisibility } from 'src/libs/panel';
 
 const MenuComponent = ({ isMobile }) =>
   isMobile
@@ -40,7 +41,7 @@ const RootComponent = ({
       inputNode={searchBarInputNode}
       outputNode={document.querySelector('.search_form__result')}
       withCategories
-      hidePanelOnOpen
+      onToggleSuggestions={suggestionsOpened => { togglePanelVisibility(!suggestionsOpened); }}
     />
   </DeviceContext.Provider>;
 };


### PR DESCRIPTION
## Description
A small refacto on the `Suggest` component to make it more generic.
Instead of taking a prop to hide the main UI panel when suggestions are open and call this very specific action directly in `Suggest`, take a callback which sends the suggestions visibility state, so any action can be implemented by the parent.

## Why
I will need to listen to this on the `Suggest` instances used by the `DirectionPanel`, so I need something more generic than `hidePanelOnOpen`.
This also reduces coupling across hi-level and lo-level components. 