### PR TITLE
Don't empty search bar on panel manipulation

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -77,9 +77,9 @@ export default class PanelManager extends React.Component {
       if (isNullOrEmpty(options?.poiFilters)) {
         fire('remove_category_markers');
       }
-    }
 
-    this.updateSearchBarContent(options);
+      this.updateSearchBarContent(options);
+    }
   }
 
   updateSearchBarContent({ poiFilters = {}, query } = {}) {


### PR DESCRIPTION
## Description
Following https://github.com/QwantResearch/erdapfel/pull/959, the search bar content can be kept when the user exits the suggest with the back arrow in the mobile top bar, even if the search query hasn't been validated.
However, if they change the panel height, this clears the search bar content.

This is a side effect of the `PanelManager` being used to manage the mobile panel size as a context. Changing the panel size triggers a re-render, and an inconditional update of the search bar.
This update can be wrapped in a condition to happen only on Panel type or option change.
