### PR TITLE
[Clean-up] Simplify favorite POI code

### DIFF
--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -75,11 +75,12 @@ export async function getFavoritesMatching(term) {
   });
 }
 
-export async function isInFavorites(poi) {
+export function isInFavorites(poi) {
   try {
     return Boolean(get(getKey(poi)));
   } catch (e) {
     Error.sendOnce('store', 'has', 'error checking existing key', e);
+    return false;
   }
 }
 

--- a/src/adapters/store.js
+++ b/src/adapters/store.js
@@ -87,7 +87,7 @@ export function isInFavorites(poi) {
 export async function addToFavorites(poi) {
   try {
     set(getKey(poi), poi);
-    fire('poi_added_to_favs', poi);
+    fire('poi_favorite_state_changed', poi, true);
   } catch (e) {
     Error.sendOnce('store', 'add', 'error adding poi', e);
   }
@@ -96,7 +96,7 @@ export async function addToFavorites(poi) {
 export async function removeFromFavorites(poi) {
   try {
     del(getKey(poi));
-    fire('poi_removed_from_favs', poi);
+    fire('poi_favorite_state_changed', poi, false);
   } catch (e) {
     Error.sendOnce('store', 'del', 'error removing item', e);
   }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -21,15 +21,6 @@ import { Flex, Panel, PanelNav, CloseButton, Divider } from 'src/components/ui';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
-async function isPoiFavorite(poi) {
-  try {
-    const storePoi = await isInFavorites(poi);
-    return !!storePoi;
-  } catch (e) {
-    return false;
-  }
-}
-
 export default class PoiPanel extends React.Component {
   static propTypes = {
     poiId: PropTypes.string.isRequired,
@@ -122,9 +113,7 @@ export default class PoiPanel extends React.Component {
     } else {
       this.setState({
         fullPoi: poi,
-      });
-      isPoiFavorite(poi).then(isPoiInFavorite => {
-        this.setState({ isPoiInFavorite });
+        isPoiInFavorite: isInFavorites(poi),
       });
       if (!updateMapEarly) {
         this.updateMapPoi(poi, mapOptions);

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -48,7 +48,7 @@ export default class PoiPanel extends React.Component {
     // Load poi or pois
     !this.props.pois ? this.loadPoi() : this.loadPois();
 
-    this.storeAddRemoveHandler = listen('poi_favorite_state_changed', (poi, isPoiInFavorite) => {
+    this.storePoiChangeHandler = listen('poi_favorite_state_changed', (poi, isPoiInFavorite) => {
       if (poi === this.state.fullPoi) {
         this.setState({ isPoiInFavorite });
       }
@@ -62,7 +62,7 @@ export default class PoiPanel extends React.Component {
   }
 
   componentWillUnmount() {
-    unListen(this.storeAddRemoveHandler);
+    unListen(this.storePoiChangeHandler);
     fire('move_mobile_bottom_ui', 0);
     fire('clean_marker');
     fire('mobile_direction_button_visibility', true);

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -48,15 +48,9 @@ export default class PoiPanel extends React.Component {
     // Load poi or pois
     !this.props.pois ? this.loadPoi() : this.loadPois();
 
-    this.storeAddHandler = listen('poi_added_to_favs', poi => {
+    this.storeAddRemoveHandler = listen('poi_favorite_state_changed', (poi, isPoiInFavorite) => {
       if (poi === this.state.fullPoi) {
-        this.setState({ isPoiInFavorite: true });
-      }
-    });
-
-    this.storeRemoveHandler = listen('poi_removed_from_favs', poi => {
-      if (poi === this.state.fullPoi) {
-        this.setState({ isPoiInFavorite: false });
+        this.setState({ isPoiInFavorite });
       }
     });
   }
@@ -68,8 +62,7 @@ export default class PoiPanel extends React.Component {
   }
 
   componentWillUnmount() {
-    unListen(this.storeAddHandler);
-    unListen(this.storeRemoveHandler);
+    unListen(this.storeAddRemoveHandler);
     fire('move_mobile_bottom_ui', 0);
     fire('clean_marker');
     fire('mobile_direction_button_visibility', true);


### PR DESCRIPTION
## Description
Simplify 2 things related to how the POI favorite Y/N status is handled by the POI panel:
 - now that the store is solely based on local storage, it is synchronous so we don't need extra code to wait for the status ;
 - we don't need two separates events to signal POI added and POI removed from the store, one with a boolean status is enough and brings simplification.

## Why
Code simplification.