### PR TITLE
Use icon mapping function from qwant-basic-gl-style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5460,8 +5460,9 @@
       "dev": true
     },
     "@qwant/qwant-basic-gl-style": {
-      "version": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#ab766abea1c1cc7c78288464bdad9cc249095327",
-      "from": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#ab766abe"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.1.0.tgz",
+      "integrity": "sha512-z8TFGA1gvLYk62fjIXCldB7wd0oji1ZcEx1BRGPyVrq2peY3Yw22I1lkga+1sKkKYqz0OnNx0oj7W6sg4p6/YQ=="
     },
     "@qwant/telemetry": {
       "version": "file:local_modules/telemetry"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@qwant/merge-po": "file:local_modules/merge-po",
     "@qwant/nconf-builder": "file:local_modules/nconf_builder",
     "@qwant/po-js": "file:local_modules/po-js",
-    "@qwant/qwant-basic-gl-style": "git+https://github.com/QwantResearch/qwant-basic-gl-style.git#ab766abe",
+    "@qwant/qwant-basic-gl-style": "^1.1.0",
     "@qwant/telemetry": "file:local_modules/telemetry",
     "@qwant/uri": "file:local_modules/uri",
     "@turf/along": "^6.0.1",

--- a/src/adapters/icon_manager.js
+++ b/src/adapters/icon_manager.js
@@ -1,96 +1,27 @@
-import styleIcons from '@qwant/qwant-basic-gl-style/icons.yml';
+import { getPoiIcon } from '@qwant/qwant-basic-gl-style';
 import classnames from 'classnames';
 import { ACTION_BLUE_DARK } from 'src/libs/colors';
 
-const nameToClass = iconName => iconName.match(/^(.*?)-[0-9]{1,2}$/)[1];
-
 export default class IconManager {
   static get({ className, subClassName, type }) {
-
-    // Get the category icon of a PoI
-    if (type === 'poi' || type === 'category') {
-      const icons = styleIcons.mappings;
-
-      // Matching class and subclass
-      let icon = icons.find(iconProperty => {
-        return iconProperty.subclass === subClassName && iconProperty.class === className;
-      });
-
-      // Or: no class and matching subclass
-      if (!icon) {
-        icon = icons.find(iconProperty => {
-          return iconProperty.subclass === subClassName && !iconProperty.class;
-        });
-      }
-
-      // Or: matching class and no subclass
-      if (!icon) {
-        icon = icons.find(iconProperty => {
-          return iconProperty.class === className && !iconProperty.subclass;
-        });
-      }
-
-      if (icon) {
-        const iconName = icon.iconName;
-        const color = icon.color;
-        const iconClass = nameToClass(iconName);
-        return { iconClass, color };
-      }
-
-      return {
-        iconClass: nameToClass(styleIcons.defaultIcon),
-        color: styleIcons.defaultColor,
-      };
-
-    // Get the icon of a location / area that is not a PoI:
-    // Exact address
-    } else if (type === 'house' || type === 'address') {
-      return {
-        iconClass: nameToClass(styleIcons.defaultAddressIcon),
-        color: styleIcons.defaultAddressColor,
-      };
-
-    // Road / street without house number
-    } else if (type === 'street') {
-      return {
-        iconClass: nameToClass(styleIcons.defaultStreetIcon),
-        color: styleIcons.defaultStreetColor,
-      };
-
-    // user geolocation "poi"
-    } else if (type === 'geoloc') {
+    if (type === 'geoloc') {
       return {
         iconClass: 'pin_geoloc',
         color: ACTION_BLUE_DARK,
         icomoon: true,
       };
-
-      // administrative zones (city, area, country)
-    } else {
-      return {
-        iconClass: nameToClass(styleIcons.defaultAdministrativeIcon),
-        color: styleIcons.defaultAdministrativeColor,
-      };
     }
+
+    return getPoiIcon({ className, subClassName, type });
   }
 }
 
-export function createIcon(iconOptions) {
-  const icon = IconManager.get(iconOptions);
-
-  // Show a white circle instead of marker2 in map markers of PoI that have no class or subclass.
-  if (icon.iconClass === nameToClass(styleIcons.defaultIcon)) {
-    icon.iconClass = 'circle';
-  }
-
+export function createDefaultPin() {
   const element = document.createElement('div');
   element.innerHTML = `
-    <div
-      class="marker ${iconOptions.className || ''}"
-      ${iconOptions.disablePointerEvents && 'style="pointer-events:none;"'}
-    >
+    <div class="marker">
       <div class="marker-container">
-        <i class="icon icon-${icon.iconClass}"></i>
+        <i class="icon icon-circle"></i>
       </div>
     </div>
   `;

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -10,7 +10,7 @@ import { getLastLocation, setLastLocation } from 'src/adapters/store';
 import getStyle from './scene_config';
 import SceneDirection from './scene_direction';
 import SceneCategory from './scene_category';
-import { createIcon } from '../adapters/icon_manager';
+import { createDefaultPin } from '../adapters/icon_manager';
 import LatLonPoi from './poi/latlon_poi';
 import { isMobileDevice } from 'src/libs/device';
 import { parseMapHash, getMapHash } from 'src/libs/url_utils';
@@ -406,11 +406,7 @@ Scene.prototype.ensureMarkerIsVisible = function(poi, options) {
 };
 
 Scene.prototype.addMarker = function(poi) {
-  const type = poi.type;
-
-  // Create a default marker (white circle on red background) when the PoI is clicked.
-  // To do so, we don't define class and subclass when we call createIcon.
-  const element = createIcon({ class: '', subclass: '', type });
+  const element = createDefaultPin();
   element.onclick = function(e) {
     // click event should not be propagated to the map itself;
     e.stopPropagation();


### PR DESCRIPTION
## Description
Uses the POI-to-icon mapping function exposed by `@qwant/qwant-basic-gl-style` in https://github.com/Qwant/qwant-basic-gl-style/pull/111, instead of defining it in Erdapfel. The only exception is for the Geolocation case, which is technically managed as a POI in Erdapfel, but it wouldn't make sense in the shared library.

## Why
Share the icon mapping with Search.