### PR TITLE
Fix Directions close/navigate back action

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -332,12 +332,16 @@ export default class DirectionPanel extends React.Component {
   }
 
   toggleDetails() {
-    if (this.props.details) {
-      window.app.navigateBack({
-        relativeUrl: 'routes/' + updateQueryString({ details: false }),
-      });
+    if (isMobileDevice()) {
+      if (this.props.details) {
+        window.app.navigateBack({
+          relativeUrl: 'routes/' + updateQueryString({ details: false }),
+        });
+      } else {
+        this.updateUrl({ params: { details: true }, replace: false });
+      }
     } else {
-      this.updateUrl({ params: { details: true } });
+      this.updateUrl({ params: { details: !this.props.details }, replace: true });
     }
   }
 
@@ -383,7 +387,7 @@ export default class DirectionPanel extends React.Component {
         destination={destination}
         toggleDetails={() => this.toggleDetails()}
         openMobilePreview={() => this.openMobilePreview(routes[activeRouteId])}
-        selectRoute={this.selecteRoute}
+        selectRoute={this.selectRoute}
       />;
 
     const isFormCompleted = origin && destination;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -125,7 +125,7 @@ export default class DirectionPanel extends React.Component {
 
     if (this.props.activeRouteId !== prevProps.activeRouteId && this.state.routes.length > 0) {
       fire('set_main_route', { routeId: this.props.activeRouteId, fitView: !isMobileDevice() });
-      this.updateUrl({ params: { details: null } });
+      this.updateUrl({ params: { details: null }, replace: true });
       this.setState({ activePreviewRoute: null });
     }
   }
@@ -327,6 +327,10 @@ export default class DirectionPanel extends React.Component {
     return handler(e);
   }
 
+  selectRoute = routeId => {
+    this.updateUrl({ params: { selected: routeId }, replace: true });
+  }
+
   toggleDetails() {
     if (this.props.details) {
       window.app.navigateBack({
@@ -379,7 +383,7 @@ export default class DirectionPanel extends React.Component {
         destination={destination}
         toggleDetails={() => this.toggleDetails()}
         openMobilePreview={() => this.openMobilePreview(routes[activeRouteId])}
-        selectRoute={routeId => this.updateUrl({ params: { selected: routeId } })}
+        selectRoute={this.selecteRoute}
       />;
 
     const isFormCompleted = origin && destination;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -125,7 +125,7 @@ export default class DirectionPanel extends React.Component {
 
     if (this.props.activeRouteId !== prevProps.activeRouteId && this.state.routes.length > 0) {
       fire('set_main_route', { routeId: this.props.activeRouteId, fitView: !isMobileDevice() });
-      this.updateUrl({ details: null });
+      this.updateUrl({ params: { details: null } });
       this.setState({ activePreviewRoute: null });
     }
   }
@@ -223,7 +223,7 @@ export default class DirectionPanel extends React.Component {
           window.execOnMapLoaded(() => {
             fire('set_routes', { routes, vehicle, activeRouteId });
           });
-          this.updateUrl({ selected: activeRouteId }, true);
+          this.updateUrl({ params: { selected: activeRouteId }, replace: true });
         });
       } else {
         // Error or empty response
@@ -242,7 +242,7 @@ export default class DirectionPanel extends React.Component {
     }
   }
 
-  updateUrl(params = {}, replace = false) {
+  updateUrl({ params = {}, replace = false } = {}) {
     const search = updateQueryString({
       mode: this.state.vehicle,
       origin: this.state.origin ? poiToUrl(this.state.origin) : null,
@@ -256,7 +256,7 @@ export default class DirectionPanel extends React.Component {
   }
 
   update() {
-    this.updateUrl({}, true);
+    this.updateUrl({ replace: true });
     this.computeRoutes();
     this.context.setSize('default');
   }
@@ -333,7 +333,7 @@ export default class DirectionPanel extends React.Component {
         relativeUrl: 'routes/' + updateQueryString({ details: false }),
       });
     } else {
-      this.updateUrl({ details: true });
+      this.updateUrl({ params: { details: true } });
     }
   }
 
@@ -379,7 +379,7 @@ export default class DirectionPanel extends React.Component {
         destination={destination}
         toggleDetails={() => this.toggleDetails()}
         openMobilePreview={() => this.openMobilePreview(routes[activeRouteId])}
-        selectRoute={routeId => this.updateUrl({ selected: routeId })}
+        selectRoute={routeId => this.updateUrl({ params: { selected: routeId } })}
       />;
 
     const isFormCompleted = origin && destination;

--- a/tests/integration/tests/direction.mobile.js
+++ b/tests/integration/tests/direction.mobile.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { initBrowser } from '../tools';
+import { initBrowser, exists, isHidden } from '../tools';
 import ResponseHandler from '../helpers/response_handler';
 const ROUTES_PATH = 'routes';
 const mockMapBox = require('../../__data__/mapbox.json');
@@ -18,22 +18,23 @@ beforeEach(async () => {
   await responseHandler.prepareResponse();
 });
 
-test('show itinerary roadmap on mobile', async () => {
-  responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
-  await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
+describe('Mobile itinerary details', () => {
+  test('show/hide itinerary roadmap on mobile', async () => {
+    responseHandler.addPreparedResponse(mockMapBox, /\/7\.5000000,47\.4000000;6\.1000000,47\.4000000/);
+    await page.goto(`${APP_URL}/${ROUTES_PATH}/?origin=latlon:47.4:7.5&destination=latlon:47.4:6.1`);
 
-  await page.waitForSelector('.itinerary_leg');
-  await page.click('.itinerary_leg .itinerary_leg_detailsBtn');
-  await page.waitForSelector('.mobile-route-details');
+    await page.waitForSelector('.itinerary_leg');
+    await page.click('.itinerary_leg .itinerary_leg_detailsBtn');
+    await page.waitForSelector('.mobile-route-details');
+    expect(await exists(page, '.mobile-route-details')).toBeTruthy();
 
-  /*
-    This simulates a user action that will close
-    all panels related to the current itinerary,
-    such as a click on a POI on the map.
-  */
-  await page.evaluate('window.app.navigateTo("/")');
-  // Itinerary container should be disabled.
-  await page.waitForSelector('.direction-panel', { hidden: true, timeout: 1000 });
+    await page.evaluate('window.history.back()');
+    expect(await isHidden(page, '.mobile-route-details')).toBeTruthy();
+    expect(await exists(page, '.direction-panel')).toBeTruthy();
+
+    await page.evaluate('window.history.back()');
+    expect(await isHidden(page, '.direction-panel')).toBeTruthy();
+  });
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Description
Fix the navigation logic of route option selection and detail panel toggling, after https://github.com/QwantResearch/erdapfel/pull/979 didn't address all the problems and created new ones on desktop (impossible to close the direction panel :fearful:).

As the main problem is the creation or replacement of new history entries to materialize the panel state, I made the signature of the `updateUrl` method a bit clearer.
Then I converted some history entry pushes to replaces, so that they don't "count" in the back navigation and we always exit the panel. I don't know why we didn't see that before…
I added a special case for the opening of route details in mobile, because in this case it must be possible to exit the details panel with the back action.

~~I'm putting this PR in draft until I add some integration tests to avoid future regressions on these behaviors~~
I've added some tests, it's better than nothing, but I'm not very satisfied of them.

I'd like to rework the whole direction suite later, to add crucial missing things (alternatives, step-by-step mode, etc.)