### PR TITLE
[Tests] Run integration suite on desktop and mobile devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "bench": "node ./bench/performances.js",
     "unit-test": "jest --config=./tests/unit.js",
-    "integration-test": "jest --config=./tests/integration.js",
+    "integration-test-mobile": "TEST_DEVICE=mobile jest --config=./tests/integration.js",
+    "integration-test-desktop": "TEST_DEVICE=desktop jest --config=./tests/integration.js",
+    "integration-test": "npm run integration-test-mobile && npm run integration-test-desktop",
     "test": "npm run unit-test && npm run integration-test",
     "start": "node bin/index.js",
     "build": "webpack --config build/webpack.config.js",

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,11 +1,12 @@
 const config = require('./integration/test_config');
+const { getIgnorePatterns } = require('./integration/device');
 
 module.exports = {
   setupFilesAfterEnv: ['jest-extended'],
   testMatch: [`${__dirname}/integration/tests/*.js`],
   globalSetup: `${__dirname}/integration/server_start.js`,
   globalTeardown: `${__dirname}/integration/server_close.js`,
-  testPathIgnorePatterns: ['/node_modules/'],
+  testPathIgnorePatterns: ['/node_modules/'].concat(getIgnorePatterns(process.env.TEST_DEVICE)),
   'rootDir': __dirname + '/../',
   'verbose': true,
   'collectCoverage': false,

--- a/tests/integration/device.js
+++ b/tests/integration/device.js
@@ -1,0 +1,26 @@
+
+const viewports = {
+  mobile: {
+    width: 400,
+    height: 800,
+    hasTouch: true,
+  },
+};
+
+const ignorePatterns = {
+  mobile: ['.desktop.'],
+  desktop: ['.mobile.'],
+};
+
+function getPupeeterViewport(deviceName) {
+  return viewports[deviceName] || null;
+}
+
+function getIgnorePatterns(deviceName) {
+  return ignorePatterns[deviceName] || [];
+}
+
+module.exports = {
+  getPupeeterViewport,
+  getIgnorePatterns,
+};

--- a/tests/integration/device.js
+++ b/tests/integration/device.js
@@ -6,6 +6,10 @@ const viewports = {
     hasTouch: true,
     isMobile: true,
   },
+  desktop: {
+    width: 800,
+    height: 600,
+  },
 };
 
 const ignorePatterns = {

--- a/tests/integration/device.js
+++ b/tests/integration/device.js
@@ -4,6 +4,7 @@ const viewports = {
     width: 400,
     height: 800,
     hasTouch: true,
+    isMobile: true,
   },
 };
 

