### PR TITLE
Set cursor position to end on focus

### DIFF
--- a/src/libs/input.js
+++ b/src/libs/input.js
@@ -1,0 +1,15 @@
+import { isMobileDevice } from 'src/libs/device';
+
+export function handleFocus(e) {
+  const input = e.target;
+
+  if (isMobileDevice()) {
+    // on mobile, position cursor at the end of the text input
+    const setCursorToEnd = () => {
+      const pos = input.value.length;
+      input.setSelectionRange(pos, pos);
+    };
+
+    setTimeout(setCursorToEnd, 0);
+  }
+}

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -8,6 +8,7 @@ import Error from 'src/adapters/error';
 import { fire } from 'src/libs/customEvents';
 import { fetchSuggests } from 'src/libs/suggest';
 import Telemetry from 'src/libs/telemetry';
+import { handleFocus } from 'src/libs/input';
 
 class DirectionInput extends React.Component {
   static propTypes = {
@@ -97,7 +98,7 @@ class DirectionInput extends React.Component {
   }
 
   render() {
-    const { pointType, inputRef, isLoading, withGeoloc } = this.props;
+    const { pointType, inputRef, isLoading, withGeoloc, value } = this.props;
     const { mounted, readOnly } = this.state;
 
     return (
@@ -113,10 +114,11 @@ class DirectionInput extends React.Component {
             placeholder={pointType === 'origin'
               ? _('Enter a starting point', 'direction')
               : _('Enter an end point', 'direction')}
-            value={this.props.value}
+            value={value}
             onChange={this.onChange}
             onKeyPress={this.onKeyPress}
             readOnly={readOnly || isLoading}
+            onFocus={handleFocus}
           />
           <div className="direction-icon-block">
             <div className={`direction-icon direction-icon-${pointType}`}/>

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -2,6 +2,8 @@
 import { selectItem, fetchSuggests } from 'src/libs/suggest';
 import Telemetry from 'src/libs/telemetry';
 
+import { handleFocus } from '../libs/input';
+
 const MAPBOX_RESERVED_KEYS = [
   'ArrowLeft', // ←
   'ArrowUp', // ↑
@@ -27,6 +29,8 @@ export default class SearchInput {
     }
 
     window.__searchInput = new SearchInput(tagSelector);
+
+    window.__searchInput.searchInputHandle.addEventListener('focus', handleFocus);
 
     window.clearSearch = (e, blur = false) => {
       e.preventDefault(); // Prevent losing focus


### PR DESCRIPTION
## Description
On mobile, on focus, set cursor at the end of the input content.
- Define a handleFocus function in libs to be used across react/non-react code.
- Use handleFocus in directionInput and in the search bar.

## Why
UX

## Screenshots
![Peek 2020-12-02 17-39](https://user-images.githubusercontent.com/2981774/100902685-67d2c500-34c5-11eb-91c6-535410c55e5b.gif)

