### PR TITLE
mobile direction shortcut: set poi state if any

### DIFF
--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -38,7 +38,8 @@ export default class ExtendedControl {
       'direction',
       () => {
         Telemetry.add(Telemetry.MAP_ITINERARY);
-        window.app.navigateTo('/routes');
+        const poi = window.history.state.poi;
+        window.app.navigateTo('/routes', poi ? { poi } : {});
       }
     );
 


### PR DESCRIPTION
## Description
On mobile, when redirecting to `/routes`, send poi in state if it exists. This is the case when the sortcut is cliked from a minimized POI panel.
This way, destination input can be automatically filled.

## Why
UX
