### PR TITLE
[Clean-up] Don't pass useless function to open step-by-step

### DIFF
--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -386,7 +386,6 @@ export default class DirectionPanel extends React.Component {
         origin={origin}
         destination={destination}
         toggleDetails={() => this.toggleDetails()}
-        openMobilePreview={() => this.openMobilePreview(routes[activeRouteId])}
         selectRoute={this.selectRoute}
       />;
 

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -5,7 +5,7 @@ import { DeviceContext } from 'src/libs/device';
 
 const Route = ({
   id, route, vehicle, showDetails, origin, destination, isActive,
-  toggleDetails, openPreview, selectRoute,
+  toggleDetails, selectRoute,
 }) => {
   const isMobile = useContext(DeviceContext);
 
@@ -17,7 +17,6 @@ const Route = ({
         isActive={isActive}
         showDetails={showDetails}
         toggleDetails={toggleDetails}
-        openPreview={openPreview}
         selectRoute={selectRoute}
         vehicle={vehicle}
       />

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -15,7 +15,6 @@ export default class RouteResult extends React.Component {
     vehicle: PropTypes.string,
     isLoading: PropTypes.bool,
     error: PropTypes.number,
-    openMobilePreview: PropTypes.func.isRequired,
     activeRouteId: PropTypes.number,
     selectRoute: PropTypes.func.isRequired,
     toggleDetails: PropTypes.func.isRequired,
@@ -43,10 +42,6 @@ export default class RouteResult extends React.Component {
   toggleRouteDetails = () => {
     Telemetry.add(Telemetry.ITINERARY_ROUTE_TOGGLE_DETAILS);
     this.props.toggleDetails();
-  }
-
-  openPreview = routeId => {
-    this.props.openMobilePreview(this.props.routes[routeId]);
   }
 
   render() {
@@ -83,7 +78,6 @@ export default class RouteResult extends React.Component {
           vehicle={this.props.vehicle}
           activeDetails={this.props.activeDetails}
           toggleRouteDetails={this.toggleRouteDetails}
-          openPreview={this.openPreview}
           selectRoute={this.selectRoute}
         />
       </div>

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -12,7 +12,6 @@ export default class RouteSummary extends React.Component {
     route: PropTypes.object.isRequired,
     vehicle: PropTypes.string.isRequired,
     toggleDetails: PropTypes.func.isRequired,
-    openPreview: PropTypes.func.isRequired,
     selectRoute: PropTypes.func.isRequired,
     isActive: PropTypes.bool.isRequired,
     showDetails: PropTypes.bool.isRequired,
@@ -25,10 +24,6 @@ export default class RouteSummary extends React.Component {
   onClickDetails = event => {
     event.stopPropagation();
     this.props.toggleDetails(this.props.id);
-  }
-
-  onClickPreview = () => {
-    this.props.openPreview(this.props.id);
   }
 
   onShareClick = (e, handler) => {

--- a/src/panel/direction/RoutesList.jsx
+++ b/src/panel/direction/RoutesList.jsx
@@ -13,7 +13,6 @@ const RoutesList = ({
   destination,
   vehicle,
   toggleRouteDetails,
-  openPreview,
   selectRoute,
   isLoading,
 }) => {
@@ -38,7 +37,6 @@ const RoutesList = ({
             isActive={route.id === activeRouteId}
             showDetails={route.id === activeRouteId && activeDetails}
             toggleDetails={toggleRouteDetails}
-            openPreview={openPreview}
             selectRoute={selectRoute}
           />
         </Item>


### PR DESCRIPTION
## Description
Since recent chances on the code of directions, we don't need to pass the callback to open the step-by-step mode down the whole component tree. Only MobileRouteDetails needs it, and it's rendered directly from DirectionPanel.

## Why
Every simplification that can be done on DirectionPanel and co. is worthwhile :)