### PR TITLE
[React] Convert some easy components to functional 

### DIFF
--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -1,5 +1,5 @@
 /* globals _ */
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { menu as menuItems } from '../../config/constants.yml';
 import nconf from '@qwant/nconf-getter';
@@ -9,93 +9,89 @@ import Telemetry from 'src/libs/telemetry';
 
 const isDirectionActive = nconf.get().direction.enabled;
 
-export default class Menu extends React.Component {
-  state = {
-    isOpen: false,
+const Menu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuContainer = useRef(document.createElement('div'));
+
+  useEffect(() => {
+    const current = menuContainer.current;
+    document.body.appendChild(current);
+    return () => {
+      document.body.removeChild(current);
+    };
+  }, []);
+
+  const open = () => {
+    Telemetry.add(Telemetry.MENU_CLICK);
+    setIsOpen(true);
   };
 
-  componentDidMount = () => {
-    this.menuContainer = document.createElement('div');
-    document.body.appendChild(this.menuContainer);
-  }
+  const close = () => {
+    setIsOpen(false);
+  };
 
-  componentWillUnmount = () => {
-    if (this.menuContainer) {
-      this.menuContainer.remove();
-    }
-  }
-
-  open = () => {
-    Telemetry.add(Telemetry.MENU_CLICK);
-    this.setState({ isOpen: true });
-  }
-
-  close = () => {
-    this.setState({ isOpen: false });
-  }
-
-  navTo = (url, options) => {
-    this.close();
+  const navTo = (url, options) => {
+    close();
     window.app.navigateTo(url, options);
-  }
+  };
 
-  render() {
-    return <Fragment>
-      <MenuButton onClick={this.open} />
+  return <Fragment>
+    <MenuButton onClick={open} />
 
-      {this.state.isOpen && ReactDOM.createPortal(<div className="menu">
-        <div className="menu__overlay" onClick={this.close} />
+    {isOpen && ReactDOM.createPortal(<div className="menu">
+      <div className="menu__overlay" onClick={close} />
 
-        <div className="menu__panel">
-          <div className="menu__panel__top">
-            <h2 className="menu__panel__top__title">
-              <i className="menu__panel__top__icon icon-map" />
-              <span>Qwant Maps</span>
-              <i className="icon-x menu__panel__top__close" onClick={this.close} />
-            </h2>
-          </div>
-
-          <div className="menu__panel__items_container">
-            <div className="menu__panel__section menu__panel__section-internal">
-              <button className="menu__panel__action"
-                onClick={() => { this.navTo('/', { focusSearch: true }); }}
-              >
-                <img
-                  className="menu__panel__action__icon"
-                  src="./statics/images/magnifier-dark.svg" alt=""
-                />
-                <span>{_('Search', 'menu')}</span>
-              </button>
-              {isDirectionActive &&
-                <button className="menu__panel__action" onClick={() => {
-                  Telemetry.add(Telemetry.MENU_ITINERARY);
-                  this.navTo('/routes/');
-                }}>
-                  <i className="menu__panel__action__icon icon-corner-up-right" />
-                  <span>{_('Directions', 'menu')}</span>
-                </button>
-              }
-              <button className="menu__panel__action" onClick={() => {
-                Telemetry.add(Telemetry.MENU_FAVORITE);
-                this.navTo('/favs/');
-              }}>
-                <i className="menu__panel__action__icon icon-icon_star" />
-                <span>{_('Favorites', 'menu')}</span>
-              </button>
-              <a className="menu__panel__action menu__panel__section_title__link"
-                href="https://github.com/QwantResearch/qwantmaps/blob/master/contributing.md"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <i className="menu__panel__action__icon icon-zap" />
-                <span>{_('How to contribute', 'menu')}</span>
-              </a>
-            </div>
-
-            {menuItems.map(menuItem => <MenuItem key={menuItem.sectionName} menuItem={menuItem} />)}
-          </div>
+      <div className="menu__panel">
+        <div className="menu__panel__top">
+          <h2 className="menu__panel__top__title">
+            <i className="menu__panel__top__icon icon-map" />
+            <span>Qwant Maps</span>
+            <i className="icon-x menu__panel__top__close" onClick={close} />
+          </h2>
         </div>
-      </div>, this.menuContainer)}
-    </Fragment>;
-  }
+
+        <div className="menu__panel__items_container">
+          <div className="menu__panel__section menu__panel__section-internal">
+            <button className="menu__panel__action"
+              onClick={() => { navTo('/', { focusSearch: true }); }}
+            >
+              <img
+                className="menu__panel__action__icon"
+                src="./statics/images/magnifier-dark.svg" alt=""
+              />
+              <span>{_('Search', 'menu')}</span>
+            </button>
+            {isDirectionActive &&
+              <button className="menu__panel__action" onClick={() => {
+                Telemetry.add(Telemetry.MENU_ITINERARY);
+                navTo('/routes/');
+              }}>
+                <i className="menu__panel__action__icon icon-corner-up-right" />
+                <span>{_('Directions', 'menu')}</span>
+              </button>
+            }
+            <button className="menu__panel__action" onClick={() => {
+              Telemetry.add(Telemetry.MENU_FAVORITE);
+              navTo('/favs/');
+            }}>
+              <i className="menu__panel__action__icon icon-icon_star" />
+              <span>{_('Favorites', 'menu')}</span>
+            </button>
+            <a className="menu__panel__action menu__panel__section_title__link"
+              href="https://github.com/QwantResearch/qwantmaps/blob/master/contributing.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <i className="menu__panel__action__icon icon-zap" />
+              <span>{_('How to contribute', 'menu')}</span>
+            </a>
+          </div>
+
+          {menuItems.map(menuItem => <MenuItem key={menuItem.sectionName} menuItem={menuItem} />)}
+        </div>
+      </div>
+    </div>, menuContainer.current)}
+  </Fragment>;
 }
+
+export default Menu;

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -92,6 +92,6 @@ const Menu = () => {
       </div>
     </div>, menuContainer.current)}
   </Fragment>;
