### PR TITLE
Improve Search form layout

### DIFF
--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -1,10 +1,6 @@
 
 #react_menu__container {
-  align-self: stretch;
   width: 40px;
-  position: absolute;
-  right: 0;
-  top: 24px;
 }
 
 .no-burger #react_menu__container {

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -1,6 +1,8 @@
 
 #react_menu__container {
-  width: 40px;
+  width: $spacing-xxl-4;
+  height: $spacing-xxl-4;
+  flex-shrink: 0;
 }
 
 .no-burger #react_menu__container {

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -3,35 +3,33 @@
   width: 100%;
   height: $top_bar_height;
   position: relative;
-  align-items: center;
   pointer-events: auto;
-  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  padding: 0 $spacing-s;
 }
 
 // Wrapper around the field and some icons, gets a colored border when the field is focused
 .search_form__wrapper {
-  height: 48px;
-  padding: 0 16px;
+  height: $spacing-xxl-4;
+  padding: 0 $spacing-m;
+  margin-left: $spacing-m;
+  margin-right: $spacing-xs;
   border: none;
   background-color: $surface;
   border-radius: 24px;
-  margin: 1px;
-  align-items: center;
-  position: absolute;
-  width: calc(100% - 110px);
-  top: 8px;
-  left: 63px;
+  width: 100%;
+  position: relative;
 }
 
 // Input
 .search_form__input {
   min-width: 0;
   width: calc(100% - 30px);
-  height: 46px;
+  height: $spacing-xxl-4;
   font-size: 16px;
   font-weight: normal;
-  color: #353c52;
-  box-shadow: none;
+  color: $grey-black;
 
   &::placeholder {
     color: $secondary_text;
@@ -70,9 +68,9 @@ input[type="search"] {
   cursor: pointer;
   width: 36px;
   height: 36px;
+  flex-shrink: 0;
   background: url(../images/qwant-logo.svg) no-repeat;
   background-size: cover;
-  margin-top: 7px;
 
   &[data-flag-text]:before {
     font-weight: bold;
@@ -104,7 +102,7 @@ input[type="search"] {
   cursor: pointer;
   position: absolute;
   top: 0;
-  right: 12px;
+  right: $spacing-s;
 }
 
 // Clear X icon
@@ -125,9 +123,6 @@ input[type="search"] {
   background-size: 24px 24px;
   cursor: pointer;
   transition: filter .1s;
-  position: absolute;
-  right: 2px;
-  top: 10px;
 
   &:hover {
     filter: brightness(80%);
@@ -167,11 +162,7 @@ input[type="search"] {
   #clear_button_desktop {
     width: 48px;
     height: 48px;
-    bagkground-position: 10px center;
     display: block;
-    position: absolute;
-    right: 2px;
-    top: 10px;
     &:hover::before {
       color: $grey-black;
     }
@@ -192,37 +183,22 @@ input[type="search"] {
   }
 }
 
-
-
 // Mobile
 @media (max-width: 640px) {
-  .search_form {
-    padding-right: 12px;
-  }
-
-  .search_form__input {
-    width: calc(100% - 35px);
-    padding: 0 0 0 12px;
-  }
-
   .search_form__input::placeholder {
     font-size: 14px;
   }
 
   .search_form__wrapper {
-    padding: 0;
-    width: calc(100% - 100px);
-    left: 60px;
-    transition: width .15s, left .15s;
-    position: absolute;
+    transition: .15s;
   }
 
   .search_form__return {
     display: none;
     font-size: 20px;
     text-align: center;
-    color: #0c0c0e;
-    margin-right: 8px;
+    color: $grey-black;
+    margin-right: $spacing-xs;
     cursor: pointer;
 
     position: absolute;
@@ -231,7 +207,7 @@ input[type="search"] {
     left: 0;
     width: 30px;
     height: 60px;
-    padding: 13px 0 0 12px;
+    padding: 14px 0 0 12px;
 
     &:hover {
       color: $primary_text;
@@ -265,7 +241,7 @@ input[type="search"] {
   .top_bar--search_filled {
 
     .search_form__wrapper {
-      padding: 0 0 0 $spacing-s;
+      padding-left: $spacing-s;
     }
 
     // Show mobile clear X button
@@ -281,9 +257,8 @@ input[type="search"] {
   // When the search field is focused (empty or not)
   .top_bar--search_focus {
     .search_form__wrapper {
-      padding: 0  0 0 30px;
+      padding-left: $spacing-xxl-3;
     }
-
 
     .search_form__input::placeholder {
       color: $grey-semi-darkness;
@@ -302,7 +277,7 @@ input[type="search"] {
 
     // Hide mobile burger menu
     #react_menu__container {
-      opacity: 0;
+      display: none;
     }
 
     // Hide desktop clear X icon
@@ -310,10 +285,13 @@ input[type="search"] {
       display: none;
     }
 
-    // Make the wrapper full-width and overlap the rest
+
+    // Make the wrapper full-width
     .search_form__wrapper {
-      left: 10px;
-      width: calc(100% - 20px);
+      margin: 0;
+    }
+    .search_form__logo__button {
+      display: none;
     }
 
     // Hide magnifying glass

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -6,14 +6,12 @@
   pointer-events: auto;
   display: flex;
   align-items: center;
-  padding-left: $spacing-s;
 }
 
 // Wrapper around the field and some icons, gets a colored border when the field is focused
 .search_form__wrapper {
   height: $spacing-xxl-4;
   padding: 0 $spacing-m;
-  margin-left: $spacing-m;
   border: none;
   background-color: $surface;
   border-radius: 24px;
@@ -70,6 +68,7 @@ input[type="search"] {
   flex-shrink: 0;
   background: url(../images/qwant-logo.svg) no-repeat;
   background-size: cover;
+  margin: 0 $spacing-m 0 $spacing-s;
 
   &[data-flag-text]:before {
     font-weight: bold;
@@ -190,10 +189,6 @@ input[type="search"] {
     font-size: 14px;
   }
 
-  .search_form__wrapper {
-    transition: .15s;
-  }
-
   .search_form__return {
     display: none;
     font-size: 20px;
@@ -203,7 +198,7 @@ input[type="search"] {
     cursor: pointer;
 
     position: absolute;
-    transition: opacity .15s;
+    transition: opacity .2s;
     top: 0;
     left: 0;
     width: 30px;
@@ -227,24 +222,25 @@ input[type="search"] {
     height: 100vh;
   }
 
-  .search_form__logo__button {
-    width: 34px;
-    height: 34px;
+  $formWidthTransitionDuration: .3s;
+
+  // Prepare transition of search field
+  .search_form__wrapper {
+    transition: margin $formWidthTransitionDuration;
   }
 
+  .search_form__logo__button,
   #react_menu__container {
     opacity: 1;
-    transition: opacity .25s;
-    z-index: -1;
+    transition: opacity $formWidthTransitionDuration;
+  }
+
+  .menu__button {
+    background-color: transparent;
   }
 
   // When the search field is filled
   .top_bar--search_filled {
-
-    .search_form {
-      padding-right: $spacing-s;
-    }
-
     .search_form__wrapper {
       padding-left: $spacing-s;
     }
@@ -261,14 +257,6 @@ input[type="search"] {
 
   // When the search field is focused (empty or not)
   .top_bar--search_focus {
-    .search_form {
-      padding-right: $spacing-s;
-    }
-
-    .search_form__wrapper {
-      padding-left: $spacing-xxl-3;
-    }
-
     .search_form__input::placeholder {
       color: $grey-semi-darkness;
       opacity: 1;
@@ -278,15 +266,19 @@ input[type="search"] {
     .search_form__return {
       display: block;
     }
+
+    // ... and make room for it
+    .search_form__wrapper {
+      padding-left: $spacing-xxl-3;
+    }
   }
 
   // When the field is filled and/or focused
   .top_bar--search_filled,
   .top_bar--search_focus {
-
-    // Hide mobile burger menu
-    #react_menu__container {
-      display: none;
+    .search_form__wrapper {
+      margin-left: -54px;
+      margin-right: -38px;
     }
 
     // Hide desktop clear X icon
@@ -294,13 +286,10 @@ input[type="search"] {
       display: none;
     }
 
-
-    // Make the wrapper full-width
-    .search_form__wrapper {
-      margin: 0;
-    }
+    #react_menu__container,
     .search_form__logo__button {
-      display: none;
+      opacity: 0;
+      pointer-events: none;
     }
 
     // Hide magnifying glass

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -6,7 +6,7 @@
   pointer-events: auto;
   display: flex;
   align-items: center;
-  padding: 0 $spacing-s;
+  padding-left: $spacing-s;
 }
 
 // Wrapper around the field and some icons, gets a colored border when the field is focused
@@ -14,7 +14,6 @@
   height: $spacing-xxl-4;
   padding: 0 $spacing-m;
   margin-left: $spacing-m;
-  margin-right: $spacing-xs;
   border: none;
   background-color: $surface;
   border-radius: 24px;
@@ -117,8 +116,9 @@ input[type="search"] {
 
 // Directions icon
 .search_form__direction_shortcut {
-  width: 48px;
-  height: 48px;
+  width: $spacing-xxl-4;
+  height: $spacing-xxl-4;
+  flex-shrink: 0;
   background: url(../images/direction-line.svg) center no-repeat;
   background-size: 24px 24px;
   cursor: pointer;
@@ -160,8 +160,9 @@ input[type="search"] {
 
   // Show desktop clear X icon
   #clear_button_desktop {
-    width: 48px;
-    height: 48px;
+    width: $spacing-xxl-4;
+    height: $spacing-xxl-4;
+    flex-shrink: 0;
     display: block;
     &:hover::before {
       color: $grey-black;
@@ -240,6 +241,10 @@ input[type="search"] {
   // When the search field is filled
   .top_bar--search_filled {
 
+    .search_form {
+      padding-right: $spacing-s;
+    }
+
     .search_form__wrapper {
       padding-left: $spacing-s;
     }
@@ -256,6 +261,10 @@ input[type="search"] {
 
   // When the search field is focused (empty or not)
   .top_bar--search_focus {
+    .search_form {
+      padding-right: $spacing-s;
+    }
+
     .search_form__wrapper {
       padding-left: $spacing-xxl-3;
     }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -48,13 +48,13 @@
             data-flag-text="<%= config.app.versionFlag %>"
           <% } %>
         ></button>
-        <div id="react_menu__container"></div>
         <div class="search_form__wrapper empty">
           <div class="search_form__return icon-arrow-left"></div>
           <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
           <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)" title="<%= _('Clear', 'search bar') %>"></button>
           <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">
         </div>
+        <div id="react_menu__container"></div>
         <% if(config.direction.enabled) { %>
         <button class="search_form__direction_shortcut" title="<%= _('Directions', 'top bar') %>"></button>
         <button id="clear_button_desktop" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)" title="<%= _('Clear', 'search bar') %>"></button>


### PR DESCRIPTION
## Description
- Avoid absolute positioning of elements in Search form
- Height fixes (height of 48px vs 46px previously)
- Use spacing variables
- Use flex layout
- Colors fixes
- Centering fixes, thanks to flexbox

## Why
- Search layout was a bit hard to maintain, due to absolute positioning of element.
- Some element were not perfectly centered due to absolute positioning.

## Screenshots
![desktop](https://user-images.githubusercontent.com/2981774/101376500-f32acc80-38b0-11eb-87bc-87fbf0d778e5.png)
![mobile](https://user-images.githubusercontent.com/2981774/101376547-02aa1580-38b1-11eb-966e-aea56d6b45b2.png)

