### PR TITLE
Centralize JS color constants from the design system

### DIFF
--- a/src/adapters/icon_manager.js
+++ b/src/adapters/icon_manager.js
@@ -1,5 +1,6 @@
 import styleIcons from '@qwant/qwant-basic-gl-style/icons.yml';
 import classnames from 'classnames';
+import { ACTION_BLUE_DARK } from 'src/libs/colors';
 
 const nameToClass = iconName => iconName.match(/^(.*?)-[0-9]{1,2}$/)[1];
 
@@ -60,7 +61,7 @@ export default class IconManager {
     } else if (type === 'geoloc') {
       return {
         iconClass: 'pin_geoloc',
-        color: '#1050c5', // action-blue-dark
+        color: ACTION_BLUE_DARK,
         icomoon: true,
       };
 

--- a/src/adapters/pois_styles.js
+++ b/src/adapters/pois_styles.js
@@ -1,3 +1,4 @@
+import { ACTION_BLUE_BASE, RED_DARKER, GREY_BLACK } from 'src/libs/colors';
 
 export const getFilteredPoisPinStyle = () => ({
   type: 'symbol',
@@ -31,14 +32,12 @@ export const getFilteredPoisLabelStyle = () => ({
     'text-justify': 'auto',
   },
   paint: {
-    'text-color': ['case', ['==', ['feature-state', 'selected'], true], '#900014', '#0c0c0e'],
+    'text-color': ['case', ['==', ['feature-state', 'selected'], true], RED_DARKER, GREY_BLACK],
     'text-halo-color': 'white',
     'text-halo-width': 1,
     'text-translate': [0, -2],
   },
 });
-
-const COLOR_ACTION_BLUE_BASE = '#1a6aff';
 
 export const setPoiHoverStyle = (map, poiLayer) => {
   if (!map.getPaintProperty) {
@@ -47,7 +46,7 @@ export const setPoiHoverStyle = (map, poiLayer) => {
   }
   const textColorProperty = map.getPaintProperty(poiLayer, 'text-color');
   map.setPaintProperty(poiLayer, 'text-color',
-    ['case', ['to-boolean', ['feature-state', 'hover']], COLOR_ACTION_BLUE_BASE, textColorProperty],
+    ['case', ['to-boolean', ['feature-state', 'hover']], ACTION_BLUE_BASE, textColorProperty],
     { validate: false },
   );
 };

--- a/src/adapters/route_styles.js
+++ b/src/adapters/route_styles.js
@@ -1,12 +1,13 @@
 import Color from 'color';
+import {
+  ACTION_BLUE_SEMI_LIGHTNESS,
+  ACTION_BLUE_DARK,
+  GREY_GREY,
+  GREY_SEMI_LIGHTNESS,
+} from 'src/libs/colors';
 
 const darkenColor = hex => Color(hex).mix(Color('black'), 0.33).hex();
 const safeHexColor = hex => hex.charAt(0) === '#' ? hex : `#${hex}`;
-
-const ACTIVE_ROUTE_COLOR = '#3f81fb'; // action-blue-semi-lightness
-const ACTIVE_ROUTE_COLOR_OUTLINE = '#1050c5'; // action-blue-dark
-const INACTIVE_ROUTE_COLOR = '#c8cbd3';
-const INACTIVE_ROUTE_COLOR_OUTLINE = darkenColor(INACTIVE_ROUTE_COLOR);
 
 export function prepareRouteColor(feature) {
   const lineColor = feature.properties?.lineColor;
@@ -14,8 +15,8 @@ export function prepareRouteColor(feature) {
     ...feature,
     properties: {
       ...feature.properties,
-      lineColor: lineColor ? safeHexColor(lineColor) : ACTIVE_ROUTE_COLOR,
-      outlineColor: lineColor ? darkenColor(safeHexColor(lineColor)) : ACTIVE_ROUTE_COLOR_OUTLINE,
+      lineColor: lineColor ? safeHexColor(lineColor) : ACTION_BLUE_SEMI_LIGHTNESS,
+      outlineColor: lineColor ? darkenColor(safeHexColor(lineColor)) : ACTION_BLUE_DARK,
     },
   };
 }
@@ -24,7 +25,7 @@ function getColorExpression(isActive, isOutline) {
   if (isActive) {
     return isOutline ? ['get', 'outlineColor'] : ['get', 'lineColor'];
   }
-  return isOutline ? INACTIVE_ROUTE_COLOR_OUTLINE : INACTIVE_ROUTE_COLOR;
+  return isOutline ? GREY_GREY : GREY_SEMI_LIGHTNESS;
 }
 
 export function getRouteStyle(vehicle, isActive, isOutline) {

--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -2,19 +2,20 @@
 import React from 'react';
 import classnames from 'classnames';
 import { capitalizeFirst } from 'src/libs/string';
+import { GREEN_DARK, RED_DARKER } from 'src/libs/colors';
 
 const getStatusMessage = status => {
   if (status === 'open') {
     return {
       label: _('Open'),
-      color: '#5d9836',
+      color: GREEN_DARK,
     };
   }
 
   if (status === 'closed') {
     return {
       label: _('Closed'),
-      color: '#900014',
+      color: RED_DARKER,
     };
   }
 

--- a/src/components/PlaceIcon.jsx
+++ b/src/components/PlaceIcon.jsx
@@ -3,8 +3,7 @@ import IconManager from 'src/adapters/icon_manager';
 import { getLightBackground } from 'src/libs/colors';
 import classnames from 'classnames';
 import { Heart } from 'src/components/ui/icons';
-
-const favoriteColor = '#cd1690';
+import { PINK_DARK, PINK_LIGHTER } from 'src/libs/colors';
 
 const PlaceIcon = ({ place, category, withBackground, className, isFavorite = false }) => {
   let iconClass = '', color = '', icomoon = false;
@@ -39,12 +38,12 @@ const FavoriteIcon = ({ className }) => {
     <div
       className={classnames('placeIcon', className)}
       style={{
-        color: favoriteColor,
-        backgroundColor: getLightBackground(favoriteColor),
+        color: PINK_DARK,
+        backgroundColor: PINK_LIGHTER,
       }}
     >
       <Heart
-        color={favoriteColor}
+        color={PINK_DARK}
         width={20}
       />
     </div>

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -2,3 +2,17 @@
 // Color is in #rrggbb format, background is #rrggbbaa where alpha is equal to '28' (0.157)
 export const getLightBackground = color =>
   color + '28';
+
+export const ACTION_BLUE_BASE = '#1a6aff';
+export const ACTION_BLUE_DARK = '#1050c5';
+export const ACTION_BLUE_SEMI_LIGHTNESS = '#3f81fb';
+export const PINK_DARK = '#cd1690';
+export const PINK_LIGHTER = '#fbd9ef';
+export const GREY_GREY = '#898991';
+export const GREY_SEMI_LIGHTNESS = '#c4c4cc';
+export const GREY_BLACK = '#0c0c0e';
+export const GREEN_BASE = '#83c458';
+export const GREEN_DARK = '#5d9836';
+export const ORANGE_BASE = '#ff851e';
+export const RED_BASE = '#ff1d3c';
+export const RED_DARKER = '#900014';

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import Telemetry from 'src/libs/telemetry';
 import { Flex, ShareMenu, Button } from 'src/components/ui';
 import { Heart } from 'src/components/ui/icons';
-
-const activeFavoriteColor = '#cd1690';
+import { PINK_DARK } from 'src/libs/colors';
 
 const ActionButtons = ({
   poi,
@@ -24,7 +23,7 @@ const ActionButtons = ({
     Telemetry.add(Telemetry.POI_SHARE_TO, { target });
   };
 
-  const favoriteColor = isPoiInFavorite ? activeFavoriteColor : null;
+  const favoriteColor = isPoiInFavorite ? PINK_DARK : null;
 
   return <Flex className="poi_panel__actions">
     {isDirectionActive && <Button

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -2,10 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Flex, Text, Meter } from 'src/components/ui';
-
-const GREEN = '#87c966';
-const YELLOW = '#ffda12';
-const RED = '#ff3b4a';
+import { GREEN_BASE, ORANGE_BASE, RED_BASE } from 'src/libs/colors';
 
 const containerTypes = type => {
   return {
@@ -32,9 +29,9 @@ const Container = ({ type, filling_level, updated_at }) =>
       <Text>{filling_level} %</Text>
     </Flex>
     <Meter value={filling_level} colors={[
-      { min: 0, color: GREEN },
-      { min: 50, color: YELLOW },
-      { min: 75, color: RED },
+      { min: 0, color: GREEN_BASE },
+      { min: 50, color: ORANGE_BASE },
+      { min: 75, color: RED_BASE },
     ]} />
   </div>;
 


### PR DESCRIPTION
## Description
Put all color constants defined in JS in a single place, and give them their "official" names from the design system.

## Why
 - Easier to maintain 
 - Better basis for communication with the design team
 - Easier to migrate later to a system where colors are defined in a single place for availability in CSS and JS (but needs CSS vars, which needs we drop IE11…)