### PR TITLE
Use label provided by Idunn instead of raw url in website block

### DIFF
--- a/src/panel/poi/blocks/Website.jsx
+++ b/src/panel/poi/blocks/Website.jsx
@@ -30,6 +30,13 @@ export default class WebsiteBlock extends React.Component {
     };
   }
 
+  getWebsiteLabel() {
+    if (this.props.block.label) {
+      return this.props.block.label;
+    }
+    return URI.extractDomain(this.props.block.url);
+  }
+
   render() {
     return <Block className="block-website" icon="icon_globe" title={_('website')}>
       <a
@@ -38,7 +45,7 @@ export default class WebsiteBlock extends React.Component {
         target="_blank"
         onClick={this.clickWebsite}
       >
-        { URI.extractDomain(this.props.block.url) }
+        { this.getWebsiteLabel() }
       </a>
     </Block>;
   }

--- a/tests/__data__/poi.json
+++ b/tests/__data__/poi.json
@@ -183,7 +183,8 @@
         }]
     }, {
         "type": "website",
-        "url": "http://www.musee-orsay.fr"
+        "url": "http://redirect.test?u=www.musee-orsay.fr",
+        "label": "www.musee-orsay.fr"
     }, {
       "type": "contact",
       "url": "mailto:admin@orsay.fr"


### PR DESCRIPTION
## Description
Idunn API may return a `label` in addition to the raw `url`, when using a redirected URL is required to proxify calls to a data provider. This label is used as the link description, instead of a misleading domain name.

See [this PR](https://github.com/QwantResearch/idunn/pull/174/files#diff-74757a4a8b90290966a7e1150d25141fc57e82657a9ac6ab2c992a75d6c7aa38) for more details
