### PR TITLE
Do not force minimize panel when unnecessary

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -63,7 +63,7 @@ export default class PanelManager extends React.Component {
     window.times.appRendered = Date.now();
 
     listen('map_user_interaction', () => {
-      if (isMobileDevice()) {
+      if (isMobileDevice() && this.state.panelSize !== 'minimized') {
         this.setState({ panelSize: 'minimized' });
       }
     });

--- a/src/panel/direction/MobileRoadMapPreview.jsx
+++ b/src/panel/direction/MobileRoadMapPreview.jsx
@@ -44,7 +44,10 @@ const MobileRoadMapPreview = ({
     () => {
       fire('zoom_step', steps[currentStep]);
     },
-    [currentStep, steps]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentStep]
+    // don't declare steps as dependency as it's dynamically recomputed on each render by DirectionPanel,
+    // causing the ref to change even if the content is the same.
   );
 
   return <div className="itinerary_mobile_step_by_step">


### PR DESCRIPTION
## Description
Improvement over https://github.com/QwantResearch/erdapfel/pull/937: avoid unnecessary re-renders by not calling `setState` when it's not needed.

Helps with the bug of the map not being movable on the step-by-step feature (see https://github.com/QwantResearch/erdapfel/pull/953#issuecomment-745209002), although the first time movement will still be imposssible… :thinking: 