-}
+};
 
 export default Menu;

--- a/src/panel/favorites/FavoritePoi.jsx
+++ b/src/panel/favorites/FavoritePoi.jsx
@@ -8,63 +8,63 @@ import Telemetry from 'src/libs/telemetry';
 import ShareMenu from 'src/components/ui/ShareMenu';
 import { toAbsoluteUrl, toUrl } from 'src/libs/pois';
 
-export default class FavoritePoi extends React.Component {
-  static propTypes = {
-    poi: PropTypes.object.isRequired,
-    removeFavorite: PropTypes.func.isRequired,
-  }
-
-  onClick = () => {
+const FavoritePoi = ({ poi, removeFavorite }) => {
+  const onClick = () => {
     Telemetry.add(Telemetry.FAVORITE_GO);
-    window.app.navigateTo(`/place/${toUrl(this.props.poi)}`, {
-      poi: this.props.poi,
+    window.app.navigateTo(`/place/${toUrl(poi)}`, {
+      poi,
       centerMap: true,
       isFromFavorite: true,
     });
-  }
-
-  onDelete = () => {
-    this.props.removeFavorite(this.props.poi);
   };
 
-  onShareClick = (e, handler) => {
+  const onDelete = () => {
+    removeFavorite(poi);
+  };
+
+  const onShareClick = (e, handler) => {
     Telemetry.add(Telemetry.FAVORITE_SHARE);
     return handler(e);
-  }
+  };
 
-  render() {
-    const { poi } = this.props;
-    const icon = IconManager.get(poi);
-    return <div className="favorite_panel__item">
-      <div
-        className={`favorite_panel__item__image icon icon-${icon && icon.iconClass}`}
-        style={{ color: icon && icon.color || '#444648' }}
+  const icon = IconManager.get(poi);
+
+  return <div className="favorite_panel__item">
+    <div
+      className={`favorite_panel__item__image icon icon-${icon && icon.iconClass}`}
+      style={{ color: icon && icon.color || '#444648' }}
+    />
+    <div className="favorite_panel__item__info" onClick={onClick}>
+      <p
+        className="favorite_panel__item__title"
+        dangerouslySetInnerHTML={{ __html: poi.name
+          ? htmlEncode(poi.name)
+          : 'default',
+        }}
       />
-      <div className="favorite_panel__item__info" onClick={this.onClick}>
-        <p
-          className="favorite_panel__item__title"
-          dangerouslySetInnerHTML={{ __html: poi.name
-            ? htmlEncode(poi.name)
-            : 'default',
-          }}
-        />
-        <p className="favorite_panel__item__desc u-text--subtitle u-firstCap">
-          {poi.subClassName ? poiSubClass(poi.subClassName) : ''}
-        </p>
-      </div>
-      <ShareMenu url={toAbsoluteUrl(this.props.poi)} scrollableParent=".panel-content">
-        {openMenu =>
-          <div
-            className="favorite_panel__item__share"
-            title={_('Share')}
-            onClick={e => this.onShareClick(e, openMenu)}
-          >
-            <i className="icon-share-2" />
-          </div>}
-      </ShareMenu>
-      <div className="favorite_panel__item__delete" title={_('Delete')} onClick={this.onDelete}>
-        <span className="icon-trash"></span>
-      </div>
-    </div>;
-  }
-}
+      <p className="favorite_panel__item__desc u-text--subtitle u-firstCap">
+        {poi.subClassName ? poiSubClass(poi.subClassName) : ''}
+      </p>
+    </div>
+    <ShareMenu url={toAbsoluteUrl(poi)} scrollableParent=".panel-content">
+      {openMenu =>
+        <div
+          className="favorite_panel__item__share"
+          title={_('Share')}
+          onClick={e => onShareClick(e, openMenu)}
+        >
+          <i className="icon-share-2" />
+        </div>}
+    </ShareMenu>
+    <div className="favorite_panel__item__delete" title={_('Delete')} onClick={onDelete}>
+      <span className="icon-trash" />
+    </div>
+  </div>;
+};
+
+FavoritePoi.propTypes = {
+  poi: PropTypes.object.isRequired,
+  removeFavorite: PropTypes.func.isRequired,
+};
+
+export default FavoritePoi;

--- a/src/panel/poi/blocks/Hour.jsx
+++ b/src/panel/poi/blocks/Hour.jsx
@@ -6,23 +6,23 @@ import PropTypes from 'prop-types';
 
 import Block from 'src/panel/poi/blocks/Block';
 
-export default class HourBlock extends React.Component {
-  static propTypes = {
-    block: PropTypes.object,
-    covid19enabled: PropTypes.bool,
+const HourBlock = ({ block, covid19enabled }) => {
+  const schedule = new OsmSchedule(block);
+  if (!schedule.days) {
+    return null;
   }
 
-  render() {
-    const schedule = new OsmSchedule(this.props.block);
-    if (!schedule.days) {
-      return null;
-    }
+  return <Block icon="icon_clock" title={_('opening hours')}>
+    <TimeTable
+      schedule={schedule}
+      title={covid19enabled && _('See the usual opening hours', 'covid19')}
+    />
+  </Block>;
+};
 
-    return <Block icon="icon_clock" title={_('opening hours')}>
-      <TimeTable
-        schedule={schedule}
-        title={this.props.covid19enabled && _('See the usual opening hours', 'covid19')}
-      />
-    </Block>;
-  }
-}
+HourBlock.propTypes = {
+  block: PropTypes.object,
+  covid19enabled: PropTypes.bool,
+};
+
+export default HourBlock;

--- a/src/panel/poi/blocks/Website.jsx
+++ b/src/panel/poi/blocks/Website.jsx
@@ -6,47 +6,40 @@ import URI from '@qwant/uri';
 import Telemetry from 'src/libs/telemetry';
 import Block from 'src/panel/poi/blocks/Block';
 
-export default class WebsiteBlock extends React.Component {
-  static propTypes = {
-    block: PropTypes.object,
-    poi: PropTypes.object,
-  }
+const WebsiteBlock = ({ block, poi }) => {
+  const onClickWebsite = () => {
+    Telemetry.sendPoiEvent(poi, 'website',
+      Telemetry.buildInteractionData(
+        {
+          'id': poi.id,
+          'source': poi.meta.source,
+          'template': 'single',
+          'zone': 'detail',
+          'element': 'website',
+        }
+      )
+    );
+  };
 
-  constructor(props) {
-    super(props);
+  const getWebsiteLabel = () => {
+    return block.label || URI.extractDomain(block.url);
+  };
 
-    this.clickWebsite = () => {
-      Telemetry.sendPoiEvent(this.props.poi, 'website',
-        Telemetry.buildInteractionData(
-          {
-            'id': this.props.poi.id,
-            'source': this.props.poi.meta.source,
-            'template': 'single',
-            'zone': 'detail',
-            'element': 'website',
-          }
-        )
-      );
-    };
-  }
+  return <Block className="block-website" icon="icon_globe" title={_('website')}>
+    <a
+      href={URI.externalise(block.url)}
+      rel="noopener noreferrer nofollow"
+      target="_blank"
+      onClick={onClickWebsite}
+    >
+      {getWebsiteLabel()}
+    </a>
+  </Block>;
+};
 
-  getWebsiteLabel() {
-    if (this.props.block.label) {
-      return this.props.block.label;
-    }
-    return URI.extractDomain(this.props.block.url);
-  }
+WebsiteBlock.propTypes = {
+  block: PropTypes.object,
+  poi: PropTypes.object,
+};
 
-  render() {
-    return <Block className="block-website" icon="icon_globe" title={_('website')}>
-      <a
-        href={URI.externalise(this.props.block.url)}
-        rel="noopener noreferrer nofollow"
-        target="_blank"
-        onClick={this.clickWebsite}
-      >
-        { this.getWebsiteLabel() }
-      </a>
-    </Block>;
-  }
-}
+export default WebsiteBlock;

--- a/src/panel/service/ServicePanelMobile.jsx
+++ b/src/panel/service/ServicePanelMobile.jsx
@@ -8,69 +8,67 @@ import Telemetry from 'src/libs/telemetry';
 
 const directionConf = nconf.get().direction;
 
-class ServicePanelMobile extends React.Component {
-  render() {
-    return <Panel
-      resizable
-      minimizedTitle={_('Unfold to see quick actions', 'service panel')}
-      className="service_panel"
-    >
-      {directionConf.enabled && <Fragment>
-        <h3 className="u-text--smallTitle u-center u-mb-s">
-          {_('Directions', 'service panel')}
-        </h3>
-        <div className="service_panel__actions">
-          <Action
-            onClick={() => {
-              Telemetry.add(Telemetry.ITINERARY_MODE_DRIVING);
-              window.app.navigateTo('/routes/?mode=driving');
-            }}
-            variant="directionMode"
-            icon="drive"
-            label={_('by car', 'service panel')}
-          />
-          {
-            directionConf.publicTransport
-            && directionConf.publicTransport.enabled
-            && <Action
-              onClick={() => {
-                Telemetry.add(Telemetry.ITINERARY_MODE_PUBLICTRANSPORT);
-                window.app.navigateTo('/routes/?mode=publicTransport');
-              }}
-              variant="directionMode"
-              icon="public-transport"
-              label={_('transit', 'service panel')}
-            />
-          }
-          <Action
-            onClick={() => {
-              Telemetry.add(Telemetry.ITINERARY_MODE_WALKING);
-              window.app.navigateTo('/routes/?mode=walking');
-            }}
-            variant="directionMode"
-            icon="foot"
-            label={_('on foot', 'service panel')}
-          />
-          <Action
-            onClick={() => {
-              Telemetry.add(Telemetry.ITINERARY_MODE_CYCLING);
-              window.app.navigateTo('/routes/?mode=cycling');
-            }}
-            variant="directionMode"
-            icon="bike"
-            label={_('by bike', 'service panel')}
-          />
-        </div>
-        <hr/>
-      </Fragment>}
-
+const ServicePanelMobile = () => {
+  return <Panel
+    resizable
+    minimizedTitle={_('Unfold to see quick actions', 'service panel')}
+    className="service_panel"
+  >
+    {directionConf.enabled && <Fragment>
       <h3 className="u-text--smallTitle u-center u-mb-s">
-        {_('Services nearby', 'service panel')}
+        {_('Directions', 'service panel')}
       </h3>
+      <div className="service_panel__actions">
+        <Action
+          onClick={() => {
+            Telemetry.add(Telemetry.ITINERARY_MODE_DRIVING);
+            window.app.navigateTo('/routes/?mode=driving');
+          }}
+          variant="directionMode"
+          icon="drive"
+          label={_('by car', 'service panel')}
+        />
+        {
+          directionConf.publicTransport
+          && directionConf.publicTransport.enabled
+          && <Action
+            onClick={() => {
+              Telemetry.add(Telemetry.ITINERARY_MODE_PUBLICTRANSPORT);
+              window.app.navigateTo('/routes/?mode=publicTransport');
+            }}
+            variant="directionMode"
+            icon="public-transport"
+            label={_('transit', 'service panel')}
+          />
+        }
+        <Action
+          onClick={() => {
+            Telemetry.add(Telemetry.ITINERARY_MODE_WALKING);
+            window.app.navigateTo('/routes/?mode=walking');
+          }}
+          variant="directionMode"
+          icon="foot"
+          label={_('on foot', 'service panel')}
+        />
+        <Action
+          onClick={() => {
+            Telemetry.add(Telemetry.ITINERARY_MODE_CYCLING);
+            window.app.navigateTo('/routes/?mode=cycling');
+          }}
+          variant="directionMode"
+          icon="bike"
+          label={_('by bike', 'service panel')}
+        />
+      </div>
+      <hr/>
+    </Fragment>}
 
-      <CategoryList className="service_panel__categories" />
-    </Panel>;
-  }
-}
+    <h3 className="u-text--smallTitle u-center u-mb-s">
+      {_('Services nearby', 'service panel')}
+    </h3>
+
+    <CategoryList className="service_panel__categories" />
+  </Panel>;
+};
 
 export default ServicePanelMobile;


### PR DESCRIPTION
## Description
Convert these React class components to the functional syntax:
 - `<Website>`
 - `<OpeningHour>`
 - `<Menu>`
 - `<ServicePanelMobile>`
 - `<FavoritePoi>`
 
## Why
The functional component syntax is the one promoted by React, used by the Search team, and allows easier state management and composition of code with hooks.