### PR TITLE
Send telemetry event on route preview open

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -27,6 +27,7 @@ module.exports = {
     'itinerary_route_select',
     'itinerary_route_toggle_details',
     'itinerary_point_geolocation',
+    'itinerary_route_preview_open',
     /* Poi */
     'poi_category_open',
     'poi_backtofavorite',

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -319,6 +319,7 @@ export default class DirectionPanel extends React.Component {
   }
 
   openMobilePreview = route => {
+    Telemetry.add(Telemetry.ITINERARY_ROUTE_PREVIEW_OPEN);
     this.setState({ activePreviewRoute: route });
   }
 


### PR DESCRIPTION
## Why
To get usage statistics for the "step by step" mode.
