### PR TITLE
[IE11] Fix 3 JS errors that break nearly everything

### DIFF
--- a/src/adapters/icon_manager.js
+++ b/src/adapters/icon_manager.js
@@ -109,7 +109,7 @@ export function createPinIcon({ className, disablePointerEvents }) {
   const element = document.createElement('div');
   element.className = classnames('marker', className);
   if (disablePointerEvents) {
-    element.style = 'pointer-events:none;';
+    element.style.pointerEvents = 'none';
   }
   return element;
 }

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -198,7 +198,8 @@ export default class SceneDirection {
   }
 
   updateRouteLabels({ id: activeRouteId }) {
-    document.querySelectorAll('.routeLabel').forEach(routeLabel => {
+    // @IE11: array spread to convert NodeList to an array
+    [...document.querySelectorAll('.routeLabel')].forEach(routeLabel => {
       if (routeLabel.dataset.id === activeRouteId.toString()) {
         routeLabel.classList.add('active');
       } else {

--- a/src/components/ui/ShareMenu.jsx
+++ b/src/components/ui/ShareMenu.jsx
@@ -39,7 +39,8 @@ export default class ShareMenu extends React.Component {
 
   componentWillUnmount() {
     if (this.portalContainer) {
-      this.portalContainer.remove();
+      // @IE11: replace with this.portalContainer.remove()
+      this.portalContainer.parent?.removeChild(this.portalContainer);
     }
     this.close();
   }


### PR DESCRIPTION
## Description
Fix 3 Javascript errors specific to IE11, that make the app completely broken on this browser and were easy to fix.

There are many other problems, mostly layout and behaviour of scrollable elements, that make the app barely usable at all. But they are trickier and probably time-consuming to fix.
I don't think if it's worth it and IMO we should quickly decide to drop the support of this browser, in favor of providing a better experience to users of modern browsers.