### PR TITLE
Hide Alert block in no_ui mode

### DIFF
--- a/src/scss/includes/no_ui.scss
+++ b/src/scss/includes/no_ui.scss
@@ -19,4 +19,8 @@
   .category__panel__pj {
     visibility: hidden;
   }
+
+  .alert {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
A small change, following #977, to ensure that the alert is not visible when the app is loaded in no_ui mode.

