### PR TITLE
sendPoiEvent: check if meta.source exist

### DIFF
--- a/src/libs/telemetry.js
+++ b/src/libs/telemetry.js
@@ -64,6 +64,10 @@ function buildInteractionData({ source, template, id, zone, element, category })
 }
 
 function sendPoiEvent(poi, event, data) {
+  if (!poi.meta || !poi.meta.source) {
+    return;
+  }
+
   const eventName = `poi_${poi.meta?.source}_${event}`.toUpperCase();
   return add(events[eventName], data);
 }


### PR DESCRIPTION
## Description
Before sending a poi event, check if poi.meta.source exists. This property does not exist in case of a `latlon` poi for instance.

This raises a question about our metrics about pois. Should we still send info about a this type of poi which do not contain meta.source ?