### PR TITLE
Direction: center route on label click, on mobile

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -124,7 +124,7 @@ export default class DirectionPanel extends React.Component {
     }
 
     if (this.props.activeRouteId !== prevProps.activeRouteId && this.state.routes.length > 0) {
-      fire('set_main_route', { routeId: this.props.activeRouteId, fitView: !isMobileDevice() });
+      fire('set_main_route', { routeId: this.props.activeRouteId, fitView: true });
       this.updateUrl({ params: { details: null }, replace: true });
       this.setState({ activePreviewRoute: null });
     }


### PR DESCRIPTION
## Description
On mobile, when clicking on a route label, the map was not recentered on the itinerary.

## Why
Consistency between mobile/desktop, and UX