### PR TITLE
CategoryPanel: debounce requests

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -19,7 +19,7 @@ import { sources } from 'config/constants.yml';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);
-const DEBOUNCE_WAIT = 500;
+const DEBOUNCE_WAIT = 100;
 
 export default class CategoryPanel extends React.Component {
   static propTypes = {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -128,7 +128,7 @@ export default class CategoryPanel extends React.Component {
 
     fire('add_category_markers', places, this.props.poiFilters);
     fire('save_location');
-  }, DEBOUNCE_WAIT)
+  }, DEBOUNCE_WAIT, { leading: true })
 
   selectPoi = poi => {
     const { poiFilters } = this.props;

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'src/components/ui/Panel';
+import debounce from 'lodash.debounce';
+
 import PoiItemList from './PoiItemList';
 import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
@@ -17,6 +19,7 @@ import { sources } from 'config/constants.yml';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);
+const DEBOUNCE_WAIT = 500;
 
 export default class CategoryPanel extends React.Component {
   static propTypes = {
@@ -98,7 +101,7 @@ export default class CategoryPanel extends React.Component {
     }
   }
 
-  fetchData = async () => {
+  fetchData = debounce(async () => {
     const { category, query } = this.props.poiFilters;
     const currentBounds = getVisibleBbox(window.map.mb, window.no_ui);
 
@@ -125,7 +128,7 @@ export default class CategoryPanel extends React.Component {
 
     fire('add_category_markers', places, this.props.poiFilters);
     fire('save_location');
-  };
+  }, DEBOUNCE_WAIT)
 
   selectPoi = poi => {
     const { poiFilters } = this.props;


### PR DESCRIPTION
## Description
Any window resize would trigger a `map_moveend` event.
Currently we fetch data as soon as this event has been fired, so I suggest to debounce `fetchData` to avoid this issue, while still being able to display data while the window is being resized.

## Why
Performance
