### PR TITLE
Simplify display of favorites in the suggest dropdown

### DIFF
--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -1,5 +1,6 @@
 /* global _ */
 import React from 'react';
+import classnames from 'classnames';
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import Category from 'src/adapters/category';
 import Intention from 'src/adapters/intention';
@@ -66,23 +67,21 @@ const PoiItem = ({ poi }) => {
       omitStreet={type === 'house' || type === 'street'}
       inline
     />;
+  const isFavorite = poi instanceof PoiStore;
 
   return (
-    <div className="autocomplete_suggestion">
+    <div className={classnames('autocomplete_suggestion', {
+      'autocomplete_suggestion--favorite': isFavorite,
+    })}>
       <PlaceIcon
         className="autocomplete_suggestion_icon"
         place={poi}
-        isFavorite={poi instanceof PoiStore}
+        isFavorite={isFavorite}
       />
       <ItemLabels firstLabel={name} secondLabel={streetAddress} />
     </div>
   );
 };
-
-const SeparatorLabel = ({ label }) =>
-  <h3 className="autocomplete_separator_label">
-    {label}
-  </h3>;
 
 const ErrorLabel = ({ label }) =>
   <div className="autocomplete_error">
@@ -90,10 +89,6 @@ const ErrorLabel = ({ label }) =>
   </div>;
 
 const SuggestItem = ({ item }) => {
-  if (item.simpleLabel) {
-    return <SeparatorLabel label={item.simpleLabel} />;
-  }
-
   if (item.errorLabel) {
     return <ErrorLabel label={item.errorLabel} />;
   }

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -17,14 +17,9 @@ const SuggestsDropdown = ({
       const { key } = e;
 
       if (key === 'ArrowDown') {
-        let h = highlighted === null ? - 1 : highlighted;
+        const h = highlighted === null ? - 1 : highlighted;
 
         if (h < suggestItems.length - 1) {
-          // Jump label
-          if (suggestItems[h + 1] && suggestItems[h + 1].simpleLabel) {
-            h++;
-          }
-
           setHighlighted(h + 1);
           onHighlight(suggestItems[h + 1]);
         } else {
@@ -35,11 +30,7 @@ const SuggestsDropdown = ({
 
       if (key === 'ArrowUp') {
         e.preventDefault(); // prevent cursor returning at beggining
-        let h = highlighted === null ? suggestItems.length : highlighted;
-        // Jump label
-        if (suggestItems[h - 1] && suggestItems[h - 1].simpleLabel) {
-          h--;
-        }
+        const h = highlighted === null ? suggestItems.length : highlighted;
 
         if (h > 0) {
           setHighlighted(h - 1);
@@ -70,14 +61,8 @@ const SuggestsDropdown = ({
       {suggestItems.map((suggest, index) =>
         <li
           key={index}
-          onMouseDown={e => suggestItems[index].simpleLabel
-            ? e.preventDefault()
-            : onSelect(suggestItems[index])
-          }
-          onMouseEnter={() => suggestItems[index].simpleLabel
-            ? setHighlighted(null)
-            : setHighlighted(index)
-          }
+          onMouseDown={() => { onSelect(suggestItems[index]); }}
+          onMouseEnter={() => { setHighlighted(index); }}
           className={classnames({ 'selected': highlighted === index })}
         >
           <SuggestItem item={suggest} />

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -3,7 +3,6 @@ import nconf from '@qwant/nconf-getter';
 
 import NavigatorGeolocalisationPoi from 'src/adapters/poi/specials/navigator_geolocalisation_poi';
 import Poi from 'src/adapters/poi/poi';
-import PoiStore from 'src/adapters/poi/poi_store';
 import Category from 'src/adapters/category';
 import Intention from 'src/adapters/intention';
 import { toUrl } from 'src/libs/pois';
@@ -71,12 +70,6 @@ export const fetchSuggests = (query, options = {}) =>
   });
 
 export const modifyList = (items, withGeoloc, query) => {
-  const firstFav = items.findIndex(item => item instanceof PoiStore);
-
-  if (firstFav > -1) {
-    items.splice(firstFav, 0, { simpleLabel: _('Favorites', 'autocomplete').toUpperCase() });
-  }
-
   if (withGeoloc) {
     items.splice(0, 0, NavigatorGeolocalisationPoi.getInstance());
   }

--- a/src/scss/includes/suggest.scss
+++ b/src/scss/includes/suggest.scss
@@ -68,13 +68,6 @@
   }
 }
 
-.autocomplete_separator_label {
-  font-size: 14px;
-  color : $primary_clear;
-  cursor: default;
-  padding: 9px 18px;
-}
-
 .autocomplete_error {
   padding: 15px 10px 5px;
   color: $primary_text;

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -195,7 +195,7 @@ test('favorite search', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await storePoi(page, { title: 'hello' });
   await page.keyboard.type('Hello');
-  expect(await exists(page, '.autocomplete_separator_label')).toBeTruthy();
+  expect(await exists(page, '.autocomplete_suggestion--favorite')).toBeTruthy();
 });
 
 test('suggestions should not reappear after fast submit', async () => {


### PR DESCRIPTION
## Description
Remove the named section "Favorites" in the suggestion dropdown, which simplifies the suggest code as it was kind of a hack.

## Why
Design.
Now that favorite suggestions have their own icon, we don't need to distinguish them even more by a dedicated section.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2020-12-22 17-43-40](https://user-images.githubusercontent.com/243653/102912884-4179c700-447e-11eb-92c8-711d72551d27.png)|![Capture d’écran de 2020-12-22 17-43-16](https://user-images.githubusercontent.com/243653/102912882-40e13080-447e-11eb-9e27-a0d710c577f5.png)|