### PR TITLE
Tweak search bar to show back button on focus only

### DIFF
--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -322,14 +322,13 @@ input[type="search"] {
   }
 
   .search_form__return {
+    display: none;
     font-size: 20px;
     text-align: center;
     color: #0c0c0e;
     margin-right: 8px;
     cursor: pointer;
 
-    display: block;
-    opacity: 0;
     position: absolute;
     transition: opacity .15s;
     top: 0;
@@ -369,6 +368,10 @@ input[type="search"] {
   // When the search field is filled
   .top_bar--search_filled {
 
+    .search_form__wrapper {
+      padding: 0 0 0 $spacing-s;
+    }
+
     // Show mobile clear X button
     #clear_button_mobile {
       display: block;
@@ -381,10 +384,19 @@ input[type="search"] {
 
   // When the search field is focused (empty or not)
   .top_bar--search_focus {
+    .search_form__wrapper {
+      padding: 0  0 0 30px;
+    }
+
 
     .search_form__input::placeholder {
       color: $grey-semi-darkness;
       opacity: 1;
+    }
+
+    // Show return arrow
+    .search_form__return {
+      display: block;
     }
   }
 
@@ -406,12 +418,6 @@ input[type="search"] {
     .search_form__wrapper {
       left: 10px;
       width: calc(100% - 20px);
-      padding: 0 0 0 30px;
-    }
-
-    // Show return arrow
-    .search_form__return {
-      opacity: 1;
     }
 
     // Hide magnifying glass

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -45,7 +45,7 @@
         <div class="search_form__logo"></div>
         <div id="react_menu__container"></div>
         <div class="search_form__wrapper empty">
-          <div class="search_form__return icon-arrow-left" onmousedown="clearSearch(event, true)"></div>
+          <div class="search_form__return icon-arrow-left"></div>
           <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
           <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)" title="<%= _('Clear', 'search bar') %>"></button>
           <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">


### PR DESCRIPTION
## Description
On mobile, display back button only when the search input is focus.

## Why
UX improvements

## Screenshots
![Peek 2020-12-04 11-06](https://user-images.githubusercontent.com/2981774/101150638-d24c4800-3620-11eb-8cec-e19c97354e87.gif)

