### PR TITLE
Direction: on mobile, clear geoloc input on tap

### DIFF
--- a/src/panel/direction/DirectionForm.jsx
+++ b/src/panel/direction/DirectionForm.jsx
@@ -76,6 +76,7 @@ export default class DirectionForm extends React.Component {
           <DirectionInput
             isLoading={isLoading}
             value={originInputText}
+            point={origin}
             pointType="origin"
             onChangePoint={(input, point) => this.onChangePoint('origin', input, point)}
             ref={this.originRef}
@@ -85,6 +86,7 @@ export default class DirectionForm extends React.Component {
           <DirectionInput
             isLoading={isLoading}
             value={destinationInputText}
+            point={destination}
             pointType="destination"
             onChangePoint={(input, point) => this.onChangePoint('destination', input, point)}
             ref={this.destinationRef}

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -9,6 +9,7 @@ import { fire } from 'src/libs/customEvents';
 import { fetchSuggests } from 'src/libs/suggest';
 import Telemetry from 'src/libs/telemetry';
 import { handleFocus } from 'src/libs/input';
+import { isMobileDevice } from 'src/libs/device';
 
 class DirectionInput extends React.Component {
   static propTypes = {
@@ -102,7 +103,7 @@ class DirectionInput extends React.Component {
   }
 
   render() {
-    const { pointType, inputRef, isLoading, withGeoloc, value } = this.props;
+    const { pointType, inputRef, isLoading, withGeoloc, value, point, onChangePoint } = this.props;
     const { mounted, readOnly } = this.state;
 
     return (
@@ -122,7 +123,14 @@ class DirectionInput extends React.Component {
             onChange={this.onChange}
             onKeyPress={this.onKeyPress}
             readOnly={readOnly || isLoading}
-            onFocus={handleFocus}
+            onFocus={e => {
+              if (point && point.type === 'geoloc' && isMobileDevice()) {
+                // Clear Input to avoid fetching unwanted suggestions
+                onChangePoint('');
+              } else {
+                handleFocus(e);
+              }
+            }}
           />
           <div className="direction-icon-block">
             <div className={`direction-icon direction-icon-${pointType}`}/>


### PR DESCRIPTION
## Description
On mobile, clear the input field on tap if the field is of type geoloc, thus avoiding unwanted queries to suggestions.

## Why
Better UX

(I can't provide any GIF this time, as it only capture a blank screen.)