### PR TITLE
Define a hover style for POI labels

### DIFF
--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -41,6 +41,10 @@ export const getFilteredPoisLabelStyle = () => ({
 const COLOR_ACTION_BLUE_BASE = '#1a6aff';
 
 export const setPoiHoverStyle = (map, poiLayer) => {
+  if (!map.getPaintProperty) {
+    // @MAPBOX: This method isn't implemented by the Mapbox-GL mock
+    return;
+  }
   const textColorProperty = map.getPaintProperty(poiLayer, 'text-color');
   map.setPaintProperty(poiLayer, 'text-color',
     ['case', ['to-boolean', ['feature-state', 'hover']], COLOR_ACTION_BLUE_BASE, textColorProperty],

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -17,8 +17,6 @@ export const getFilteredPoisPinStyle = () => ({
   },
 });
 
-
-
 export const getFilteredPoisLabelStyle = () => ({
   type: 'symbol',
   layout: {
@@ -39,3 +37,13 @@ export const getFilteredPoisLabelStyle = () => ({
     'text-translate': [0, -2],
   },
 });
+
+const COLOR_ACTION_BLUE_BASE = '#1a6aff';
+
+export const setPoiHoverStyle = (map, poiLayer) => {
+  const textColorProperty = map.getPaintProperty(poiLayer, 'text-color');
+  map.setPaintProperty(poiLayer, 'text-color',
+    ['case', ['to-boolean', ['feature-state', 'hover']], COLOR_ACTION_BLUE_BASE, textColorProperty],
+    { validate: false },
+  );
+};


### PR DESCRIPTION
## Description
Change the label color of map tiles POI to blue on "hover".
To do so, modify the style of POI layers dynamically to add a condition based on Mapbox-GL [`feature-state`](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#feature-state) to the existing `text-color` rule.
(Sadly some other parameters like the font weight can't be changed with this mechanism.)

For now I add that to existing init code about POI interactivity in `scene.js`, but I think we could structure this part better. Like extracting all this interactivity code to another module so it's easier to manage and simplify `scene.js`.

## Screenshots
![Peek 14-01-2021 15-27](https://user-images.githubusercontent.com/243653/104603841-1baaa100-567d-11eb-92e9-2542e8f6dbeb.gif)
