### PR TITLE
Routes step-by-step: map elements UI

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -126,6 +126,7 @@ export default class DirectionPanel extends React.Component {
     if (this.props.activeRouteId !== prevProps.activeRouteId && this.state.routes.length > 0) {
       fire('set_main_route', { routeId: this.props.activeRouteId, fitView: !isMobileDevice() });
       this.updateUrl({ details: null });
+      this.setState({ activePreviewRoute: null });
     }
   }
 

--- a/src/panel/direction/MobileRoadMapPreview.jsx
+++ b/src/panel/direction/MobileRoadMapPreview.jsx
@@ -17,6 +17,11 @@ export default class MobileRoadMapPreview extends React.Component {
   componentDidMount() {
     this.zoomToCurrentStep();
     fire('move_mobile_geolocation_button', 65);
+    document.body.classList.add('directions-stepByStep');
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove('directions-stepByStep');
   }
 
   zoomToCurrentStep = () => {

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -116,3 +116,7 @@
     }
   }
 }
+
+.directions-stepByStep .routeLabel {
+  display: none;
+}


### PR DESCRIPTION
## Description
Two improvements on the step-by-step mode:
 - hide the route labels
 - keep the alternative routes displayed on the map view but switch to it and exit the step-by-step mode if the user clicks on of them. 