### PR TITLE
Don't attach POI 'hover' interaction on mobile devices

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -116,27 +116,29 @@ Scene.prototype.initMapBox = async function(locationHash) {
     this.mb.addControl(new ExtendedControl(), 'bottom-right');
     this.mb.addControl(new MobileCompassControl(), 'top-right');
 
-    interactiveLayers.forEach(interactiveLayer => {
-      setPoiHoverStyle(this.mb, interactiveLayer);
+    if (!isMobileDevice()) {
+      interactiveLayers.forEach(interactiveLayer => {
+        setPoiHoverStyle(this.mb, interactiveLayer);
 
-      this.mb.on('mouseenter', interactiveLayer, e => {
-        if (e.features.length > 0) {
-          this.hoveredPoi = e.features[0];
-          this.mb.setFeatureState(this.hoveredPoi, { hover: true });
-        }
-        this.mb.getCanvas().style.cursor = 'pointer';
+        this.mb.on('mouseenter', interactiveLayer, e => {
+          if (e.features.length > 0) {
+            this.hoveredPoi = e.features[0];
+            this.mb.setFeatureState(this.hoveredPoi, { hover: true });
+          }
+          this.mb.getCanvas().style.cursor = 'pointer';
+        });
+
+        this.mb.on('mouseleave', interactiveLayer, () => {
+          if (this.hoveredPoi) {
+            this.mb.setFeatureState(this.hoveredPoi, { hover: false });
+            this.hoveredPoi = null;
+          }
+          this.mb.getCanvas().style.cursor = '';
+        });
+
+        this.popup.addListener(interactiveLayer);
       });
-
-      this.mb.on('mouseleave', interactiveLayer, () => {
-        if (this.hoveredPoi) {
-          this.mb.setFeatureState(this.hoveredPoi, { hover: false });
-          this.hoveredPoi = null;
-        }
-        this.mb.getCanvas().style.cursor = '';
-      });
-
-      this.popup.addListener(interactiveLayer);
-    });
+    }
 
     // we have to delay click event resolution to make time for possible double click events,
     // which are thrown *after* two separate click events are thrown


### PR DESCRIPTION
## Description
Add a `isMobileDevice` check around the declaration of hover interactions on POIs, as they can be properly done on touch-based device.

This is an imperfect solution, as it doesn't react to screen size changes after loads and uses the screen size as a criterion for determining if the device is touch-based, but I did it because we already solved the same problem on the dynamic POI layer the same way https://github.com/QwantResearch/erdapfel/blob/master/src/adapters/scene_category.js#L93-L96

A better way to implement that is to use a [`hover` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover), but as this isn't supported on IE11 it would disable on this browser.
I've added this to the list of [things we can improve after we ditch IE11](https://github.com/QwantResearch/erdapfel/issues/978).