--- a/tests/integration/tests/autocomplete.desktop.js
+++ b/tests/integration/tests/autocomplete.desktop.js
@@ -1,0 +1,81 @@
+import { clearStore, initBrowser, getMapView, exists } from '../tools';
+import AutocompleteHelper from '../helpers/autocomplete';
+import ResponseHandler from '../helpers/response_handler';
+const configBuilder = require('@qwant/nconf-builder');
+const config = configBuilder.get_without_check();
+
+const SUGGEST_MAX_ITEMS = config.services.geocoder.maxItems;
+
+let browser;
+let page;
+let autocompleteHelper;
+let responseHandler;
+const mockAutocomplete = require('../../__data__/autocomplete.json');
+const mockAutocompleteAllTypes = require('../../__data__/autocomplete_type.json');
+const mockPoi = require('../../__data__/poi.json');
+
+beforeAll(async () => {
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+  autocompleteHelper = new AutocompleteHelper(page);
+  responseHandler = new ResponseHandler(page);
+  await responseHandler.prepareResponse();
+  responseHandler.addPreparedResponse(mockPoi, /places\/*/);
+});
+
+test('search and clear', async () => {
+  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
+  await page.goto(APP_URL);
+  await autocompleteHelper.typeAndWait('Hello');
+  expect(await exists(page, '#clear_button_desktop')).toBeTruthy();
+
+  const autocompleteItems = await autocompleteHelper.getSuggestList();
+  expect(autocompleteItems.length).toEqual(SUGGEST_MAX_ITEMS);
+
+  const searchValue = await autocompleteHelper.getSearchInputValue();
+  expect(searchValue).toEqual('Hello');
+
+  await page.click('#clear_button_desktop');
+  const searchValueAfterClear = await autocompleteHelper.getSearchInputValue();
+  expect(searchValueAfterClear).toEqual('');
+});
+
+// http://idunn_test.test/v1/pois/osm:node:4872758213?lang=fr
+test('submit key', async () => {
+  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
+  await page.goto(APP_URL);
+  /* submit with data already loaded */
+  await autocompleteHelper.typeAndWait('Hello');
+  await page.keyboard.press('Enter');
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
+
+  const { center } = await getMapView(page);
+
+  let firstFeatureCenter = mockAutocomplete.features[0].geometry.coordinates;
+  expect(center).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
+  await page.click('#clear_button_desktop');
+
+  /* force specific query */
+  responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=paris/);
+  await autocompleteHelper.typeAndWait('paris');
+  await page.keyboard.press('Enter');
+  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
+
+  await page.waitFor(300);
+
+  const { center: newCenter } = await getMapView(page);
+  firstFeatureCenter = mockAutocompleteAllTypes.features[0].geometry.coordinates;
+  expect(newCenter).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
+});
+
+afterEach(async () => {
+  await clearStore(page);
+  responseHandler.reset();
+});
+
+afterAll(async () => {
+  await browser.close();
+});

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -28,23 +28,6 @@ beforeEach(async () => {
   responseHandler.addPreparedResponse(mockPoi, /places\/*/);
 });
 
-test('search and clear', async () => {
-  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
-  await page.goto(APP_URL);
-  await autocompleteHelper.typeAndWait('Hello');
-  expect(await exists(page, '#clear_button_desktop')).toBeTruthy();
-
-  const autocompleteItems = await autocompleteHelper.getSuggestList();
-  expect(autocompleteItems.length).toEqual(SUGGEST_MAX_ITEMS);
-
-  const searchValue = await autocompleteHelper.getSearchInputValue();
-  expect(searchValue).toEqual('Hello');
-
-  await page.click('#clear_button_desktop');
-  const searchValueAfterClear = await autocompleteHelper.getSearchInputValue();
-  expect(searchValueAfterClear).toEqual('');
-});
-
 test('search with no suggest', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteEmpty, /autocomplete\?q=Goodbye/);
   await page.goto(APP_URL);
@@ -214,36 +197,6 @@ test('favorite search', async () => {
   await page.keyboard.type('Hello');
   expect(await exists(page, '.autocomplete_separator_label')).toBeTruthy();
 });
-
-
-// http://idunn_test.test/v1/pois/osm:node:4872758213?lang=fr
-test('submit key', async () => {
-  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
-  await page.goto(APP_URL);
-  /* submit with data already loaded */
-  await autocompleteHelper.typeAndWait('Hello');
-  await page.keyboard.press('Enter');
-  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
-
-  const { center } = await getMapView(page);
-
-  let firstFeatureCenter = mockAutocomplete.features[0].geometry.coordinates;
-  expect(center).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
-  await page.click('#clear_button_desktop');
-
-  /* force specific query */
-  responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=paris/);
-  await autocompleteHelper.typeAndWait('paris');
-  await page.keyboard.press('Enter');
-  await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
-
-  await page.waitFor(300);
-
-  const { center: newCenter } = await getMapView(page);
-  firstFeatureCenter = mockAutocompleteAllTypes.features[0].geometry.coordinates;
-  expect(newCenter).toEqual({ lat: firstFeatureCenter[1], lng: firstFeatureCenter[0] });
-});
-
 
 test('suggestions should not reappear after fast submit', async () => {
   responseHandler.addPreparedResponse(

--- a/tests/integration/tests/direction.desktop.js
+++ b/tests/integration/tests/direction.desktop.js
@@ -1,0 +1,83 @@
+/* eslint-disable max-len */
+import { initBrowser, getInputValue, exists, isHidden } from '../tools';
+import ResponseHandler from '../helpers/response_handler';
+const ROUTES_PATH = 'routes';
+const mockAutocomplete = require('../../__data__/autocomplete.json');
+const mockMapBox = require('../../__data__/mapbox.json');
+
+let browser;
+let page;
+let responseHandler;
+
+beforeAll(async () => {
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+  responseHandler = new ResponseHandler(page);
+  await responseHandler.prepareResponse();
+});
+
+test('check "My position" label', async () => {
+  await page.goto(`${APP_URL}/${ROUTES_PATH}`);
+
+  // wait for autocomplete library starting-up
+  await page.click('#direction-input_origin');
+  await page.waitForSelector('.autocomplete_suggestions');
+
+  expect(await exists(page, '.autocomplete_suggestion--geoloc')).toBeTruthy();
+});
+
+test('switch start end', async () => {
+  await page.goto(`${APP_URL}/${ROUTES_PATH}`);
+  await page.waitForSelector('#direction-input_origin');
+  await page.type('#direction-input_origin', 'start');
+  await page.type('#direction-input_destination', 'end');
+  await page.click('.direction-invert-button');
+  const inputValues = {
+    startInput: await getInputValue(page, '#direction-input_origin'),
+    endInput: await getInputValue(page, '#direction-input_destination'),
+  };
+  expect(inputValues).toEqual({ startInput: 'end', endInput: 'start' });
+});
+
+test('simple search', async () => {
+  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=direction/);
+  responseHandler.addPreparedResponse(mockMapBox, /\/30\.0000000,5\.0000000;30\.0000000,5\.0000000/);
+  await page.goto(`${APP_URL}/${ROUTES_PATH}`);
+  expect(await isHidden(page, '.direction-panel-share-button')).toBeTruthy();
+  await page.waitForSelector('#direction-input_origin');
+  await page.type('#direction-input_origin', 'direction');
+  await page.keyboard.press('Enter');
+  await page.type('#direction-input_destination', 'direction');
+  await page.keyboard.press('Enter');
+  expect(await page.waitForSelector('.direction-panel-share-button', { visible: true })).toBeTruthy();
+  expect(await exists(page, '.itinerary_leg')).toBeTruthy();
+});
+
+describe('Close panel behavior', () => {
+  test('returning to home', async () => {
+    await page.goto(APP_URL);
+    const directionButton = await page.waitForSelector('.search_form__direction_shortcut');
+    await directionButton.click();
+    await page.waitForSelector('.direction-panel');
+    await page.click('.vehicleSelector-button:not(.vehicleSelector-button--active)');
+    await page.click('.direction-panel .closeButton');
+    expect(await exists(page, '.service_panel')).toBeTruthy();
+  });
+
+  test('returning to the POI', async () => {
+    await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=16.50/48.8602571/2.3262281`);
+    const directionFromPOIButton = await page.waitForSelector('.poi_panel__action__direction');
+    await directionFromPOIButton.click();
+    await page.waitForSelector('.direction-panel');
+    await page.click('.vehicleSelector-button:not(.vehicleSelector-button--active)');
+    await page.click('.direction-panel .closeButton');
+    expect(await exists(page, '.poi_panel')).toBeTruthy();
+  });
+});
+
+afterAll(async () => {
+  await browser.close();
+});

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -124,29 +124,6 @@ test('select itinerary step', async () => {
   expect(center).toEqual({ 'lat': 48.823566, 'lng': 2.290454 });
 });
 
-
-test('show itinerary roadmap on mobile', async () => {
-  await page.setViewport({
-    width: 400,
-    height: 800,
-  });
-  responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
-  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
-
-  await page.waitForSelector('.itinerary_leg');
-  await page.click('.itinerary_leg .itinerary_leg_detailsBtn');
-  await page.waitForSelector('.mobile-route-details');
-
-  /*
-    This simulates a user action that will close
-    all panels related to the current itinerary,
-    such as a click on a POI on the map.
-  */
-  await page.evaluate('window.app.navigateTo("/")');
-  // Itinerary container should be disabled.
-  await page.waitForSelector('.direction-panel', { hidden: true, timeout: 1000 });
-});
-
 test('api error handling', async () => {
   /* prepare "error" response */
   responseHandler.addPreparedResponse({}, /\/7\.5000000,47\.4000000;6\.6000000,6\.6000000/, { status: 422 });

--- a/tests/integration/tests/direction.js
+++ b/tests/integration/tests/direction.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { initBrowser, simulateClickOnMap, getInputValue, getMapView, exists, isHidden } from '../tools';
+import { initBrowser, simulateClickOnMap, getInputValue, getMapView, exists } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 const ROUTES_PATH = 'routes';
 const mockAutocomplete = require('../../__data__/autocomplete.json');
@@ -22,16 +22,6 @@ beforeEach(async () => {
   await responseHandler.prepareResponse();
 });
 
-test('check "My position" label', async () => {
-  await page.goto(`${APP_URL}/${ROUTES_PATH}`);
-
-  // wait for autocomplete library starting-up
-  await page.click('#direction-input_origin');
-  await page.waitForSelector('.autocomplete_suggestions');
-
-  expect(await exists(page, '.autocomplete_suggestion--geoloc')).toBeTruthy();
-});
-
 test('Start/end inputs are correctly filled', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}`);
   await page.waitForSelector('#direction-input_origin');
@@ -48,33 +38,6 @@ test('Start/end inputs are correctly filled', async () => {
   await simulateClickOnMap(page, { lat: 43.70324, lng: 7.25997 });
   const directionEndInput = await getInputValue(page, '#direction-input_destination');
   expect(directionEndInput).toEqual('16 Avenue Thiers');
-});
-
-test('switch start end', async () => {
-  await page.goto(`${APP_URL}/${ROUTES_PATH}`);
-  await page.waitForSelector('#direction-input_origin');
-  await page.type('#direction-input_origin', 'start');
-  await page.type('#direction-input_destination', 'end');
-  await page.click('.direction-invert-button');
-  const inputValues = {
-    startInput: await getInputValue(page, '#direction-input_origin'),
-    endInput: await getInputValue(page, '#direction-input_destination'),
-  };
-  expect(inputValues).toEqual({ startInput: 'end', endInput: 'start' });
-});
-
-test('simple search', async () => {
-  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=direction/);
-  responseHandler.addPreparedResponse(mockMapBox, /\/30\.0000000,5\.0000000;30\.0000000,5\.0000000/);
-  await page.goto(`${APP_URL}/${ROUTES_PATH}`);
-  expect(await isHidden(page, '.direction-panel-share-button')).toBeTruthy();
-  await page.waitForSelector('#direction-input_origin');
-  await page.type('#direction-input_origin', 'direction');
-  await page.keyboard.press('Enter');
-  await page.type('#direction-input_destination', 'direction');
-  await page.keyboard.press('Enter');
-  expect(await page.waitForSelector('.direction-panel-share-button', { visible: true })).toBeTruthy();
-  expect(await exists(page, '.itinerary_leg')).toBeTruthy();
 });
 
 test('route flag', async () => {
@@ -196,28 +159,6 @@ test('api wait effect', async () => {
   await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:6.6:6.7`);
   expect(await exists(page, '.itinerary_leg--placeholder')).toBeTruthy();
   expect(await exists(page, '.itinerary_leg:not(.itinerary_leg--placeholder)')).toBeTruthy();
-});
-
-describe('Close panel behavior', () => {
-  test('returning to home', async () => {
-    await page.goto(APP_URL);
-    const directionButton = await page.waitForSelector('.search_form__direction_shortcut');
-    await directionButton.click();
-    await page.waitForSelector('.direction-panel');
-    await page.click('.vehicleSelector-button:not(.vehicleSelector-button--active)');
-    await page.click('.direction-panel .closeButton');
-    expect(await exists(page, '.service_panel')).toBeTruthy();
-  });
-
-  test('returning to the POI', async () => {
-    await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=16.50/48.8602571/2.3262281`);
-    const directionFromPOIButton = await page.waitForSelector('.poi_panel__action__direction');
-    await directionFromPOIButton.click();
-    await page.waitForSelector('.direction-panel');
-    await page.click('.vehicleSelector-button:not(.vehicleSelector-button--active)');
-    await page.click('.direction-panel .closeButton');
-    expect(await exists(page, '.poi_panel')).toBeTruthy();
-  });
 });
 
 afterAll(async () => {

--- a/tests/integration/tests/direction.mobile.js
+++ b/tests/integration/tests/direction.mobile.js
@@ -1,0 +1,41 @@
+/* eslint-disable max-len */
+import { initBrowser } from '../tools';
+import ResponseHandler from '../helpers/response_handler';
+const ROUTES_PATH = 'routes';
+const mockMapBox = require('../../__data__/mapbox.json');
+
+let browser;
+let page;
+let responseHandler;
+
+beforeAll(async () => {
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+  responseHandler = new ResponseHandler(page);
+  await responseHandler.prepareResponse();
+});
+
+test('show itinerary roadmap on mobile', async () => {
+  responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
+  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
+
+  await page.waitForSelector('.itinerary_leg');
+  await page.click('.itinerary_leg .itinerary_leg_detailsBtn');
+  await page.waitForSelector('.mobile-route-details');
+
+  /*
+    This simulates a user action that will close
+    all panels related to the current itinerary,
+    such as a click on a POI on the map.
+  */
+  await page.evaluate('window.app.navigateTo("/")');
+  // Itinerary container should be disabled.
+  await page.waitForSelector('.direction-panel', { hidden: true, timeout: 1000 });
+});
+
+afterAll(async () => {
+  await browser.close();
+});

--- a/tests/integration/tests/menu.desktop.js
+++ b/tests/integration/tests/menu.desktop.js
@@ -1,0 +1,43 @@
+import { clearStore, initBrowser, exists, isHidden, waitForAnimationEnd } from '../tools';
+
+let browser;
+let page;
+
+beforeAll(async () => {
+  const browserPage = await initBrowser();
+  page = browserPage.page;
+  browser = browserPage.browser;
+});
+
+test('menu open favorite', async () => {
+  await page.goto(APP_URL);
+  await page.waitForSelector('.menu__button');
+
+  await page.click('.menu__button');
+  await page.waitForSelector('.menu__panel');
+  await waitForAnimationEnd(page, '.menu__panel');
+  await page.click('.menu__panel__action:nth-child(2)');
+
+  expect(await exists(page, '.direction-panel')).toBeTruthy();
+
+  await page.click('.menu__button');
+  await page.waitForSelector('.menu__panel__action');
+  await waitForAnimationEnd(page, '.menu__panel');
+  await page.click('.menu__panel__action:nth-child(3)');
+
+  expect(await exists(page, '.favorite_panel')).toBeTruthy();
+});
+
+test('close service panel when opening direction', async () => {
+  await page.goto(APP_URL);
+  await page.click('.search_form__direction_shortcut');
+  expect(await isHidden(page, '.service_panel')).toBeTruthy();
+});
+
+afterEach(async () => {
+  await clearStore(page);
+});
+
+afterAll(async () => {
+  await browser.close();
+});

--- a/tests/integration/tests/menu.js
+++ b/tests/integration/tests/menu.js
@@ -1,16 +1,12 @@
 import { clearStore, initBrowser, exists, isHidden, waitForAnimationEnd } from '../tools';
-import ResponseHandler from '../helpers/response_handler';
 
 let browser;
 let page;
-let responseHandler;
 
 beforeAll(async () => {
   const browserPage = await initBrowser();
   page = browserPage.page;
   browser = browserPage.browser;
-  responseHandler = new ResponseHandler(page);
-  await responseHandler.prepareResponse();
 });
 
 test('test menu toggling', async () => {
@@ -24,31 +20,6 @@ test('test menu toggling', async () => {
   await waitForAnimationEnd(page, '.menu__panel');
   await page.click('.menu__panel__top__close');
   expect(await isHidden(page, '.menu_panel')).toBeTruthy();
-});
-
-test('menu open favorite', async () => {
-  await page.goto(APP_URL);
-  await page.waitForSelector('.menu__button');
-
-  await page.click('.menu__button');
-  await page.waitForSelector('.menu__panel');
-  await waitForAnimationEnd(page, '.menu__panel');
-  await page.click('.menu__panel__action:nth-child(2)');
-
-  expect(await exists(page, '.direction-panel')).toBeTruthy();
-
-  await page.click('.menu__button');
-  await page.waitForSelector('.menu__panel__action');
-  await waitForAnimationEnd(page, '.menu__panel');
-  await page.click('.menu__panel__action:nth-child(3)');
-
-  expect(await exists(page, '.favorite_panel')).toBeTruthy();
-});
-
-test('close service panel when opening direction', async () => {
-  await page.goto(APP_URL);
-  await page.click('.search_form__direction_shortcut');
-  expect(await isHidden(page, '.service_panel')).toBeTruthy();
 });
 
 afterEach(async () => {

--- a/tests/integration/tests/poi.desktop.js
+++ b/tests/integration/tests/poi.desktop.js
@@ -1,0 +1,120 @@
+const poiMock = require('../../__data__/poi.json');
+
+import ResponseHandler from '../helpers/response_handler';
+import { initBrowser, clearStore, exists } from '../tools';
+import { getFavorites, toggleFavoritePanel } from '../favorites_tools';
+
+let browser;
+let page;
+let responseHandler;
+
+beforeAll(async () => {
+  browser = (await initBrowser()).browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+  page.setDefaultTimeout(3000);
+  await page.setExtraHTTPHeaders({
+    'accept-language': 'fr_FR,fr,en;q=0.8', /* force fr header */
+  });
+  responseHandler = new ResponseHandler(page);
+  await responseHandler.prepareResponse();
+
+  const autocompleteMock = require('../../__data__/autocomplete.json');
+  responseHandler.addPreparedResponse(autocompleteMock, /autocomplete/);
+  responseHandler.addPreparedResponse(poiMock, /places\/osm:way:63178753(\?[^?]*)?$/);
+});
+
+test('display details about the poi on a poi click', async () => {
+  await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/48.8605833/2.3261037`);
+  await page.waitForSelector('.poiTitle');
+
+  await page.click('.poi_panel__content .poiItem');
+  let infoTitle = await page.evaluate(() => {
+    return document.querySelector('.poi_panel__sub_block__title').innerText;
+  });
+  expect(infoTitle.trim()).toEqual('Accessible en fauteuil roulant.');
+  await page.click('.poi_panel__block__collapse');
+
+  infoTitle = await page.evaluate(() => {
+    return document.querySelector('.poi_panel__sub_block__title').innerText;
+  });
+  expect(infoTitle.trim()).toEqual('');
+
+  const { address, contact, contactUrl, phone, website } = await page.evaluate(() => {
+    return {
+      address: document.querySelector('.block-address .block-value').innerText,
+      contact: document.querySelector('.block-contact-link').innerText,
+      contactUrl: document.querySelector('.block-contact-link').href,
+      phone: document.querySelector('.block-phone').innerText,
+      website: document.querySelector('.block-website').innerText,
+    };
+  });
+  expect(address).toEqual('1 Rue de la Légion d\'Honneur, 75007 Paris');
+  expect(await exists(page, '.poi_panel .openingHour--closed')).toBeTruthy();
+  expect(phone).toMatch('01 40 49 48 14');
+  expect(website).toMatch('www.musee-orsay.fr');
+  expect(contactUrl).toMatch('mailto:admin@orsay.fr');
+  expect(contact).toMatch('admin@orsay.fr');
+  expect(await exists(page, '.poi_panel__info__wiki')).toBeTruthy();
+});
+
+async function clickPoi(page) {
+  const mapPoiMock = {
+    properties: {
+      global_id: poiMock.id,
+      name: poiMock.name,
+    },
+    geometry: poiMock.geometry,
+  };
+  await page.evaluate(clickedFeature => {
+    window.map.clickOnMap({}, clickedFeature);
+  }, mapPoiMock);
+  const mockPoiBounds = await page.$('#mock_poi').then(e => e.boundingBox());
+  // Click on the top-left corner
+  await page.mouse.click(mockPoiBounds.x, mockPoiBounds.y);
+}
+
+test('add a poi as favorite and find it back in the favorite menu', async () => {
+  await page.goto(APP_URL);
+
+  // we select a poi and 'star' it
+  await clickPoi(page);
+  expect(await exists(page, '.poiTitle')).toBeTruthy();
+  expect(await exists(page, '.poi_panel')).toBeTruthy();
+  await page.click('.poi_panel__actions .poi_panel__action__favorite');
+  await page.click('.poi_panel .closeButton');
+  // we check that the first favorite item is our poi
+  await toggleFavoritePanel(page);
+  let fav = await getFavorites(page);
+  expect(fav).toHaveLength(1);
+  expect(fav[0].title).toEqual('Musée d\'Orsay');
+  expect(fav[0].desc).toEqual('Musée');
+  expect(fav[0].icons).toContainEqual('icon-museum');
+
+  // we then reopen the poi panel and 'unstar' the poi.
+  await page.click('.favorite_panel__item');
+  expect(await exists(page, '.poiTitle')).toBeTruthy();
+  expect(await exists(page, '.poi_panel')).toBeTruthy();
+
+  await page.click('.poi_panel__actions .poi_panel__action__favorite');
+  await page.click('.poi_panel .closeButton');
+  // it should disappear from the favorites
+  await toggleFavoritePanel(page);
+  fav = await getFavorites(page);
+  expect(fav).toEqual([]);
+});
+
+afterEach(async () => {
+  try {
+    await clearStore(page); /* if only the above test is run page is not used */
+  } catch (e) {
+    console.error(e);
+  }
+});
+
+afterAll(async () => {
+  await browser.close();
+});
+

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -2,7 +2,7 @@ const poiMock = require('../../__data__/poi.json');
 
 import ResponseHandler from '../helpers/response_handler';
 import { initBrowser, getText, clearStore, getInputValue, exists } from '../tools';
-import { getFavorites, toggleFavoritePanel, storePoi } from '../favorites_tools';
+import { toggleFavoritePanel, storePoi } from '../favorites_tools';
 import { languages } from '../../../config/constants.yml';
 
 let browser;
@@ -129,40 +129,6 @@ test('center the map to the poi on a poi click', async () => {
   });
 });
 
-test('display details about the poi on a poi click', async () => {
-  await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/48.8605833/2.3261037`);
-  await page.waitForSelector('.poiTitle');
-
-  await page.click('.poi_panel__content .poiItem');
-  let infoTitle = await page.evaluate(() => {
-    return document.querySelector('.poi_panel__sub_block__title').innerText;
-  });
-  expect(infoTitle.trim()).toEqual('Accessible en fauteuil roulant.');
-  await page.click('.poi_panel__block__collapse');
-
-  infoTitle = await page.evaluate(() => {
-    return document.querySelector('.poi_panel__sub_block__title').innerText;
-  });
-  expect(infoTitle.trim()).toEqual('');
-
-  const { address, contact, contactUrl, phone, website } = await page.evaluate(() => {
-    return {
-      address: document.querySelector('.block-address .block-value').innerText,
-      contact: document.querySelector('.block-contact-link').innerText,
-      contactUrl: document.querySelector('.block-contact-link').href,
-      phone: document.querySelector('.block-phone').innerText,
-      website: document.querySelector('.block-website').innerText,
-    };
-  });
-  expect(address).toEqual('1 Rue de la Légion d\'Honneur, 75007 Paris');
-  expect(await exists(page, '.poi_panel .openingHour--closed')).toBeTruthy();
-  expect(phone).toMatch('01 40 49 48 14');
-  expect(website).toMatch('www.musee-orsay.fr');
-  expect(contactUrl).toMatch('mailto:admin@orsay.fr');
-  expect(contact).toMatch('admin@orsay.fr');
-  expect(await exists(page, '.poi_panel__info__wiki')).toBeTruthy();
-});
-
 test('Poi name i18n', async () => {
   await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=16.50/48.8602571/2.3262281`);
   await page.waitForSelector('.poiTitle');
@@ -220,37 +186,6 @@ async function clickPoi(page) {
   // Click on the top-left corner
   await page.mouse.click(mockPoiBounds.x, mockPoiBounds.y);
 }
-
-test('add a poi as favorite and find it back in the favorite menu', async () => {
-  await page.goto(APP_URL);
-
-  // we select a poi and 'star' it
-  await clickPoi(page);
-  expect(await exists(page, '.poiTitle')).toBeTruthy();
-  expect(await exists(page, '.poi_panel')).toBeTruthy();
-  await page.click('.poi_panel__actions .poi_panel__action__favorite');
-  await page.click('.poi_panel .closeButton');
-  // we check that the first favorite item is our poi
-  await toggleFavoritePanel(page);
-  let fav = await getFavorites(page);
-  expect(fav).toHaveLength(1);
-  expect(fav[0].title).toEqual('Musée d\'Orsay');
-  expect(fav[0].desc).toEqual('Musée');
-  expect(fav[0].icons).toContainEqual('icon-museum');
-
-  // we then reopen the poi panel and 'unstar' the poi.
-  await page.click('.favorite_panel__item');
-  expect(await exists(page, '.poiTitle')).toBeTruthy();
-  expect(await exists(page, '.poi_panel')).toBeTruthy();
-
-  await page.click('.poi_panel__actions .poi_panel__action__favorite');
-  await page.click('.poi_panel .closeButton');
-  // it should disappear from the favorites
-  await toggleFavoritePanel(page);
-  fav = await getFavorites(page);
-  expect(fav).toEqual([]);
-});
-
 
 describe('Poi hour i18n', () => {
   languages.supportedLanguages.forEach(language => {

--- a/tests/integration/tests/poi.js
+++ b/tests/integration/tests/poi.js
@@ -58,17 +58,6 @@ test('load a poi from url with simple id', async () => {
   expect(title).toMatch(/Musée d'Orsay/);
 });
 
-test('load a poi from url on mobile', async () => {
-  await page.setViewport({
-    width: 400,
-    height: 800,
-  });
-  await page.goto(`${APP_URL}/place/osm:way:63178753@Musée_dOrsay#map=17.49/2.3261037/48.8605833`);
-  await page.waitForSelector('.poiTitle');
-  const title = await page.evaluate(() => document.querySelector('.poiTitle').innerText);
-  expect(title).toMatch(/Musée d'Orsay/);
-});
-
 test('load a poi already in my favorite from url', async () => {
   await page.goto(APP_URL);
   await storePoi(page, { id: 'osm:way:63178753' });

--- a/tests/integration/tools.js
+++ b/tests/integration/tools.js
@@ -1,6 +1,7 @@
 /* globals puppeteerArguments */
 import puppeteer from 'puppeteer';
 import LatLngPoi from 'src/adapters/poi/latlon_poi';
+import { getPupeeterViewport } from './device';
 
 export const getText = async function(page, selector) {
   return await page.evaluate(selector => {
@@ -11,8 +12,11 @@ export const getText = async function(page, selector) {
 export const initBrowser = async function() {
   const headless = process.env.headless !== 'false';
 
-
-  const browser = await puppeteer.launch({ args: puppeteerArguments, headless });
+  const browser = await puppeteer.launch({
+    args: puppeteerArguments,
+    headless,
+    defaultViewport: getPupeeterViewport(process.env.TEST_DEVICE),
+  });
   const page = await browser.newPage();
   await page.setExtraHTTPHeaders({
     'accept-language': 'fr_FR,fr,en;q=0.8', /* force fr header */


### PR DESCRIPTION
## Description
I modified the integration test configuration so it accepts a new env var `TEST_DEVICE`, with values `mobile` or `desktop`.
This env var is used for 2 things:
 - to set the default viewport of all Puppeteer browser instances to a corresponding configuration 
 - to filter out some tests depending on the platform if they are not compatible with it.

This filter mechanism uses the file name:
 - `feature.js`: tests in it will be run on `mobile` and `desktop` configs
 - `feature.mobile.js`: tests in it will be run only on `mobile` config
 - `feature.desktop.js`: tests in it will be run only on `desktop` config

I moved some tests to `*.mobile.js` and `*.desktop.js` files to adapt to the new configs. But when possible it would probably be more maintainable to rewrite them so they are adapted to both device types.
It does the job, but in use it's a bit cumbersome to operate on different files to rewrite stuff. And as planned there is a lot of boilerplate code duplication (imports, before/after hooks, etc.). Maybe it's just the set up and it will be fine in practice.

What do you think?

## Why
Increase the coverage and reliability of our tests by forcing tests on mobile.