### PR TITLE
QMAPS-1920 various CSS adjustments around the input fields (PC/mobile)

### DIFF
--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -55,14 +55,14 @@
           position: fixed;
           z-index: 2;
           left: 24px;
-          top: 22px;
+          top: 20px;
           font-size: 20px;
           color: #353C52;
         }
 
         input:valid ~ .direction-field-clear {
           position: fixed;
-          right: 30px;
+          right: 15px;
           display: block;
           top: 15px;
           pointer-events: all;
@@ -75,7 +75,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 64px;
+      width: 56px;
       flex-shrink: 0;
 
       @media (max-width: 640px) {
@@ -123,7 +123,9 @@
 
     @media (max-width: 640px) {
       input:focus {
-        padding-left: 64px;
+        padding-left: 56px;
+        width: calc(100% - 24px);
+
         ~ .direction-icon-block {
           display: none;
         }
@@ -147,6 +149,7 @@
       border: none;
       color: $primary_text;
       font-size: 16px;
+      padding: 0 30px 3px 0;
     }
 
     input:read-only {

--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -123,7 +123,7 @@
 
     @media (max-width: 640px) {
       input:focus {
-        padding-left: 56px;
+        padding-left: 54px;
         width: calc(100% - 24px);
 
         ~ .direction-icon-block {
@@ -139,7 +139,7 @@
       top: 1px;
       padding: 10px;
       color: $secondary_text;
-      font-size: 16px;
+      font-size: 18px;
       pointer-events: none;
     }
 

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -1,6 +1,6 @@
 
 #react_menu__container {
-  width: $spacing-xxl-4;
+  width: 42px;
   height: $spacing-xxl-4;
   flex-shrink: 0;
 }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -23,7 +23,7 @@
 .search_form__input {
   min-width: 0;
   width: calc(100% - 30px);
-  height: 46px;
+  height: $spacing-xxl-4;
   font-size: 16px;
   font-weight: normal;
   color: $grey-black;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -23,7 +23,7 @@
 .search_form__input {
   min-width: 0;
   width: calc(100% - 30px);
-  height: $spacing-xxl-4;
+  height: 46px;
   font-size: 16px;
   font-weight: normal;
   color: $grey-black;
@@ -109,7 +109,7 @@ input[type="search"] {
   width: 30px;
   color: $secondary_text;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 18px;
   display: none;
 }
 
@@ -159,7 +159,7 @@ input[type="search"] {
 
   // Show desktop clear X icon
   #clear_button_desktop {
-    width: $spacing-xxl-4;
+    width: 42px;
     height: $spacing-xxl-4;
     flex-shrink: 0;
     display: block;
@@ -172,7 +172,6 @@ input[type="search"] {
     background: url(../images/magnifier-blue.svg) center no-repeat;
     background-size: 16px 16px;
   }
-
 }
 
 // When the search field is focused and filled
@@ -180,6 +179,9 @@ input[type="search"] {
   .search_form__action {
     background: url(../images/magnifier-blue.svg) center no-repeat;
     background-size: 16px 16px;
+  }
+  .search_form__clear {
+    color: $primary_text;
   }
 }
 

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -251,7 +251,7 @@ input[type="search"] {
     #clear_button_mobile {
       display: block;
       position: absolute;
-      right: 15px;
+      right: 10px;
       top: 0;
       height: 50px;
     }
@@ -280,7 +280,7 @@ input[type="search"] {
   .top_bar--search_focus {
     .search_form__wrapper {
       margin-left: -54px;
-      margin-right: -38px;
+      margin-right: -33px;
     }
 
     // Hide desktop clear X icon


### PR DESCRIPTION
## Description
- Align the input fields and icons better, and avoid overlaps
- Fix some colors and sizes too, according to the mockups

## Screenshots

Mobile:
Pas focus
![image](https://user-images.githubusercontent.com/1225909/103003725-9d515800-4531-11eb-99ed-77095cdbe56c.png)
Focus champ principal / itinéraire
![image](https://user-images.githubusercontent.com/1225909/103003787-bfe37100-4531-11eb-9d7b-bc45a9a9f1cc.png)

PC:
Itinéraire:
![image](https://user-images.githubusercontent.com/1225909/103004692-0769fd00-4532-11eb-9d8a-7ba9126f09d8.png)

Home:
![image](https://user-images.githubusercontent.com/1225909/103004834-118bfb80-4532-11eb-92c3-7345dd5cb82c.png)
![image](https://user-images.githubusercontent.com/1225909/103004955-19e43680-4532-11eb-838a-fc435c0e4e93.png)
