### PR TITLE
Poi: trigger + handle directionShortcutClick event

### DIFF
--- a/src/mapbox/extended_nav_control.js
+++ b/src/mapbox/extended_nav_control.js
@@ -2,12 +2,19 @@ import ExtendedScaleControl from './extended_scale_control';
 import ExtendedAttributionControl from './extended_attribution_control';
 import GeolocControl from './extended_geolocate_control';
 import Telemetry from 'src/libs/telemetry';
+import { listen, unListen } from '../libs/customEvents';
 
 export default class ExtendedControl {
   constructor() {
     this._container = document.createElement('div');
     this.topButtonGroup = document.createElement('div');
     this.bottomButtonGroup = document.createElement('div');
+
+    // Store a callback to trigger when direction shortcut is clicked.
+    // if no callback is registered, then the default action will be executed
+    // (navigate to /routes)
+    this.directionShortcutCallback = null;
+    listen('set_direction_shortcut_callback', cb => this.directionShortcutCallback = cb);
 
     const buttonClass = 'icon-plus map_control_group__button__zoom';
 
@@ -38,7 +45,9 @@ export default class ExtendedControl {
       'direction',
       () => {
         Telemetry.add(Telemetry.MAP_ITINERARY);
-        window.app.navigateTo('/routes');
+        this.directionShortcutCallback
+          ? this.directionShortcutCallback()
+          : window.app.navigateTo('/routes'); // default action, if no cb has been set
       }
     );
 
@@ -103,6 +112,7 @@ export default class ExtendedControl {
   onRemove() {
     this._container.parentNode.removeChild(this._container);
     this._map = undefined;
+    unListen('set_direction_shortcut_callback');
   }
 
   _createButton(className, ariaLabel, fn) {

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -43,7 +43,9 @@ export default class PoiPanel extends React.Component {
   }
 
   componentDidMount() {
+    // direction shortcut will be visible in minimized state
     fire('mobile_direction_button_visibility', false);
+    fire('set_direction_shortcut_callback', this.openDirection);
 
     // Load poi or pois
     !this.props.pois ? this.loadPoi() : this.loadPois();
@@ -66,6 +68,8 @@ export default class PoiPanel extends React.Component {
     fire('move_mobile_bottom_ui', 0);
     fire('clean_marker');
     fire('mobile_direction_button_visibility', true);
+    // Clear direction shortcut cb to reset default action
+    fire('set_direction_shortcut_callback', null);
   }
 
   loadPois = () => {


### PR DESCRIPTION
## Description
- On the Direction shortcut button (managed by mapbox), listen for `set_direction_shortcut_callback`.
- Use set_direction_shortcut_callback on PoiPanel.

## Why
Add missing destination when clicking the "shortcut" direction button from a Poi.

## Screenshots
![Peek 2021-01-06 14-54](https://user-images.githubusercontent.com/2981774/103776007-233fc980-502f-11eb-87be-f1fc2c1697d9.gif)

