### PR TITLE
Add an optional env name in the page title

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -1,5 +1,7 @@
 PORT: 3000
 
+envName: # optional environment name (ex: 'Local', 'Dev') displayed in the page title. Keep empty for production.
+
 # Server
 server:
   maxBodySize: '5KB' # max request body size on POST

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,6 +4,7 @@
     <meta charset='utf-8'>
     <title><%= _('Qwant Maps') %>
       <% if(config.app.versionFlag) { %> - <%= config.app.versionFlag %><% } %>
+      <% if(config.envName) { %> - <%= config.envName %><% } %>
     </title>
     <meta name="description" content="<%= _('The map that respects your privacy') %>">
     <base href="<%= config.system.baseUrl %>" target="_blank">


### PR DESCRIPTION
## Description
Small tweak to add an optional `envName` config value in the page title.
The idea is you add such name in your `.env` file so it's easier to differentiate local and prod (or plive, or dev, if we change the config), especially on mobile tab switching where the url is not displayed.

## Screenshots
|Before|After|
|---|---|
|![IMG_0011](https://user-images.githubusercontent.com/243653/101801917-266a9700-3b0f-11eb-8bce-ec189e479833.PNG)|![IMG_0012](https://user-images.githubusercontent.com/243653/101802095-5b76e980-3b0f-11eb-8591-5ea65a89a80c.PNG)|
|![Screenshot_20201210-173615_Chrome](https://user-images.githubusercontent.com/243653/101802200-73e70400-3b0f-11eb-983e-f48997af1333.jpg)|![Screenshot_20201210-173658_Chrome](https://user-images.githubusercontent.com/243653/101802333-9711b380-3b0f-11eb-99a8-a9bc16620db3.jpg)|


