### PR TITLE
Tweak the layout of the category shortcuts on POI panel

### DIFF
--- a/src/scss/includes/components/mainActionButton.scss
+++ b/src/scss/includes/components/mainActionButton.scss
@@ -5,7 +5,7 @@
 
   &-label {
     font-size: 12px;
-    color: #5c6f84;
+    color: $grey-semi-darkness;
     line-height: 16px;
   }
 
@@ -15,7 +15,7 @@
     line-height: 48px;
     margin: auto;
     border-radius: 50%;
-    margin-bottom: 4px;
+    margin-bottom: $spacing-xs;
   }
 
   &:active {

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -194,9 +194,9 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 }
 
 .poi_panel__categories {
-  .mainActionButton {
-    width: 25%;
-  }
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-gap: $spacing-s;
 }
 
 .marker-anywhere {


### PR DESCRIPTION
## Description
Small style tweaks on the POI panel category shortcuts after review by the design team.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-12-07 à 14 41 15](https://user-images.githubusercontent.com/243653/101357954-7a207a80-389a-11eb-99e5-9ac7dd757c89.png)|![Capture d’écran 2020-12-07 à 14 40 24](https://user-images.githubusercontent.com/243653/101357956-7b51a780-389a-11eb-8bef-043e69c0c140.png)|
