### PR TITLE
Panel: force rerender after mount to resize panel correctly on mobile

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -79,7 +79,9 @@ class Panel extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleViewportResize);
-    this.updateMobileMapUI();
+
+    // A rerender may be required to fit the panel height to its content
+    this.forceUpdate();
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
## Why
When the PoiPanel is first rendered (via a direct URL on mobile, such as http://localhost:3000/place/pj:00030994 ), the panel is not correctly resized to fit its content. 
Possibly caused by recent changes where re-rendering was prevented.

Opened as a draft, as I am not sure `.forceUpdate()` is really a good practice here.

## Screenshots
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/4726554/102914529-b817c400-4480-11eb-8188-4c9fdcf1feec.png)|![image](https://user-images.githubusercontent.com/4726554/102914607-d8478300-4480-11eb-9651-930a3b8c9609.png)|




