### PR TITLE
SuggestItem: use magnifier icon as fallback for categories without icon

### DIFF
--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -26,19 +26,15 @@ const IntentionItem = ({ intention }) => {
     ? `${_('Close to')} ${place.properties.geocoding.name}`
     : _('nearby');
 
+  const intentionIcon = category && category.iconName
+    ? <PlaceIcon className="autocomplete_suggestion_icon" category={category} withBackground />
+    :
+    <div className="autocomplete_suggestion_icon_background autocomplete_suggestion_icon">
+      <Magnifier width={20} />
+    </div>;
+
   return <div className="autocomplete_suggestion autocomplete_suggestion--intention">
-    {category && <PlaceIcon
-      className="autocomplete_suggestion_icon"
-      category={category}
-      withBackground
-    />}
-
-    {fullTextQuery &&
-      <div className="autocomplete_suggestion_icon_background autocomplete_suggestion_icon">
-        <Magnifier width={20} />
-      </div>
-    }
-
+    {intentionIcon}
     <ItemLabels firstLabel={category?.label || fullTextQuery} secondLabel={placeString} />
   </div>;
 };


### PR DESCRIPTION
## Why
Some intentions may be related to categories without explicit icon

## Screenshots

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/102905576-a8de4980-4473-11eb-856c-7fe6c540264e.png)|![image](https://user-images.githubusercontent.com/4726554/102905794-f2c72f80-4473-11eb-9074-ec55d7c5bd2d.png)|


