### PR TITLE
Qmaps 1895 - fix state loop with a window.app.navigateBack method

### DIFF
--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -89,7 +89,7 @@ export default class App {
    * @param {Object} fallback.relativeUrl - The relativeUrl to fallback to if history.back is unavailable
    * @param {Object} fallback.state - The state to fallback to if history.back is unavailable
    */
-  back({ relativeUrl = '/', state = {} }) {
+  navigateBack({ relativeUrl = '/', state = {} }) {
     if (history.state !== null) {
       window.history.back();
     } else {

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -84,9 +84,9 @@ export default class App {
 
   /**
    * Go to the previous application state using history.back()
-   * If no previous state is available, use replaceState as a fallback.
+   * If we determine history.back would exit the application, use replaceState as a fallback.
    * @param {Object} fallback
-   * @param {Object} fallback.relativeUrl - The relativeUrl to fallback to if history.back is unavailable
+   * @param {String} fallback.relativeUrl - The relativeUrl to fallback to if history.back is unavailable
    * @param {Object} fallback.state - The state to fallback to if history.back is unavailable
    */
   navigateBack({ relativeUrl = '/', state = {} }) {

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -81,6 +81,20 @@ export default class App {
     const urlWithoutHash = window.location.href.split('#')[0];
     window.history.replaceState(window.history.state, null, `${urlWithoutHash}#${hash}`);
   }
+
+  /**
+   * Go to the previous application state using history.back()
+   * If no previous state is available, use replaceState as a fallback.
+   * @param {Object} fallback
+   * @param {Object} fallback.relativeUrl - The relativeUrl to fallback to if history.back is unavailable
+   * @param {Object} fallback.state - The state to fallback to if history.back is unavailable
+   */
+  back({ relativeUrl = '/', state = {} }) {
+    if (history.state !== null) {
+      window.history.back();
+    } else {
+      // Fallback to search params
+      this.navigateTo(relativeUrl, state, { replaceState: true });
+    }
+  }
 }
-
-

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -328,7 +328,13 @@ export default class DirectionPanel extends React.Component {
   }
 
   toggleDetails() {
-    this.updateUrl({ details: this.props.details ? null : true });
+    if (this.props.details) {
+      window.app.back({
+        relativeUrl: 'routes/' + updateQueryString({ details: false }),
+      });
+    } else {
+      this.updateUrl({ details: true });
+    }
   }
 
   render() {

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -329,7 +329,7 @@ export default class DirectionPanel extends React.Component {
 
   toggleDetails() {
     if (this.props.details) {
-      window.app.back({
+      window.app.navigateBack({
         relativeUrl: 'routes/' + updateQueryString({ details: false }),
       });
     } else {


### PR DESCRIPTION
## Description
- Suggest an api to go back to previous state:
`back` would try to use history.back if there is a previous state, and would replace the state as a fallback method.
the suggested method' signature is :
```js
back({ relativeUrl = '/', state = {} }) {
```


## Why
Short term : Avoid current issue where the app state goes into an infinite loop when toggling direction details.
mid-term : Use a new api to normalize the way we handle going back across our app.
