### PR TITLE
Fix error and inconsistent state when clearing route point with Esc

### DIFF
--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -90,6 +90,10 @@ class DirectionInput extends React.Component {
 
   clear = e => {
     e.preventDefault(); // prevent losing focus
+    this.removePoint();
+  }
+
+  removePoint = () => {
     this.props.onChangePoint('', null);
     this.props.inputRef.current.value = '';
     // Trigger an input event to refresh Suggest's state
@@ -133,7 +137,7 @@ class DirectionInput extends React.Component {
               outputNode={document.getElementById('direction-autocomplete_suggestions')}
               withGeoloc={withGeoloc}
               onSelect={this.selectItem}
-              onClear={this.clear}
+              onClear={this.removePoint}
             />
         }
       </div>


### PR DESCRIPTION
## Description
Fix a JS error that happens when using the 'Esc' key on a direction point input after a route has already been computed.
The error caused a console message and an inconsistent UI state: the input was cleared, the suggestions were displayed, but the route itself was still displayed below and on the map, because the point object wasn't removed from the DirectionPanel state as it should have.

![Capture d’écran de 2020-12-03 15-31-03](https://user-images.githubusercontent.com/243653/101041077-98c20100-357c-11eb-9008-8f4697ba5bdc.png)

At first I proposed going beyong this simple bug fix and also changing the behavior of the `Esc` on input.
IMO it should close the suggest dropdown and blur the field, but not clear the input. The design team seems to be ok with that according to the Design System, but this has complex UX implications for us so let's just explore the subject in itself later.