### PR TITLE
Try scroll-snap-stop:always

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -396,6 +396,7 @@ button.direction_shortcut {
         align-items: center;
         justify-content: center;
         scroll-snap-align: start;
+        scroll-snap-stop: always;
         border: none;
         border-radius: 12px;
         box-shadow: $shadow;


### PR DESCRIPTION
## Description
Try [`scroll-snap-stop:always`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) as a light fix to the "too sensitive" scroll on mobile Chrome.
It's supposed to be supported https://bugs.chromium.org/p/chromium/issues/detail?id=823998&q=scroll-snap-stop&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified.