### PR TITLE
Limit POI panel description to 4 lines

### DIFF
--- a/src/scss/includes/mixins.scss
+++ b/src/scss/includes/mixins.scss
@@ -1,0 +1,6 @@
+@mixin lineClamp($lineCount) {
+  display: -webkit-box;
+  -webkit-line-clamp: $lineCount;
+  -webkit-box-orient: vertical;  
+  overflow: hidden;
+}

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -99,6 +99,10 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   margin-top: 20px;
   position: relative;
 
+  p {
+    @include lineClamp(4);
+  }
+
   a {
     position: absolute;
     right: 0;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -4,7 +4,7 @@ $font_system: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetic
 @import "includes/font";
 @import "includes/colors";
 @import "includes/spacing";
-
+@import "includes/mixins";
 @import "includes/component";
 @import "includes/menu";
 @import "includes/reset";


### PR DESCRIPTION
## Description
Limit the optional description block in POI panel to 4 lines maximum.

Uses the [`-webkit-line-clamp` property](https://css-tricks.com/almanac/properties/l/line-clamp/), which is non-standard but [well-supported by modern browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp#Browser_compatibility), even Firefox (tested on Android and desktop) and Safari (tested on iPhone and another Webkit-based desktop browser).
For such non-critical feature, it's ok and great to avoid a JS-based solution.

## Why
UI balance.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2020-12-08 à 14 48 22](https://user-images.githubusercontent.com/243653/101491924-9a1c7080-3964-11eb-867a-8316e312eb2f.png)|![Capture d’écran 2020-12-08 à 14 47 47](https://user-images.githubusercontent.com/243653/101491932-9be63400-3964-11eb-9f4f-04be0f14aeb5.png)|
