### PR TITLE
Qmaps 1875 fit maximized direction

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -44,7 +44,7 @@ class Panel extends React.Component {
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
     minimizedTitle: PropTypes.node,
     resizable: PropTypes.bool,
-    fitContent: PropTypes.arrayOf(PropTypes.oneOf(['default', 'minimized'])),
+    fitContent: PropTypes.arrayOf(PropTypes.oneOf(['default', 'minimized', 'maximized'])),
     size: PropTypes.string,
     setSize: PropTypes.func,
     marginTop: PropTypes.number,
@@ -229,7 +229,9 @@ class Panel extends React.Component {
       'minimized': height - (fitContent.indexOf('minimized') >= 0
         ? panelHeight + FIT_CONTENT_PADDING
         : DEFAULT_MINIMIZED_SIZE),
-      'maximized': 0,
+      'maximized': fitContent.indexOf('maximized') >= 0
+        ? height - panelHeight - FIT_CONTENT_PADDING
+        : 0,
     };
 
     return values[size];

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -401,7 +401,7 @@ export default class DirectionPanel extends React.Component {
             <Panel
               className="direction-panel-mobile"
               resizable
-              fitContent={['default']}
+              fitContent={['default', 'maximized']}
               marginTop={marginTop}
               minimizedTitle={_('Unfold to show the results', 'direction')}
               onClose={this.onClose}


### PR DESCRIPTION
## Description
- `Panel`'s fitContent property can now accept maximized value, along with existing minimized and default values.
- In DirectionPanel, use fitContent prop to fit content in maximized state too

I'm quite happy with our previous panels improvements, it seems quite easy to extends its behavior now :hugs: 

## Screenshots
![Peek 2020-12-10 18-29](https://user-images.githubusercontent.com/2981774/101807694-b14e9000-3b15-11eb-8562-a85b72f0a379.gif)


