### PR TITLE
Fix transparent gradient used as ellipsis on iOS

### DIFF
--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -104,7 +104,7 @@ $BLOCK_ICON_FONT_SIZE: 16px;
     right: 0;
     bottom: 0;
     padding-left: 48px;
-    background: linear-gradient(to right, transparent 0, white 48px, white 100%);
+    background: linear-gradient(to right, rgba(255,255,255,0) 0, white 48px, white 100%);
   }
 }
 


### PR DESCRIPTION
## Description
On iOS, fix the appareance of the transparent-to-white gradient used as ellipsis on POI descriptions.

## Why
iOS has a different algorithm than other browsers for interpolating between colors in gradients. With `transparent`, it doesn't know what is the "real" color to start from. Using the transparent version of the color we want allows it to render the correct gradient.
See https://stackoverflow.com/a/56548711 for ref.

## Screenshots
|Before|After|
|---|---|
|![IMG_0010](https://user-images.githubusercontent.com/243653/101336942-5863cb00-387b-11eb-9955-f42082cf2a5c.PNG)|![IMG_0009](https://user-images.githubusercontent.com/243653/101336915-51d55380-387b-11eb-8376-b6f631fc0938.PNG)|